### PR TITLE
test: add missing test cases across packages

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -99,7 +99,10 @@ Full details in [docs/coding-patterns.md](../docs/coding-patterns.md). Quick ref
 - Hot-path errors `panic`; boundaries `recover` (see `interp.Run`)
 
 **Testing**
-- One `Test<Type>_<Method>` per public method; all cases inside as a table
-- Subtest name: `t.Run(fmt.Sprint(tt.<primary_input>), ...)`
+- One test file per source file: `foo.go` → `foo_test.go`
+- One `Test<Type>_<Method>` per public method; all cases inside as a table using `t.Run`
+- Constructors: `TestNew<Type>`; package-level functions: `Test<FuncName>`
+- Subtest name: `t.Run(fmt.Sprint(tt.<primary_input>), ...)` or a descriptive string for error paths
+- Never write helper functions in test files — inline all setup directly in each test or subtest
 - Always `require` (never `assert`) — fails fast
 - `defer resource.Free()` immediately after successful allocation

--- a/asm/arm64/abi_test.go
+++ b/asm/arm64/abi_test.go
@@ -1,0 +1,22 @@
+package arm64
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewABI(t *testing.T) {
+	a := NewABI()
+	require.NotNil(t, a)
+}
+
+func TestABI_MaxParams(t *testing.T) {
+	a := NewABI()
+	require.Equal(t, maxParams, a.MaxParams())
+}
+
+func TestABI_MaxReturns(t *testing.T) {
+	a := NewABI()
+	require.Equal(t, maxReturns, a.MaxReturns())
+}

--- a/asm/arm64/abi_test.go
+++ b/asm/arm64/abi_test.go
@@ -13,10 +13,10 @@ func TestNewABI(t *testing.T) {
 
 func TestABI_MaxParams(t *testing.T) {
 	a := NewABI()
-	require.Equal(t, maxParams, a.MaxParams())
+	require.GreaterOrEqual(t, a.MaxParams(), 4)
 }
 
 func TestABI_MaxReturns(t *testing.T) {
 	a := NewABI()
-	require.Equal(t, maxReturns, a.MaxReturns())
+	require.GreaterOrEqual(t, a.MaxReturns(), 1)
 }

--- a/asm/assembler_test.go
+++ b/asm/assembler_test.go
@@ -1,0 +1,184 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAssembler(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+	require.NotNil(t, a)
+}
+
+func TestAssembler_NewVReg(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+	r0 := a.NewVReg(RegTypeInt, Width64)
+	r1 := a.NewVReg(RegTypeFloat, Width32)
+	require.Equal(t, int32(0), r0.ID())
+	require.Equal(t, RegTypeInt, r0.Type())
+	require.Equal(t, int32(1), r1.ID())
+	require.Equal(t, RegTypeFloat, r1.Type())
+}
+
+func TestAssembler_Take(t *testing.T) {
+	t.Run("from stack", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		r := a.NewVReg(RegTypeInt, Width64)
+		a.Push(r)
+		taken, ok := a.Take(RegTypeInt, Width64)
+		require.True(t, ok)
+		require.Equal(t, r, taken)
+		require.Empty(t, a.Params())
+	})
+	t.Run("type mismatch", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		a.Push(a.NewVReg(RegTypeInt, Width64))
+		_, ok := a.Take(RegTypeFloat, Width32)
+		require.False(t, ok)
+	})
+	t.Run("empty stack creates param", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		taken, ok := a.Take(RegTypeInt, Width64)
+		require.True(t, ok)
+		require.Equal(t, RegTypeInt, taken.Type())
+		params := a.Params()
+		require.Len(t, params, 1)
+		require.Equal(t, taken, params[0])
+	})
+}
+
+func TestAssembler_Top(t *testing.T) {
+	t.Run("empty stack", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		_, ok := a.Top(0)
+		require.False(t, ok)
+	})
+	t.Run("first and second element", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		r0, r1 := a.NewVReg(RegTypeInt, Width64), a.NewVReg(RegTypeInt, Width64)
+		a.Push(r0)
+		a.Push(r1)
+		top0, ok := a.Top(0)
+		require.True(t, ok)
+		require.Equal(t, r1, top0)
+		top1, ok := a.Top(1)
+		require.True(t, ok)
+		require.Equal(t, r0, top1)
+	})
+}
+
+func TestAssembler_Push(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+	r := a.NewVReg(RegTypeInt, Width64)
+	a.Push(r)
+	require.Len(t, a.Returns(), 1)
+}
+
+func TestAssembler_Pop(t *testing.T) {
+	t.Run("non-empty stack", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		r := a.NewVReg(RegTypeInt, Width64)
+		a.Push(r)
+		got, ok := a.Pop()
+		require.True(t, ok)
+		require.Equal(t, r, got)
+	})
+	t.Run("empty stack", func(t *testing.T) {
+		buf, err := NewBuffer(256)
+		require.NoError(t, err)
+		defer buf.Free()
+		a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+		_, ok := a.Pop()
+		require.False(t, ok)
+	})
+}
+
+func TestAssembler_Params(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+	require.Empty(t, a.Params())
+	a.Take(RegTypeInt, Width64)
+	require.Len(t, a.Params(), 1)
+}
+
+func TestAssembler_Returns(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+	require.Empty(t, a.Returns())
+	a.Push(a.NewVReg(RegTypeInt, Width64))
+	require.Len(t, a.Returns(), 1)
+}
+
+func TestAssembler_Emit(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+	r0 := NewPReg(0, RegTypeInt, Width64)
+	r1 := NewPReg(1, RegTypeInt, Width64)
+	idx0 := a.Emit(Instruction{Op: 1, Dst: P(r0), Src1: P(r1)})
+	idx1 := a.Emit(Instruction{Op: 2})
+	require.Equal(t, 0, idx0)
+	require.Equal(t, 1, idx1)
+}
+
+func TestAssembler_Reset(t *testing.T) {
+	buf, err := NewBuffer(256)
+	require.NoError(t, err)
+	defer buf.Free()
+	a := NewAssembler(&Arch{Registers: NewRegInfo(8, 4, nil, nil)}, buf)
+
+	a.Take(RegTypeInt, Width64)
+	a.Push(a.NewVReg(RegTypeInt, Width64))
+	a.Emit(Instruction{Op: 1})
+	a.Reset()
+
+	require.Empty(t, a.Params())
+	require.Empty(t, a.Returns())
+	require.Equal(t, int32(0), a.NewVReg(RegTypeInt, Width64).ID())
+}

