### PR TITLE
[codex] test: cover threaded fusion regressions

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2321,6 +2321,60 @@ func TestInterpreter_Run(t *testing.T) {
 		require.Equal(t, uint64(1), opcodes[byte(instr.DROP)])
 	})
 
+	t.Run("fused local get arithmetic returns from callee", func(t *testing.T) {
+		i := New(program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 41),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(
+				types.NewFunctionBuilder(&types.FunctionType{
+					Params:  []types.Type{types.TypeI32},
+					Returns: []types.Type{types.TypeI32},
+				}).Emit(
+					instr.New(instr.LOCAL_GET, 0),
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.I32_ADD),
+					instr.New(instr.RETURN),
+				).Build(),
+			),
+		), WithThreshold(-1))
+		defer i.Close()
+
+		err := i.Run(context.Background())
+		require.NoError(t, err)
+
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(42), v)
+	})
+
+	t.Run("fused local get arithmetic preserves divide by zero", func(t *testing.T) {
+		i := New(program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 7),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(
+				types.NewFunctionBuilder(&types.FunctionType{
+					Params:  []types.Type{types.TypeI32},
+					Returns: []types.Type{types.TypeI32},
+				}).Emit(
+					instr.New(instr.LOCAL_GET, 0),
+					instr.New(instr.I32_CONST, 0),
+					instr.New(instr.I32_DIV_S),
+					instr.New(instr.RETURN),
+				).Build(),
+			),
+		), WithThreshold(-1))
+		defer i.Close()
+
+		err := i.Run(context.Background())
+		require.ErrorIs(t, err, ErrDivideByZero)
+	})
+
 	t.Run("hook cancel is observed on next tick", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()


### PR DESCRIPTION
## What changed
- Added a regression test that exercises fused `LOCAL_GET` + `I32_CONST` + `I32_ADD` through `CALL`/`RETURN` in `interp/threaded.go`.
- Added a regression test that exercises fused `LOCAL_GET` + `I32_CONST` + `I32_DIV_S` and verifies `ErrDivideByZero` still propagates.

## Why
Recent interpreter changes introduced threaded fusion for numeric `LOCAL_GET` and constant producers in `interp/threaded.go`. These paths were changed recently but were not pinned by a focused test around callee return flow or fused arithmetic error propagation.

## Changed paths tested
- `interp/threaded.go`: fused numeric `LOCAL_GET` path
- `interp/threaded.go`: fused arithmetic on `I32_CONST` producers
- `interp/interp.go`: cached current-frame behavior exercised via call/return execution

## Validation
- `go test -race ./interp`

## Skipped targets
- `interp/jit.go` cutoff/closure updates: existing nearby JIT tests already cover emission/link behavior, and adding more would require architecture-specific setup beyond this narrow diff.
- Ref-valued `LOCAL_GET` non-fusion path: the recent change explicitly preserves the threaded fallback for refs, but there was no equally small new regression case with stronger signal than the numeric fusion tests added here.