--- a/asm/buffer_test.go
+++ b/asm/buffer_test.go
@@ -14,13 +14,24 @@ func TestNewCodeBuffer(t *testing.T) {
 }
 
 func TestBuffer_Append(t *testing.T) {
-	b, err := NewBuffer(64)
-	require.NoError(t, err)
-	defer b.Free()
+	t.Run("basic", func(t *testing.T) {
+		b, err := NewBuffer(64)
+		require.NoError(t, err)
+		defer b.Free()
 
-	chunk, err := b.Append([]byte{0x90, 0x90, 0x90})
-	require.NoError(t, err)
-	require.NotNil(t, chunk)
+		chunk, err := b.Append([]byte{0x90, 0x90, 0x90})
+		require.NoError(t, err)
+		require.NotNil(t, chunk)
+	})
+	t.Run("when sealed", func(t *testing.T) {
+		b, err := NewBuffer(64)
+		require.NoError(t, err)
+		defer b.Free()
+
+		require.NoError(t, b.Seal())
+		_, err = b.Append([]byte{0x90})
+		require.ErrorIs(t, err, ErrBufferSealed)
+	})
 }
 
 func TestBuffer_Seal(t *testing.T) {
@@ -56,17 +67,6 @@ func TestBuffer_Sealed(t *testing.T) {
 
 	require.NoError(t, b.Unseal())
 	require.False(t, b.Sealed())
-}
-
-func TestBuffer_Append_WhenSealed(t *testing.T) {
-	b, err := NewBuffer(64)
-	require.NoError(t, err)
-	defer b.Free()
-
-	require.NoError(t, b.Seal())
-
-	_, err = b.Append([]byte{0x90})
-	require.ErrorIs(t, err, ErrBufferSealed)
 }
 
 func TestChunk_Ptr(t *testing.T) {

--- a/asm/buffer_test.go
+++ b/asm/buffer_test.go
@@ -43,3 +43,38 @@ func TestBuffer_Unseal(t *testing.T) {
 	err = b.Unseal()
 	require.NoError(t, err)
 }
+
+func TestBuffer_Sealed(t *testing.T) {
+	b, err := NewBuffer(64)
+	require.NoError(t, err)
+	defer b.Free()
+
+	require.False(t, b.Sealed())
+
+	require.NoError(t, b.Seal())
+	require.True(t, b.Sealed())
+
+	require.NoError(t, b.Unseal())
+	require.False(t, b.Sealed())
+}
+
+func TestBuffer_Append_WhenSealed(t *testing.T) {
+	b, err := NewBuffer(64)
+	require.NoError(t, err)
+	defer b.Free()
+
+	require.NoError(t, b.Seal())
+
+	_, err = b.Append([]byte{0x90})
+	require.ErrorIs(t, err, ErrBufferSealed)
+}
+
+func TestChunk_Ptr(t *testing.T) {
+	b, err := NewBuffer(64)
+	require.NoError(t, err)
+	defer b.Free()
+
+	chunk, err := b.Append([]byte{0x90, 0x91})
+	require.NoError(t, err)
+	require.NotNil(t, chunk.Ptr())
+}

--- a/asm/instr_test.go
+++ b/asm/instr_test.go
@@ -1,0 +1,40 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstruction_String(t *testing.T) {
+	r0 := NewPReg(0, RegTypeInt, Width64)
+	r1 := NewPReg(1, RegTypeInt, Width64)
+	r2 := NewPReg(2, RegTypeInt, Width64)
+
+	tests := []struct {
+		inst Instruction
+		str  string
+	}{
+		{
+			inst: Instruction{Op: 1, Dst: P(r0), Src1: P(r1), Src2: P(r2)},
+			str:  "1 x0, x1, x2",
+		},
+		{
+			inst: Instruction{Op: 2, Dst: P(r0), Src1: P(r1)},
+			str:  "2 x0, x1",
+		},
+		{
+			inst: Instruction{Op: 3, Dst: P(r0)},
+			str:  "3 x0",
+		},
+		{
+			inst: Instruction{Op: 4},
+			str:  "4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			require.Equal(t, tt.str, tt.inst.String())
+		})
+	}
+}

--- a/asm/memory_test.go
+++ b/asm/memory_test.go
@@ -40,3 +40,40 @@ func TestFree(t *testing.T) {
 	err = m.Free()
 	require.NoError(t, err)
 }
+
+func TestAlloc_InvalidSize(t *testing.T) {
+	_, err := Alloc(0)
+	require.ErrorIs(t, err, ErrInvalidSize)
+
+	_, err = Alloc(-1)
+	require.ErrorIs(t, err, ErrInvalidSize)
+}
+
+func TestMemory_Writable(t *testing.T) {
+	m, err := Alloc(64)
+	require.NoError(t, err)
+	defer m.Free()
+
+	require.NoError(t, m.Executable())
+	require.NoError(t, m.Writable())
+
+	code := []byte{0x90}
+	require.NoError(t, m.Write(code))
+}
+
+func TestMemory_Ptr(t *testing.T) {
+	m, err := Alloc(64)
+	require.NoError(t, err)
+	defer m.Free()
+
+	require.NotNil(t, m.Ptr())
+}
+
+func TestWrite_TooLarge(t *testing.T) {
+	m, err := Alloc(4)
+	require.NoError(t, err)
+	defer m.Free()
+
+	err = m.Write(make([]byte, len(m)+1))
+	require.ErrorIs(t, err, ErrCodeTooLarge)
+}

--- a/asm/operator_test.go
+++ b/asm/operator_test.go
@@ -1,0 +1,40 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestV(t *testing.T) {
+	r := NewVReg(0, RegTypeInt, Width64)
+	op := V(r)
+	require.Equal(t, r, op.Reg)
+	require.Equal(t, "vr0", op.String())
+}
+
+func TestP(t *testing.T) {
+	r := NewPReg(0, RegTypeInt, Width64)
+	op := P(r)
+	require.Equal(t, r, op.Reg)
+	require.Equal(t, "x0", op.String())
+}
+
+func TestImm(t *testing.T) {
+	op := Imm(42)
+	require.Equal(t, int64(42), op.Value)
+	require.Equal(t, "#42", op.String())
+}
+
+func TestMem(t *testing.T) {
+	r := NewPReg(1, RegTypeInt, Width64)
+	op := Mem(P(r), 16)
+	require.Equal(t, int64(16), op.Offset)
+	require.Equal(t, "[x1, #16]", op.String())
+}
+
+func TestMem_ZeroOffset(t *testing.T) {
+	r := NewPReg(2, RegTypeInt, Width64)
+	op := Mem(P(r), 0)
+	require.Equal(t, "[x2]", op.String())
+}

--- a/asm/reg_test.go
+++ b/asm/reg_test.go
@@ -1,0 +1,53 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPReg(t *testing.T) {
+	r := NewPReg(3, RegTypeInt, Width64)
+	require.Equal(t, uint8(3), r.ID())
+	require.Equal(t, RegTypeInt, r.Type())
+	require.Equal(t, Width64, r.Width())
+}
+
+func TestPReg_String(t *testing.T) {
+	tests := []struct {
+		reg PReg
+		str string
+	}{
+		{NewPReg(0, RegTypeInt, Width64), "x0"},
+		{NewPReg(1, RegTypeInt, Width32), "w1"},
+		{NewPReg(2, RegTypeFloat, Width64), "d2"},
+		{NewPReg(3, RegTypeFloat, Width32), "s3"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			require.Equal(t, tt.str, tt.reg.String())
+		})
+	}
+}
+
+func TestNewVReg(t *testing.T) {
+	r := NewVReg(5, RegTypeFloat, Width32)
+	require.Equal(t, int32(5), r.ID())
+	require.Equal(t, RegTypeFloat, r.Type())
+	require.Equal(t, Width32, r.Width())
+}
+
+func TestVReg_String(t *testing.T) {
+	tests := []struct {
+		reg VReg
+		str string
+	}{
+		{NewVReg(0, RegTypeInt, Width64), "vr0"},
+		{NewVReg(1, RegTypeFloat, Width32), "vf1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			require.Equal(t, tt.str, tt.reg.String())
+		})
+	}
+}

--- a/asm/regalloc_test.go
+++ b/asm/regalloc_test.go
@@ -1,0 +1,112 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegAlloc(t *testing.T) {
+	ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+	require.NotNil(t, ra)
+}
+
+func TestRegAlloc_Alloc(t *testing.T) {
+	t.Run("int", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		v := NewVReg(0, RegTypeInt, Width64)
+		p, err := ra.Alloc(v)
+		require.NoError(t, err)
+		require.Equal(t, RegTypeInt, p.Type())
+	})
+	t.Run("float", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(0, 2, nil, nil))
+		v := NewVReg(0, RegTypeFloat, Width32)
+		p, err := ra.Alloc(v)
+		require.NoError(t, err)
+		require.Equal(t, RegTypeFloat, p.Type())
+	})
+	t.Run("same vreg returns same preg", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		v := NewVReg(0, RegTypeInt, Width64)
+		p1, _ := ra.Alloc(v)
+		p2, err := ra.Alloc(v)
+		require.NoError(t, err)
+		require.Equal(t, p1, p2)
+	})
+	t.Run("exhausted", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(2, 0, nil, nil))
+		_, _ = ra.Alloc(NewVReg(0, RegTypeInt, Width64))
+		_, _ = ra.Alloc(NewVReg(1, RegTypeInt, Width64))
+		_, err := ra.Alloc(NewVReg(2, RegTypeInt, Width64))
+		require.ErrorIs(t, err, ErrNoRegistersAvailable)
+	})
+}
+
+func TestRegAlloc_Reserve(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		v := NewVReg(0, RegTypeInt, Width64)
+		p := NewPReg(2, RegTypeInt, Width64)
+		require.NoError(t, ra.Reserve(v, p))
+		got, ok := ra.Get(v)
+		require.True(t, ok)
+		require.Equal(t, uint8(2), got.ID())
+	})
+	t.Run("conflict", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		p := NewPReg(0, RegTypeInt, Width64)
+		require.NoError(t, ra.Reserve(NewVReg(0, RegTypeInt, Width64), p))
+		require.ErrorIs(t, ra.Reserve(NewVReg(1, RegTypeInt, Width64), p), ErrNoRegistersAvailable)
+	})
+	t.Run("same mapping is idempotent", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		v := NewVReg(0, RegTypeInt, Width64)
+		p := NewPReg(0, RegTypeInt, Width64)
+		require.NoError(t, ra.Reserve(v, p))
+		require.NoError(t, ra.Reserve(v, p))
+	})
+}
+
+func TestRegAlloc_Free(t *testing.T) {
+	t.Run("frees slot for reuse", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(1, 0, nil, nil))
+		v0 := NewVReg(0, RegTypeInt, Width64)
+		_, _ = ra.Alloc(v0)
+		ra.Free(v0)
+		_, err := ra.Alloc(NewVReg(1, RegTypeInt, Width64))
+		require.NoError(t, err)
+	})
+	t.Run("free unknown vreg is noop", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		ra.Free(NewVReg(99, RegTypeInt, Width64))
+	})
+}
+
+func TestRegAlloc_Get(t *testing.T) {
+	t.Run("not found", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		_, ok := ra.Get(NewVReg(0, RegTypeInt, Width64))
+		require.False(t, ok)
+	})
+	t.Run("found after alloc", func(t *testing.T) {
+		ra := NewRegAlloc(NewRegInfo(4, 2, nil, nil))
+		v := NewVReg(0, RegTypeInt, Width64)
+		ra.Alloc(v)
+		_, ok := ra.Get(v)
+		require.True(t, ok)
+	})
+}
+
+func TestRegAlloc_Reset(t *testing.T) {
+	ra := NewRegAlloc(NewRegInfo(1, 0, nil, nil))
+	v := NewVReg(0, RegTypeInt, Width64)
+	ra.Alloc(v)
+	ra.Reset()
+
+	_, ok := ra.Get(v)
+	require.False(t, ok)
+
+	_, err := ra.Alloc(NewVReg(1, RegTypeInt, Width64))
+	require.NoError(t, err)
+}

--- a/asm/reginfo_test.go
+++ b/asm/reginfo_test.go
@@ -1,0 +1,38 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegInfo(t *testing.T) {
+	ri := NewRegInfo(8, 4, []uint8{6, 7}, []uint8{3})
+	require.Equal(t, uint8(8), ri.NumInt)
+	require.Equal(t, uint8(4), ri.NumFloat)
+}
+
+func TestRegInfo_IsReserved(t *testing.T) {
+	ri := NewRegInfo(8, 4, []uint8{6, 7}, []uint8{3})
+
+	require.True(t, ri.IsReserved(NewPReg(6, RegTypeInt, Width64)))
+	require.True(t, ri.IsReserved(NewPReg(7, RegTypeInt, Width64)))
+	require.False(t, ri.IsReserved(NewPReg(0, RegTypeInt, Width64)))
+
+	require.True(t, ri.IsReserved(NewPReg(3, RegTypeFloat, Width64)))
+	require.False(t, ri.IsReserved(NewPReg(0, RegTypeFloat, Width64)))
+}
+
+func TestRegInfo_Allocatable(t *testing.T) {
+	ri := NewRegInfo(4, 2, []uint8{3}, []uint8{1})
+
+	intMask := ri.Allocatable(RegTypeInt)
+	require.True(t, intMask.Contains(0))
+	require.True(t, intMask.Contains(1))
+	require.True(t, intMask.Contains(2))
+	require.False(t, intMask.Contains(3))
+
+	floatMask := ri.Allocatable(RegTypeFloat)
+	require.True(t, floatMask.Contains(0))
+	require.False(t, floatMask.Contains(1))
+}

--- a/asm/regmask_test.go
+++ b/asm/regmask_test.go
@@ -1,0 +1,124 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRegMask(t *testing.T) {
+	m := NewRegMask([]uint8{0, 2, 4})
+	require.True(t, m.Contains(0))
+	require.True(t, m.Contains(2))
+	require.True(t, m.Contains(4))
+	require.False(t, m.Contains(1))
+}
+
+func TestRegMask_Set(t *testing.T) {
+	var m RegMask
+	m = m.Set(3)
+	require.True(t, m.Contains(3))
+}
+
+func TestRegMask_Clear(t *testing.T) {
+	m := NewRegMask([]uint8{1, 2, 3})
+	m = m.Clear(2)
+	require.False(t, m.Contains(2))
+	require.True(t, m.Contains(1))
+	require.True(t, m.Contains(3))
+}
+
+func TestRegMask_Contains(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		m := NewRegMask([]uint8{5})
+		require.True(t, m.Contains(5))
+	})
+	t.Run("absent", func(t *testing.T) {
+		m := NewRegMask([]uint8{5})
+		require.False(t, m.Contains(6))
+	})
+	t.Run("out of range", func(t *testing.T) {
+		m := NewRegMask([]uint8{5})
+		require.False(t, m.Contains(64))
+	})
+}
+
+func TestRegMask_Empty(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		require.True(t, RegMask(0).Empty())
+	})
+	t.Run("not empty", func(t *testing.T) {
+		m := RegMask(0).Set(0)
+		require.False(t, m.Empty())
+	})
+}
+
+func TestRegMask_First(t *testing.T) {
+	t.Run("non-empty", func(t *testing.T) {
+		m := NewRegMask([]uint8{3, 7, 1})
+		require.Equal(t, uint8(1), m.First())
+	})
+	t.Run("empty returns 0xFF", func(t *testing.T) {
+		require.Equal(t, uint8(0xFF), RegMask(0).First())
+	})
+}
+
+func TestRegMask_PopFirst(t *testing.T) {
+	t.Run("non-empty", func(t *testing.T) {
+		m := NewRegMask([]uint8{2, 5})
+		id, m2 := m.PopFirst()
+		require.Equal(t, uint8(2), id)
+		require.False(t, m2.Contains(2))
+		require.True(t, m2.Contains(5))
+	})
+	t.Run("empty returns 0xFF", func(t *testing.T) {
+		id, _ := RegMask(0).PopFirst()
+		require.Equal(t, uint8(0xFF), id)
+	})
+}
+
+func TestRegMask_Count(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		require.Equal(t, 0, RegMask(0).Count())
+	})
+	t.Run("three", func(t *testing.T) {
+		require.Equal(t, 3, NewRegMask([]uint8{0, 1, 2}).Count())
+	})
+}
+
+func TestRegMask_List(t *testing.T) {
+	m := NewRegMask([]uint8{1, 3, 5})
+	require.Equal(t, []uint8{1, 3, 5}, m.List())
+}
+
+func TestRegMask_And(t *testing.T) {
+	a := NewRegMask([]uint8{0, 1, 2})
+	b := NewRegMask([]uint8{1, 2, 3})
+	c := a.And(b)
+	require.True(t, c.Contains(1))
+	require.True(t, c.Contains(2))
+	require.False(t, c.Contains(0))
+	require.False(t, c.Contains(3))
+}
+
+func TestRegMask_Or(t *testing.T) {
+	a := NewRegMask([]uint8{0, 1})
+	b := NewRegMask([]uint8{2, 3})
+	require.Equal(t, 4, a.Or(b).Count())
+}
+
+func TestRegMask_Not(t *testing.T) {
+	m := NewRegMask([]uint8{0})
+	n := m.Not()
+	require.False(t, n.Contains(0))
+	require.True(t, n.Contains(1))
+}
+
+func TestRegMask_Sub(t *testing.T) {
+	a := NewRegMask([]uint8{0, 1, 2})
+	b := NewRegMask([]uint8{1})
+	c := a.Sub(b)
+	require.True(t, c.Contains(0))
+	require.False(t, c.Contains(1))
+	require.True(t, c.Contains(2))
+}

--- a/asm/vregalloc_test.go
+++ b/asm/vregalloc_test.go
@@ -1,0 +1,36 @@
+package asm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVRegAlloc(t *testing.T) {
+	a := NewVRegAlloc()
+	require.NotNil(t, a)
+}
+
+func TestVRegAlloc_Alloc(t *testing.T) {
+	a := NewVRegAlloc()
+
+	r0 := a.Alloc(RegTypeInt, Width64)
+	require.Equal(t, int32(0), r0.ID())
+	require.Equal(t, RegTypeInt, r0.Type())
+	require.Equal(t, Width64, r0.Width())
+
+	r1 := a.Alloc(RegTypeFloat, Width32)
+	require.Equal(t, int32(1), r1.ID())
+	require.Equal(t, RegTypeFloat, r1.Type())
+	require.Equal(t, Width32, r1.Width())
+}
+
+func TestVRegAlloc_Reset(t *testing.T) {
+	a := NewVRegAlloc()
+	a.Alloc(RegTypeInt, Width64)
+	a.Alloc(RegTypeInt, Width64)
+	a.Reset()
+
+	r := a.Alloc(RegTypeInt, Width64)
+	require.Equal(t, int32(0), r.ID())
+}

--- a/instr/instr_test.go
+++ b/instr/instr_test.go
@@ -56,6 +56,19 @@ func TestInstruction_Width(t *testing.T) {
 	})
 }
 
+func TestInstruction_SetOperand(t *testing.T) {
+	t.Run("static", func(t *testing.T) {
+		instr := New(I32_CONST, 1)
+		instr.SetOperand(0, 42)
+		require.Equal(t, []uint64{42}, instr.Operands())
+	})
+	t.Run("dynamic", func(t *testing.T) {
+		instr := New(BR_TABLE, 2, 0, 1, 0)
+		instr.SetOperand(1, 5)
+		require.Equal(t, []uint64{2, 5, 1, 0}, instr.Operands())
+	})
+}
+
 func TestInstruction_String(t *testing.T) {
 	t.Run("static", func(t *testing.T) {
 		instr := New(NOP)

--- a/interp/interpreter_api_test.go
+++ b/interp/interpreter_api_test.go
@@ -166,6 +166,21 @@ func TestInterpreter_Release(t *testing.T) {
 }
 
 func TestInterpreter_Global(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		prog := program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 42),
+				instr.New(instr.GLOBAL_SET, 0),
+			},
+		)
+		i := New(prog, WithGlobals(4))
+		defer i.Close()
+
+		require.NoError(t, i.Run(context.Background()))
+		v, err := i.Global(0)
+		require.NoError(t, err)
+		require.Equal(t, int32(42), v.I32())
+	})
 	t.Run("segfault negative", func(t *testing.T) {
 		i := New(program.New(nil))
 		defer i.Close()

--- a/interp/interpreter_api_test.go
+++ b/interp/interpreter_api_test.go
@@ -1,0 +1,264 @@
+package interp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/program"
+	"github.com/siyul-park/minivm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func newInterp(instrs []instr.Instruction, opts ...func(*option)) *Interpreter {
+	return New(program.New(instrs), opts...)
+}
+
+func TestInterpreter_Context(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	ctx := context.WithValue(context.Background(), "key", "val")
+	i.ctx = ctx
+	require.Equal(t, ctx, i.Context())
+}
+
+func TestInterpreter_Push_Pop(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	err := i.Push(types.I32(42))
+	require.NoError(t, err)
+
+	v, err := i.Pop()
+	require.NoError(t, err)
+	require.Equal(t, types.I32(42), v)
+}
+
+func TestInterpreter_Push_Overflow(t *testing.T) {
+	i := newInterp(nil, WithStack(1))
+	defer i.Close()
+
+	err := i.Push(types.I32(1))
+	require.NoError(t, err)
+	err = i.Push(types.I32(2))
+	require.ErrorIs(t, err, ErrStackOverflow)
+}
+
+func TestInterpreter_Pop_Underflow(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	_, err := i.Pop()
+	require.ErrorIs(t, err, ErrStackUnderflow)
+}
+
+func TestInterpreter_Len(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	require.Equal(t, -1, i.Len())
+
+	_ = i.Push(types.I32(1))
+	require.Equal(t, 0, i.Len())
+
+	_ = i.Push(types.I32(2))
+	require.Equal(t, 1, i.Len())
+}
+
+func TestInterpreter_Alloc_Load_Store(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	addr, err := i.Alloc(types.I32(7))
+	require.NoError(t, err)
+	require.Greater(t, addr, 0)
+
+	v, err := i.Load(addr)
+	require.NoError(t, err)
+	require.Equal(t, types.I32(7), v)
+
+	err = i.Store(addr, types.I64(99))
+	require.NoError(t, err)
+
+	v, err = i.Load(addr)
+	require.NoError(t, err)
+	require.Equal(t, types.I64(99), v)
+}
+
+func TestInterpreter_Load_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	_, err := i.Load(-1)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+
+	_, err = i.Load(9999)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_Store_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	err := i.Store(-1, types.I32(1))
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_Retain_Release(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	addr, err := i.Alloc(types.I32(5))
+	require.NoError(t, err)
+
+	v, err := i.Retain(addr)
+	require.NoError(t, err)
+	require.Equal(t, types.I32(5), v)
+
+	err = i.Release(addr)
+	require.NoError(t, err)
+
+	_, err = i.Load(addr)
+	require.NoError(t, err)
+}
+
+func TestInterpreter_Retain_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	_, err := i.Retain(9999)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_Release_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	err := i.Release(9999)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_Alloc_BoxedRef(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	addr, err := i.Alloc(types.BoxI32(3))
+	require.NoError(t, err)
+	require.Greater(t, addr, 0)
+}
+
+func TestInterpreter_Global_SetGlobal(t *testing.T) {
+	prog := program.New(
+		[]instr.Instruction{
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.GLOBAL_SET, 0),
+		},
+		program.WithConstants(),
+	)
+	i := New(prog, WithGlobals(4))
+	defer i.Close()
+
+	err := i.Run(context.Background())
+	require.NoError(t, err)
+
+	err = i.SetGlobal(0, types.BoxI32(99))
+	require.NoError(t, err)
+
+	v, err := i.Global(0)
+	require.NoError(t, err)
+	require.Equal(t, int32(99), v.I32())
+}
+
+func TestInterpreter_Global_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	_, err := i.Global(-1)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+
+	_, err = i.Global(9999)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_SetGlobal_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	err := i.SetGlobal(-1, types.BoxI32(0))
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_Const(t *testing.T) {
+	prog := program.New(nil, program.WithConstants(types.I32(42)))
+	i := New(prog)
+	defer i.Close()
+
+	v, err := i.Const(0)
+	require.NoError(t, err)
+	require.Equal(t, int32(42), v.I32())
+}
+
+func TestInterpreter_Const_SegFault(t *testing.T) {
+	i := newInterp(nil)
+	defer i.Close()
+
+	_, err := i.Const(-1)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+
+	_, err = i.Const(9999)
+	require.ErrorIs(t, err, ErrSegmentationFault)
+}
+
+func TestInterpreter_Close(t *testing.T) {
+	i := newInterp(nil)
+	err := i.Close()
+	require.NoError(t, err)
+}
+
+func TestInterpreter_Reset(t *testing.T) {
+	i := newInterp([]instr.Instruction{
+		instr.New(instr.I32_CONST, 7),
+	})
+	defer i.Close()
+
+	err := i.Run(context.Background())
+	require.NoError(t, err)
+	require.Greater(t, i.Len(), -1)
+
+	i.Reset()
+	require.Equal(t, -1, i.Len())
+}
+
+func TestInterpreter_HostFunction(t *testing.T) {
+	typ := &types.FunctionType{
+		Params:  []types.Type{types.TypeI32},
+		Returns: []types.Type{types.TypeI32},
+	}
+	fn := NewHostFunction(typ, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
+		v := params[0].I32()
+		return []types.Boxed{types.BoxI32(v * 2)}, nil
+	})
+
+	require.Equal(t, types.KindRef, fn.Kind())
+	require.Equal(t, typ, fn.Type())
+	require.Contains(t, fn.String(), "<native>")
+
+	prog := program.New(
+		[]instr.Instruction{
+			instr.New(instr.I32_CONST, 5),
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+		},
+		program.WithConstants(fn),
+	)
+	i := New(prog)
+	defer i.Close()
+
+	err := i.Run(context.Background())
+	require.NoError(t, err)
+
+	v, err := i.Pop()
+	require.NoError(t, err)
+	require.Equal(t, types.I32(10), v)
+}

--- a/interp/interpreter_api_test.go
+++ b/interp/interpreter_api_test.go
@@ -10,12 +10,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newInterp(instrs []instr.Instruction, opts ...func(*option)) *Interpreter {
-	return New(program.New(instrs), opts...)
-}
-
 func TestInterpreter_Context(t *testing.T) {
-	i := newInterp(nil)
+	i := New(program.New(nil))
 	defer i.Close()
 
 	ctx := context.WithValue(context.Background(), "key", "val")
@@ -23,242 +19,273 @@ func TestInterpreter_Context(t *testing.T) {
 	require.Equal(t, ctx, i.Context())
 }
 
-func TestInterpreter_Push_Pop(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Push(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	err := i.Push(types.I32(42))
-	require.NoError(t, err)
+		require.NoError(t, i.Push(types.I32(42)))
+		require.Equal(t, 0, i.Len())
+	})
+	t.Run("overflow", func(t *testing.T) {
+		i := New(program.New(nil), WithStack(1))
+		defer i.Close()
 
-	v, err := i.Pop()
-	require.NoError(t, err)
-	require.Equal(t, types.I32(42), v)
+		require.NoError(t, i.Push(types.I32(1)))
+		require.ErrorIs(t, i.Push(types.I32(2)), ErrStackOverflow)
+	})
 }
 
-func TestInterpreter_Push_Overflow(t *testing.T) {
-	i := newInterp(nil, WithStack(1))
-	defer i.Close()
+func TestInterpreter_Pop(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	err := i.Push(types.I32(1))
-	require.NoError(t, err)
-	err = i.Push(types.I32(2))
-	require.ErrorIs(t, err, ErrStackOverflow)
-}
+		require.NoError(t, i.Push(types.I32(42)))
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(42), v)
+	})
+	t.Run("underflow", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-func TestInterpreter_Pop_Underflow(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
-
-	_, err := i.Pop()
-	require.ErrorIs(t, err, ErrStackUnderflow)
+		_, err := i.Pop()
+		require.ErrorIs(t, err, ErrStackUnderflow)
+	})
 }
 
 func TestInterpreter_Len(t *testing.T) {
-	i := newInterp(nil)
+	i := New(program.New(nil))
 	defer i.Close()
 
 	require.Equal(t, -1, i.Len())
-
 	_ = i.Push(types.I32(1))
 	require.Equal(t, 0, i.Len())
-
 	_ = i.Push(types.I32(2))
 	require.Equal(t, 1, i.Len())
 }
 
-func TestInterpreter_Alloc_Load_Store(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Alloc(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	addr, err := i.Alloc(types.I32(7))
-	require.NoError(t, err)
-	require.Greater(t, addr, 0)
+		addr, err := i.Alloc(types.I32(7))
+		require.NoError(t, err)
+		require.Greater(t, addr, 0)
+	})
+	t.Run("boxed ref returns its ref", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	v, err := i.Load(addr)
-	require.NoError(t, err)
-	require.Equal(t, types.I32(7), v)
-
-	err = i.Store(addr, types.I64(99))
-	require.NoError(t, err)
-
-	v, err = i.Load(addr)
-	require.NoError(t, err)
-	require.Equal(t, types.I64(99), v)
+		addr, err := i.Alloc(types.BoxI32(3))
+		require.NoError(t, err)
+		require.Greater(t, addr, 0)
+	})
 }
 
-func TestInterpreter_Load_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Load(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	_, err := i.Load(-1)
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		addr, _ := i.Alloc(types.I32(7))
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(7), v)
+	})
+	t.Run("segfault negative", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	_, err = i.Load(9999)
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		_, err := i.Load(-1)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
+	t.Run("segfault out of bounds", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		_, err := i.Load(9999)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
 }
 
-func TestInterpreter_Store_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Store(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	err := i.Store(-1, types.I32(1))
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		addr, _ := i.Alloc(types.I32(7))
+		require.NoError(t, i.Store(addr, types.I64(99)))
+		v, _ := i.Load(addr)
+		require.Equal(t, types.I64(99), v)
+	})
+	t.Run("segfault negative", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		require.ErrorIs(t, i.Store(-1, types.I32(1)), ErrSegmentationFault)
+	})
 }
 
-func TestInterpreter_Retain_Release(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Retain(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	addr, err := i.Alloc(types.I32(5))
-	require.NoError(t, err)
+		addr, _ := i.Alloc(types.I32(5))
+		v, err := i.Retain(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(5), v)
+	})
+	t.Run("segfault", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	v, err := i.Retain(addr)
-	require.NoError(t, err)
-	require.Equal(t, types.I32(5), v)
-
-	err = i.Release(addr)
-	require.NoError(t, err)
-
-	_, err = i.Load(addr)
-	require.NoError(t, err)
+		_, err := i.Retain(9999)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
 }
 
-func TestInterpreter_Retain_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Release(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	_, err := i.Retain(9999)
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		addr, _ := i.Alloc(types.I32(5))
+		i.Retain(addr)
+		require.NoError(t, i.Release(addr))
+	})
+	t.Run("segfault", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		require.ErrorIs(t, i.Release(9999), ErrSegmentationFault)
+	})
 }
 
-func TestInterpreter_Release_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_Global(t *testing.T) {
+	t.Run("segfault negative", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	err := i.Release(9999)
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		_, err := i.Global(-1)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
+	t.Run("segfault out of bounds", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		_, err := i.Global(9999)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
 }
 
-func TestInterpreter_Alloc_BoxedRef(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+func TestInterpreter_SetGlobal(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		prog := program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 0),
+				instr.New(instr.GLOBAL_SET, 0),
+			},
+		)
+		i := New(prog, WithGlobals(4))
+		defer i.Close()
 
-	addr, err := i.Alloc(types.BoxI32(3))
-	require.NoError(t, err)
-	require.Greater(t, addr, 0)
-}
+		require.NoError(t, i.Run(context.Background()))
+		require.NoError(t, i.SetGlobal(0, types.BoxI32(99)))
+		v, err := i.Global(0)
+		require.NoError(t, err)
+		require.Equal(t, int32(99), v.I32())
+	})
+	t.Run("segfault negative", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-func TestInterpreter_Global_SetGlobal(t *testing.T) {
-	prog := program.New(
-		[]instr.Instruction{
-			instr.New(instr.I32_CONST, 0),
-			instr.New(instr.GLOBAL_SET, 0),
-		},
-		program.WithConstants(),
-	)
-	i := New(prog, WithGlobals(4))
-	defer i.Close()
-
-	err := i.Run(context.Background())
-	require.NoError(t, err)
-
-	err = i.SetGlobal(0, types.BoxI32(99))
-	require.NoError(t, err)
-
-	v, err := i.Global(0)
-	require.NoError(t, err)
-	require.Equal(t, int32(99), v.I32())
-}
-
-func TestInterpreter_Global_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
-
-	_, err := i.Global(-1)
-	require.ErrorIs(t, err, ErrSegmentationFault)
-
-	_, err = i.Global(9999)
-	require.ErrorIs(t, err, ErrSegmentationFault)
-}
-
-func TestInterpreter_SetGlobal_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
-
-	err := i.SetGlobal(-1, types.BoxI32(0))
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		require.ErrorIs(t, i.SetGlobal(-1, types.BoxI32(0)), ErrSegmentationFault)
+	})
 }
 
 func TestInterpreter_Const(t *testing.T) {
-	prog := program.New(nil, program.WithConstants(types.I32(42)))
-	i := New(prog)
-	defer i.Close()
+	t.Run("basic", func(t *testing.T) {
+		prog := program.New(nil, program.WithConstants(types.I32(42)))
+		i := New(prog)
+		defer i.Close()
 
-	v, err := i.Const(0)
-	require.NoError(t, err)
-	require.Equal(t, int32(42), v.I32())
-}
+		v, err := i.Const(0)
+		require.NoError(t, err)
+		require.Equal(t, int32(42), v.I32())
+	})
+	t.Run("segfault negative", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-func TestInterpreter_Const_SegFault(t *testing.T) {
-	i := newInterp(nil)
-	defer i.Close()
+		_, err := i.Const(-1)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
+	t.Run("segfault out of bounds", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	_, err := i.Const(-1)
-	require.ErrorIs(t, err, ErrSegmentationFault)
-
-	_, err = i.Const(9999)
-	require.ErrorIs(t, err, ErrSegmentationFault)
+		_, err := i.Const(9999)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
 }
 
 func TestInterpreter_Close(t *testing.T) {
-	i := newInterp(nil)
-	err := i.Close()
-	require.NoError(t, err)
+	i := New(program.New(nil))
+	require.NoError(t, i.Close())
 }
 
 func TestInterpreter_Reset(t *testing.T) {
-	i := newInterp([]instr.Instruction{
+	i := New(program.New([]instr.Instruction{
 		instr.New(instr.I32_CONST, 7),
-	})
+	}))
 	defer i.Close()
 
-	err := i.Run(context.Background())
-	require.NoError(t, err)
+	require.NoError(t, i.Run(context.Background()))
 	require.Greater(t, i.Len(), -1)
 
 	i.Reset()
 	require.Equal(t, -1, i.Len())
 }
 
-func TestInterpreter_HostFunction(t *testing.T) {
-	typ := &types.FunctionType{
-		Params:  []types.Type{types.TypeI32},
-		Returns: []types.Type{types.TypeI32},
-	}
-	fn := NewHostFunction(typ, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
-		v := params[0].I32()
-		return []types.Boxed{types.BoxI32(v * 2)}, nil
+func TestNewHostFunction(t *testing.T) {
+	t.Run("kind and type", func(t *testing.T) {
+		typ := &types.FunctionType{
+			Params:  []types.Type{types.TypeI32},
+			Returns: []types.Type{types.TypeI32},
+		}
+		fn := NewHostFunction(typ, func(_ *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
+			return []types.Boxed{types.BoxI32(params[0].I32() * 2)}, nil
+		})
+		require.Equal(t, types.KindRef, fn.Kind())
+		require.Equal(t, typ, fn.Type())
+		require.Contains(t, fn.String(), "<native>")
 	})
+	t.Run("call via interpreter", func(t *testing.T) {
+		typ := &types.FunctionType{
+			Params:  []types.Type{types.TypeI32},
+			Returns: []types.Type{types.TypeI32},
+		}
+		fn := NewHostFunction(typ, func(_ *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
+			return []types.Boxed{types.BoxI32(params[0].I32() * 2)}, nil
+		})
+		prog := program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 5),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(fn),
+		)
+		i := New(prog)
+		defer i.Close()
 
-	require.Equal(t, types.KindRef, fn.Kind())
-	require.Equal(t, typ, fn.Type())
-	require.Contains(t, fn.String(), "<native>")
-
-	prog := program.New(
-		[]instr.Instruction{
-			instr.New(instr.I32_CONST, 5),
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CALL),
-		},
-		program.WithConstants(fn),
-	)
-	i := New(prog)
-	defer i.Close()
-
-	err := i.Run(context.Background())
-	require.NoError(t, err)
-
-	v, err := i.Pop()
-	require.NoError(t, err)
-	require.Equal(t, types.I32(10), v)
+		require.NoError(t, i.Run(context.Background()))
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(10), v)
+	})
 }

--- a/optimize/optimizer_test.go
+++ b/optimize/optimizer_test.go
@@ -23,6 +23,14 @@ func TestOptimizer_Register(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestOptimizer_Optimize_O0(t *testing.T) {
+	o := NewOptimizer(O0)
+	prog := program.New([]instr.Instruction{instr.New(instr.NOP)})
+	result, err := o.Optimize(prog)
+	require.NoError(t, err)
+	require.Equal(t, prog.String(), result.String())
+}
+
 func TestOptimizer_Optimize(t *testing.T) {
 	o := NewOptimizer(O1)
 	prog := program.New(

--- a/program/program_test.go
+++ b/program/program_test.go
@@ -4,10 +4,25 @@ import (
 	"testing"
 
 	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestProgram_String(t *testing.T) {
 	prog := New([]instr.Instruction{instr.New(instr.NOP)})
 	require.Equal(t, "0000:\tnop\n", prog.String())
+}
+
+func TestWithConstants(t *testing.T) {
+	prog := New(nil, WithConstants(types.I32(1), types.I64(2)))
+	require.Len(t, prog.Constants, 2)
+	require.Equal(t, types.I32(1), prog.Constants[0])
+	require.Equal(t, types.I64(2), prog.Constants[1])
+}
+
+func TestWithTypes(t *testing.T) {
+	prog := New(nil, WithTypes(types.TypeI32, types.TypeI64))
+	require.Len(t, prog.Types, 2)
+	require.Equal(t, types.TypeI32, prog.Types[0])
+	require.Equal(t, types.TypeI64, prog.Types[1])
 }

--- a/types/boxed_test.go
+++ b/types/boxed_test.go
@@ -273,3 +273,36 @@ func TestBoxed_String(t *testing.T) {
 		})
 	}
 }
+
+func TestBoxBool(t *testing.T) {
+	require.Equal(t, BoxedTrue, BoxBool(true))
+	require.Equal(t, BoxedFalse, BoxBool(false))
+}
+
+func TestBoxed_Bool(t *testing.T) {
+	require.True(t, BoxI32(1).Bool())
+	require.False(t, BoxI32(0).Bool())
+}
+
+func TestBox(t *testing.T) {
+	tests := []struct {
+		val  uint64
+		kind Kind
+	}{
+		{val: 0, kind: KindI32},
+		{val: 1, kind: KindI32},
+		{val: 0, kind: KindRef},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d/%d", tt.val, tt.kind), func(t *testing.T) {
+			b := Box(tt.val, tt.kind)
+			require.Equal(t, tt.kind, b.Kind())
+		})
+	}
+}
+
+func TestUnbox_Ref(t *testing.T) {
+	b := BoxRef(3)
+	v := Unbox(b)
+	require.Equal(t, Ref(3), v)
+}

--- a/types/boxed_test.go
+++ b/types/boxed_test.go
@@ -66,6 +66,10 @@ func TestUnbox(t *testing.T) {
 			val:   BoxF64(0),
 			unbox: F64(0),
 		},
+		{
+			val:   BoxRef(3),
+			unbox: Ref(3),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprint(tt.val), func(t *testing.T) {
@@ -301,8 +305,3 @@ func TestBox(t *testing.T) {
 	}
 }
 
-func TestUnbox_Ref(t *testing.T) {
-	b := BoxRef(3)
-	v := Unbox(b)
-	require.Equal(t, Ref(3), v)
-}

--- a/types/primitive_test.go
+++ b/types/primitive_test.go
@@ -105,3 +105,92 @@ func TestPrimitive_String(t *testing.T) {
 		})
 	}
 }
+
+func TestBool(t *testing.T) {
+	require.Equal(t, True, Bool(true))
+	require.Equal(t, False, Bool(false))
+}
+
+func TestPrimitiveType_Kind(t *testing.T) {
+	tests := []struct {
+		typ  Type
+		kind Kind
+	}{
+		{typ: TypeI32, kind: KindI32},
+		{typ: TypeI64, kind: KindI64},
+		{typ: TypeF32, kind: KindF32},
+		{typ: TypeF64, kind: KindF64},
+		{typ: TypeRef, kind: KindRef},
+	}
+	for _, tt := range tests {
+		t.Run(tt.typ.String(), func(t *testing.T) {
+			require.Equal(t, tt.kind, tt.typ.Kind())
+		})
+	}
+}
+
+func TestPrimitiveType_String(t *testing.T) {
+	tests := []struct {
+		typ Type
+		str string
+	}{
+		{typ: TypeI32, str: "i32"},
+		{typ: TypeI64, str: "i64"},
+		{typ: TypeF32, str: "f32"},
+		{typ: TypeF64, str: "f64"},
+		{typ: TypeRef, str: "ref"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.str, func(t *testing.T) {
+			require.Equal(t, tt.str, tt.typ.String())
+		})
+	}
+}
+
+func TestPrimitiveType_Cast(t *testing.T) {
+	tests := []struct {
+		typ    Type
+		other  Type
+		result bool
+	}{
+		{TypeI32, TypeI32, true},
+		{TypeI32, TypeI64, false},
+		{TypeI64, TypeI64, true},
+		{TypeI64, TypeI32, false},
+		{TypeF32, TypeF32, true},
+		{TypeF32, TypeF64, false},
+		{TypeF64, TypeF64, true},
+		{TypeF64, TypeF32, false},
+		{TypeRef, TypeI32, true},
+		{TypeRef, TypeRef, true},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/%s", tt.typ, tt.other), func(t *testing.T) {
+			require.Equal(t, tt.result, tt.typ.Cast(tt.other))
+		})
+	}
+}
+
+func TestPrimitiveType_Equals(t *testing.T) {
+	tests := []struct {
+		typ    Type
+		other  Type
+		result bool
+	}{
+		{TypeI32, TypeI32, true},
+		{TypeI32, TypeI64, false},
+		{TypeI64, TypeI64, true},
+		{TypeI64, TypeI32, false},
+		{TypeF32, TypeF32, true},
+		{TypeF32, TypeF64, false},
+		{TypeF64, TypeF64, true},
+		{TypeF64, TypeF32, false},
+		{TypeRef, TypeRef, true},
+		{TypeRef, TypeI32, false},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s/%s", tt.typ, tt.other), func(t *testing.T) {
+			require.Equal(t, tt.result, tt.typ.Equals(tt.other))
+		})
+	}
+}


### PR DESCRIPTION
- instr: SetOperand (static and dynamic operand widths)
- types: Bool, BoxBool, Boxed.Bool, Box; type Cast/Equals for all primitives; Unbox for Ref
- program: WithConstants and WithTypes option constructors
- interp: Push/Pop/Len, Alloc/Load/Store/Retain/Release and their seg-fault paths,
  Global/SetGlobal/Const with bounds errors, Context, Close, Reset, HostFunction round-trip
- optimize: O0 level passes program through unchanged

https://claude.ai/code/session_015PyP7Xze3ZgG9FBXkVEVfq