### PR TITLE
feat: fuse ref-typed producer chains into single closure

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1888,6 +1888,287 @@ var tests = []struct {
 		),
 		values: []types.Value{types.I64(3628800)},
 	},
+	// --- ref: ARRAY_LEN (standalone handler) ---
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 3),
+				instr.New(instr.ARRAY_NEW_DEFAULT, 0),
+				instr.New(instr.ARRAY_LEN),
+			},
+			program.WithTypes(types.NewArrayType(types.TypeI32)),
+		),
+		values: []types.Value{types.I32(3)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 4),
+				instr.New(instr.ARRAY_NEW_DEFAULT, 0),
+				instr.New(instr.ARRAY_LEN),
+			},
+			program.WithTypes(types.NewArrayType(types.TypeRef)),
+		),
+		values: []types.Value{types.I32(4)},
+	},
+	// --- fusion: CONST_GET ref + 1-arg ref op ---
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.STRING_LEN),
+			},
+			program.WithConstants(types.String("hello")),
+		),
+		values: []types.Value{types.I32(5)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.ARRAY_LEN),
+			},
+			program.WithConstants(types.I32Array{10, 20, 30, 40}),
+		),
+		values: []types.Value{types.I32(4)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.REF_IS_NULL),
+			},
+			program.WithConstants(types.String("x")),
+		),
+		values: []types.Value{types.I32(0)},
+	},
+	// --- fusion: CONST_GET ref + CONST_GET ref + 2-arg ref op ---
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.STRING_EQ),
+			},
+			program.WithConstants(types.String("foo")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 1),
+				instr.New(instr.STRING_NE),
+			},
+			program.WithConstants(types.String("foo"), types.String("bar")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 1),
+				instr.New(instr.STRING_LT),
+			},
+			program.WithConstants(types.String("bar"), types.String("foo")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 1),
+				instr.New(instr.STRING_GT),
+			},
+			program.WithConstants(types.String("foo"), types.String("bar")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.STRING_LE),
+			},
+			program.WithConstants(types.String("foo")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.STRING_GE),
+			},
+			program.WithConstants(types.String("foo")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.REF_EQ),
+			},
+			program.WithConstants(types.String("foo")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CONST_GET, 1),
+				instr.New(instr.REF_NE),
+			},
+			program.WithConstants(types.String("a"), types.String("b")),
+		),
+		values: []types.Value{types.I32(1)},
+	},
+	// --- fusion: CONST_GET ref + I32_CONST + ARRAY_GET ---
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.ARRAY_GET),
+			},
+			program.WithConstants(types.I32Array{10, 20, 30}),
+		),
+		values: []types.Value{types.I32(20)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 2),
+				instr.New(instr.ARRAY_GET),
+			},
+			program.WithConstants(types.I64Array{100, 200, 300}),
+		),
+		values: []types.Value{types.I64(300)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 0),
+				instr.New(instr.ARRAY_GET),
+			},
+			program.WithConstants(types.F32Array{1.5, 2.5}),
+		),
+		values: []types.Value{types.F32(1.5)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.ARRAY_GET),
+			},
+			program.WithConstants(types.F64Array{1.25, 2.5}),
+		),
+		values: []types.Value{types.F64(2.5)},
+	},
+	// --- fusion: LOCAL_GET ref + LOCAL_GET i32 + ARRAY_GET (inside a function) ---
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(
+				types.NewFunctionBuilder(&types.FunctionType{
+					Returns: []types.Type{types.TypeI32},
+				}).WithLocals(types.TypeRef, types.TypeI32).Emit(
+					instr.New(instr.CONST_GET, 1),
+					instr.New(instr.LOCAL_SET, 0),
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.LOCAL_SET, 1),
+					instr.New(instr.LOCAL_GET, 0),
+					instr.New(instr.LOCAL_GET, 1),
+					instr.New(instr.ARRAY_GET),
+					instr.New(instr.RETURN),
+				).Build(),
+				types.I32Array{10, 20, 30},
+			),
+		),
+		values: []types.Value{types.I32(20)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(
+				types.NewFunctionBuilder(&types.FunctionType{
+					Returns: []types.Type{types.TypeI32},
+				}).WithLocals(types.TypeRef).Emit(
+					instr.New(instr.CONST_GET, 1),
+					instr.New(instr.LOCAL_SET, 0),
+					instr.New(instr.LOCAL_GET, 0),
+					instr.New(instr.STRING_LEN),
+					instr.New(instr.RETURN),
+				).Build(),
+				types.String("fusion"),
+			),
+		),
+		values: []types.Value{types.I32(6)},
+	},
+	// --- fusion: LOCAL_GET ref + I32_CONST + STRUCT_GET (each field kind) ---
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(
+				types.NewFunctionBuilder(&types.FunctionType{
+					Returns: []types.Type{types.TypeI32},
+				}).WithLocals(types.TypeRef).Emit(
+					instr.New(instr.I32_CONST, 42),
+					instr.New(instr.STRUCT_NEW, 0),
+					instr.New(instr.LOCAL_SET, 0),
+					instr.New(instr.LOCAL_GET, 0),
+					instr.New(instr.I32_CONST, 0),
+					instr.New(instr.STRUCT_GET),
+					instr.New(instr.RETURN),
+				).Build(),
+			),
+			program.WithTypes(types.NewStructType(types.NewStructField(types.TypeI32))),
+		),
+		values: []types.Value{types.I32(42)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(
+				types.NewFunctionBuilder(&types.FunctionType{
+					Returns: []types.Type{types.TypeI64},
+				}).WithLocals(types.TypeRef).Emit(
+					instr.New(instr.I64_CONST, 7),
+					instr.New(instr.STRUCT_NEW, 0),
+					instr.New(instr.LOCAL_SET, 0),
+					instr.New(instr.LOCAL_GET, 0),
+					instr.New(instr.I32_CONST, 0),
+					instr.New(instr.STRUCT_GET),
+					instr.New(instr.RETURN),
+				).Build(),
+			),
+			program.WithTypes(types.NewStructType(types.NewStructField(types.TypeI64))),
+		),
+		values: []types.Value{types.I64(7)},
+	},
 }
 
 func TestInterpreter_Context(t *testing.T) {
@@ -2294,6 +2575,31 @@ func TestInterpreter_Run(t *testing.T) {
 		err := i.Run(context.Background())
 		require.NoError(t, err)
 		require.Equal(t, []int{0, 1, 2, 3}, ips)
+	})
+
+	t.Run("ref producer chain fuses outside precise mode", func(t *testing.T) {
+		p := program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.ARRAY_GET),
+			},
+			program.WithConstants(types.I32Array{10, 20, 30}),
+		)
+
+		precise := New(p, WithTick(1), WithThreshold(-1))
+		defer precise.Close()
+		require.NoError(t, precise.Run(context.Background()))
+		preciseVal, err := precise.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(20), preciseVal)
+
+		fused := New(p, WithThreshold(-1))
+		defer fused.Close()
+		require.NoError(t, fused.Run(context.Background()))
+		fusedVal, err := fused.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(20), fusedVal)
 	})
 
 	t.Run("profile records opcode samples", func(t *testing.T) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -14,10 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var tests = []struct {
+type runTest struct {
+	name    string
 	program *program.Program
+	opts    []func(*option)
 	values  []types.Value
-}{
+	err     error
+	before  func(*testing.T, *Interpreter)
+	after   func(*testing.T, *Interpreter)
+}
+
+var tests = []runTest{
 	// --- stack: NOP, DROP, DUP, SWAP, SELECT ---
 	{
 		program: program.New(
@@ -2442,25 +2449,52 @@ func TestInterpreter_Reset(t *testing.T) {
 }
 
 func TestInterpreter_Run(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		for _, tt := range tests {
-			t.Run(tt.program.String(), func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.TODO())
-				defer cancel()
-
-				i := New(tt.program)
-				defer i.Close()
-
-				err := i.Run(ctx)
-				require.NoError(t, err)
-				for _, val := range tt.values {
-					v, err := i.Pop()
-					require.NoError(t, err)
-					require.Equal(t, val, v)
+	modes := []struct {
+		name string
+		opts []func(*option)
+	}{
+		{name: "default"},
+		{name: "jit", opts: []func(*option){WithTick(1), WithThreshold(1), WithCutoff(1)}},
+	}
+	for _, mode := range modes {
+		mode := mode
+		t.Run(mode.name, func(t *testing.T) {
+			for _, tt := range tests {
+				tt := tt
+				name := tt.name
+				if name == "" {
+					name = tt.program.String()
 				}
-			})
-		}
-	})
+				t.Run(name, func(t *testing.T) {
+					opts := append([]func(*option){}, tt.opts...)
+					opts = append(opts, mode.opts...)
+
+					i := New(tt.program, opts...)
+					defer i.Close()
+
+					if tt.before != nil {
+						tt.before(t, i)
+					}
+
+					err := i.Run(context.Background())
+					if tt.err != nil {
+						require.ErrorIs(t, err, tt.err)
+					} else {
+						require.NoError(t, err)
+						for _, val := range tt.values {
+							v, err := i.Pop()
+							require.NoError(t, err)
+							require.Equal(t, val, v)
+						}
+					}
+
+					if tt.after != nil {
+						tt.after(t, i)
+					}
+				})
+			}
+		})
+	}
 
 	t.Run("canceled context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -2525,60 +2559,13 @@ func TestInterpreter_Run(t *testing.T) {
 		}
 	})
 
-	t.Run("hook inspects interpreter", func(t *testing.T) {
+	t.Run("single run cases", func(t *testing.T) {
 		var lens []int
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 7),
-			instr.New(instr.NOP),
-		}), WithTick(1), WithHook(func(i *Interpreter) error {
-			lens = append(lens, i.Len())
-			return nil
-		}))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, []int{0, 1}, lens)
-	})
-
-	t.Run("normal tick keeps threaded nop fusion", func(t *testing.T) {
 		var ips []int
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.NOP),
-			instr.New(instr.NOP),
-			instr.New(instr.NOP),
-			instr.New(instr.I32_CONST, 7),
-		}), WithTick(2), WithThreshold(-1), WithHook(func(i *Interpreter) error {
-			ips = append(ips, i.IP())
-			return nil
-		}))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, []int{3}, ips)
-	})
-
-	t.Run("tick one preserves threaded nop boundaries", func(t *testing.T) {
-		var ips []int
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.NOP),
-			instr.New(instr.NOP),
-			instr.New(instr.NOP),
-			instr.New(instr.I32_CONST, 7),
-		}), WithTick(1), WithThreshold(-1), WithHook(func(i *Interpreter) error {
-			ips = append(ips, i.IP())
-			return nil
-		}))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, []int{0, 1, 2, 3}, ips)
-	})
-
-	t.Run("ref producer chain fuses outside precise mode", func(t *testing.T) {
-		p := program.New(
+		var preciseIPs []int
+		errHook := errors.New("hook failed")
+		profile := prof.New()
+		refProgram := program.New(
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
 				instr.New(instr.I32_CONST, 1),
@@ -2586,75 +2573,374 @@ func TestInterpreter_Run(t *testing.T) {
 			},
 			program.WithConstants(types.I32Array{10, 20, 30}),
 		)
+		jitDisabledProfile := prof.New()
+		thresholdProfile := prof.New()
+		counterProfile := prof.New()
+		recursiveFn := types.NewFunctionBuilder(nil).Emit(
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+		).Build()
+		fuelCalls := 0
 
-		precise := New(p, WithTick(1), WithThreshold(-1))
-		defer precise.Close()
-		require.NoError(t, precise.Run(context.Background()))
-		preciseVal, err := precise.Pop()
-		require.NoError(t, err)
-		require.Equal(t, types.I32(20), preciseVal)
+		cases := []runTest{
+			{
+				name: "hook inspects interpreter",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 7),
+					instr.New(instr.NOP),
+				}),
+				opts: []func(*option){
+					WithTick(1),
+					WithHook(func(i *Interpreter) error {
+						lens = append(lens, i.Len())
+						return nil
+					}),
+				},
+				after: func(t *testing.T, i *Interpreter) {
+					require.Equal(t, []int{0, 1}, lens)
+				},
+			},
+			{
+				name: "normal tick keeps threaded nop fusion",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.NOP),
+					instr.New(instr.NOP),
+					instr.New(instr.NOP),
+					instr.New(instr.I32_CONST, 7),
+				}),
+				opts: []func(*option){
+					WithTick(2),
+					WithThreshold(-1),
+					WithHook(func(i *Interpreter) error {
+						ips = append(ips, i.IP())
+						return nil
+					}),
+				},
+				after: func(t *testing.T, i *Interpreter) {
+					require.Equal(t, []int{3}, ips)
+				},
+			},
+			{
+				name: "tick one preserves threaded nop boundaries",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.NOP),
+					instr.New(instr.NOP),
+					instr.New(instr.NOP),
+					instr.New(instr.I32_CONST, 7),
+				}),
+				opts: []func(*option){
+					WithTick(1),
+					WithThreshold(-1),
+					WithHook(func(i *Interpreter) error {
+						preciseIPs = append(preciseIPs, i.IP())
+						return nil
+					}),
+				},
+				after: func(t *testing.T, i *Interpreter) {
+					require.Equal(t, []int{0, 1, 2, 3}, preciseIPs)
+				},
+			},
+			{
+				name: "profile records opcode samples",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 7),
+					instr.New(instr.DROP),
+				}),
+				opts: []func(*option){WithProfile(profile), WithTick(1)},
+				after: func(t *testing.T, i *Interpreter) {
+					snap := profile.Snapshot()
+					require.Equal(t, uint64(2), snap.Samples)
+					require.Equal(t, uint64(2), snap.Funcs[0].Samples)
+					require.Equal(t, uint64(1), profile.IP(0, 0).Samples)
+					require.Equal(t, uint64(1), profile.IP(0, 5).Samples)
 
-		fused := New(p, WithThreshold(-1))
-		defer fused.Close()
-		require.NoError(t, fused.Run(context.Background()))
-		fusedVal, err := fused.Pop()
-		require.NoError(t, err)
-		require.Equal(t, types.I32(20), fusedVal)
-	})
-
-	t.Run("profile records opcode samples", func(t *testing.T) {
-		p := prof.New()
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 7),
-			instr.New(instr.DROP),
-		}), WithProfile(p), WithTick(1))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-
-		snap := p.Snapshot()
-		require.Equal(t, uint64(2), snap.Samples)
-		require.Equal(t, uint64(2), snap.Funcs[0].Samples)
-		require.Equal(t, uint64(1), p.IP(0, 0).Samples)
-		require.Equal(t, uint64(1), p.IP(0, 5).Samples)
-
-		opcodes := map[byte]uint64{}
-		for _, op := range snap.Opcodes {
-			opcodes[op.Code] = op.Samples
+					opcodes := map[byte]uint64{}
+					for _, op := range snap.Opcodes {
+						opcodes[op.Code] = op.Samples
+					}
+					require.Equal(t, uint64(1), opcodes[byte(instr.I32_CONST)])
+					require.Equal(t, uint64(1), opcodes[byte(instr.DROP)])
+				},
+			},
+			{
+				name: "hook returns error",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.NOP),
+				}),
+				opts: []func(*option){
+					WithTick(1),
+					WithHook(func(i *Interpreter) error {
+						return errHook
+					}),
+				},
+				err: errHook,
+			},
+			{
+				name:    "precise",
+				program: refProgram,
+				opts:    []func(*option){WithTick(1), WithThreshold(-1)},
+				values:  []types.Value{types.I32(20)},
+			},
+			{
+				name:    "fused outside precise mode",
+				program: refProgram,
+				opts:    []func(*option){WithThreshold(-1)},
+				values:  []types.Value{types.I32(20)},
+			},
+			{
+				name: "negative threshold disables jit",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.I32_CONST, 2),
+					instr.New(instr.I32_ADD),
+				}),
+				opts: []func(*option){WithProfile(jitDisabledProfile), WithTick(1), WithThreshold(-1), WithCutoff(1)},
+				after: func(t *testing.T, i *Interpreter) {
+					require.Zero(t, jitDisabledProfile.Snapshot().JIT.Attempts)
+				},
+			},
+			{
+				name: "threshold zero attempts jit on first sample",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.I32_CONST, 2),
+					instr.New(instr.I32_ADD),
+				}),
+				opts: []func(*option){WithProfile(thresholdProfile), WithTick(1), WithThreshold(0), WithCutoff(1)},
+				before: func(t *testing.T, i *Interpreter) {
+					if arch == nil {
+						t.Skip("jit is not available on this architecture")
+					}
+				},
+				after: func(t *testing.T, i *Interpreter) {
+					require.Equal(t, uint64(1), thresholdProfile.Snapshot().JIT.Attempts)
+				},
+			},
+			{
+				name: "profile records jit counters",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.I32_CONST, 2),
+					instr.New(instr.I32_ADD),
+				}),
+				opts: []func(*option){WithProfile(counterProfile), WithTick(1), WithThreshold(1), WithCutoff(1)},
+				before: func(t *testing.T, i *Interpreter) {
+					if arch == nil {
+						t.Skip("jit is not available on this architecture")
+					}
+				},
+				after: func(t *testing.T, i *Interpreter) {
+					jit := counterProfile.Snapshot().JIT
+					require.Equal(t, uint64(1), jit.Attempts)
+					require.NotZero(t, jit.Emits)
+					require.NotZero(t, jit.Links)
+					require.NotZero(t, jit.Bytes)
+				},
+			},
+			func() runTest {
+				p := prof.New()
+				return runTest{
+					name: "jit compiles numeric globals",
+					program: program.New([]instr.Instruction{
+						instr.New(instr.I32_CONST, 9),
+						instr.New(instr.GLOBAL_SET, 0),
+						instr.New(instr.GLOBAL_GET, 0),
+					}),
+					opts:   []func(*option){WithProfile(p), WithCutoff(1)},
+					values: []types.Value{types.I32(9)},
+					before: func(t *testing.T, i *Interpreter) {
+						if arch == nil {
+							t.Skip("jit is not available on this architecture")
+						}
+						p.Add(0, 0, byte(instr.I32_CONST))
+						i.globals = append(i.globals, types.BoxI32(1))
+						require.NoError(t, i.jit(0))
+					},
+					after: func(t *testing.T, i *Interpreter) {
+						jit := p.Snapshot().JIT
+						require.Equal(t, uint64(1), jit.Attempts)
+						require.NotZero(t, jit.Emits)
+						require.NotZero(t, jit.Links)
+					},
+				}
+			}(),
+			func() runTest {
+				p := prof.New()
+				return runTest{
+					name: "jit skips ref globals",
+					program: program.New([]instr.Instruction{
+						instr.New(instr.GLOBAL_GET, 0),
+					}),
+					opts:   []func(*option){WithProfile(p), WithCutoff(1)},
+					values: []types.Value{types.Null},
+					before: func(t *testing.T, i *Interpreter) {
+						if arch == nil {
+							t.Skip("jit is not available on this architecture")
+						}
+						p.Add(0, 0, byte(instr.GLOBAL_GET))
+						i.globals = append(i.globals, types.BoxedNull)
+						require.NoError(t, i.jit(0))
+					},
+					after: func(t *testing.T, i *Interpreter) {
+						jit := p.Snapshot().JIT
+						require.Equal(t, uint64(1), jit.Attempts)
+						require.Zero(t, jit.Emits)
+						require.Zero(t, jit.Links)
+					},
+				}
+			}(),
+			{
+				name: "fuel zero is unlimited",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 7),
+					instr.New(instr.I32_CONST, 8),
+					instr.New(instr.I32_ADD),
+				}),
+				opts:   []func(*option){WithTick(1), WithFuel(0)},
+				values: []types.Value{types.I32(15)},
+			},
+			{
+				name: "fuel exhausts recursive execution",
+				program: program.New(
+					[]instr.Instruction{
+						instr.New(instr.CONST_GET, 0),
+						instr.New(instr.CALL),
+					},
+					program.WithConstants(recursiveFn),
+				),
+				opts: []func(*option){WithTick(1), WithFuel(2)},
+				err:  ErrFuelExhausted,
+			},
+			{
+				name: "fuel rounds up to tick interval",
+				program: program.New(
+					[]instr.Instruction{
+						instr.New(instr.CONST_GET, 0),
+						instr.New(instr.CALL),
+					},
+					program.WithConstants(recursiveFn),
+				),
+				opts: []func(*option){
+					WithTick(2),
+					WithFuel(3),
+					WithHook(func(i *Interpreter) error {
+						fuelCalls++
+						return nil
+					}),
+				},
+				err: ErrFuelExhausted,
+				after: func(t *testing.T, i *Interpreter) {
+					require.Equal(t, 2, fuelCalls)
+				},
+			},
+			{
+				name: "fuel exhausts jit execution",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 2),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 3),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 4),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 5),
+					instr.New(instr.DROP),
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.CALL),
+				}, program.WithConstants(NewHostFunction(&types.FunctionType{}, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
+					return nil, nil
+				}))),
+				opts: []func(*option){WithTick(1), WithThreshold(1), WithCutoff(1), WithFuel(1)},
+				err:  ErrFuelExhausted,
+			},
 		}
-		require.Equal(t, uint64(1), opcodes[byte(instr.I32_CONST)])
-		require.Equal(t, uint64(1), opcodes[byte(instr.DROP)])
+		for _, tt := range cases {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				i := New(tt.program, tt.opts...)
+				defer i.Close()
+
+				if tt.before != nil {
+					tt.before(t, i)
+				}
+
+				err := i.Run(context.Background())
+				if tt.err != nil {
+					require.ErrorIs(t, err, tt.err)
+				} else {
+					require.NoError(t, err)
+					for _, val := range tt.values {
+						v, err := i.Pop()
+						require.NoError(t, err)
+						require.Equal(t, val, v)
+					}
+				}
+
+				if tt.after != nil {
+					tt.after(t, i)
+				}
+			})
+		}
 	})
 
 	t.Run("hook cancel is observed on next tick", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		cases := []struct {
+			name    string
+			program *program.Program
+			opts    []func(*option)
+		}{
+			{
+				name: "threaded",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.NOP),
+					instr.New(instr.I32_CONST, 0),
+				}),
+				opts: []func(*option){WithTick(1)},
+			},
+			{
+				name: "jit",
+				program: program.New([]instr.Instruction{
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 2),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 3),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 4),
+					instr.New(instr.DROP),
+					instr.New(instr.I32_CONST, 5),
+					instr.New(instr.DROP),
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.CALL),
+				}, program.WithConstants(NewHostFunction(&types.FunctionType{}, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
+					return nil, nil
+				}))),
+				opts: []func(*option){WithTick(1), WithThreshold(1), WithCutoff(1)},
+			},
+		}
+		for _, tt := range cases {
+			tt := tt
+			t.Run(tt.name, func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
 
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.NOP),
-			instr.New(instr.I32_CONST, 0),
-		}), WithTick(1), WithHook(func(i *Interpreter) error {
-			cancel()
-			return nil
-		}))
-		defer i.Close()
+				calls := 0
+				opts := append([]func(*option){}, tt.opts...)
+				opts = append(opts, WithHook(func(i *Interpreter) error {
+					calls++
+					cancel()
+					return nil
+				}))
 
-		err := i.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-	})
+				i := New(tt.program, opts...)
+				defer i.Close()
 
-	t.Run("hook returns error", func(t *testing.T) {
-		errHook := errors.New("hook failed")
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.NOP),
-		}), WithTick(1), WithHook(func(i *Interpreter) error {
-			return errHook
-		}))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.ErrorIs(t, err, errHook)
+				err := i.Run(ctx)
+				require.ErrorIs(t, err, context.Canceled)
+				require.Equal(t, 1, calls)
+			})
+		}
 	})
 
 	t.Run("debugger breakpoint stops before instruction", func(t *testing.T) {
@@ -2692,22 +2978,6 @@ func TestInterpreter_Run(t *testing.T) {
 		require.ErrorIs(t, err, ErrStopped)
 		require.Equal(t, id, dbg.Stop().Breakpoint)
 		require.Equal(t, 1, i.Len())
-	})
-
-	t.Run("debugger breakpoint management", func(t *testing.T) {
-		var dbg Debugger
-		first := dbg.Break(0, 0)
-		second := dbg.Break(0, 1)
-
-		require.True(t, dbg.Enable(first, false))
-		require.False(t, dbg.Enable(99, false))
-		require.True(t, dbg.Clear(second))
-		require.False(t, dbg.Clear(second))
-
-		bps := dbg.Breakpoints()
-		require.Len(t, bps, 1)
-		require.Equal(t, first, bps[0].ID)
-		require.False(t, bps[0].Enabled)
 	})
 
 	t.Run("debugger helpers inspect current frame", func(t *testing.T) {
@@ -2803,94 +3073,6 @@ func TestInterpreter_Run(t *testing.T) {
 		})
 	})
 
-	t.Run("negative threshold disables jit", func(t *testing.T) {
-		p := prof.New()
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 1),
-			instr.New(instr.I32_CONST, 2),
-			instr.New(instr.I32_ADD),
-		}), WithProfile(p), WithTick(1), WithThreshold(-1), WithCutoff(1))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-		require.Zero(t, p.Snapshot().JIT.Attempts)
-	})
-
-	t.Run("threshold zero attempts jit on first sample", func(t *testing.T) {
-		if arch == nil {
-			t.Skip("jit is not available on this architecture")
-		}
-		p := prof.New()
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 1),
-			instr.New(instr.I32_CONST, 2),
-			instr.New(instr.I32_ADD),
-		}), WithProfile(p), WithTick(1), WithThreshold(0), WithCutoff(1))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-		require.Equal(t, uint64(1), p.Snapshot().JIT.Attempts)
-	})
-
-	t.Run("fuel zero is unlimited", func(t *testing.T) {
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 7),
-			instr.New(instr.I32_CONST, 8),
-			instr.New(instr.I32_ADD),
-		}), WithTick(1), WithFuel(0))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-
-		val, err := i.Pop()
-		require.NoError(t, err)
-		require.Equal(t, types.I32(15), val)
-	})
-
-	t.Run("fuel exhausts recursive execution", func(t *testing.T) {
-		fn := types.NewFunctionBuilder(nil).Emit(
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CALL),
-		).Build()
-		i := New(program.New(
-			[]instr.Instruction{
-				instr.New(instr.CONST_GET, 0),
-				instr.New(instr.CALL),
-			},
-			program.WithConstants(fn),
-		), WithTick(1), WithFuel(2))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.ErrorIs(t, err, ErrFuelExhausted)
-	})
-
-	t.Run("fuel rounds up to tick interval", func(t *testing.T) {
-		calls := 0
-		fn := types.NewFunctionBuilder(nil).Emit(
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CALL),
-		).Build()
-		i := New(program.New(
-			[]instr.Instruction{
-				instr.New(instr.CONST_GET, 0),
-				instr.New(instr.CALL),
-			},
-			program.WithConstants(fn),
-		), WithTick(2), WithFuel(3), WithHook(func(i *Interpreter) error {
-			calls++
-			return nil
-		}))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.ErrorIs(t, err, ErrFuelExhausted)
-		require.Equal(t, 2, calls)
-	})
-
 	t.Run("reset restores fuel", func(t *testing.T) {
 		i := New(program.New([]instr.Instruction{
 			instr.New(instr.NOP),
@@ -2905,48 +3087,6 @@ func TestInterpreter_Run(t *testing.T) {
 
 		err = i.Run(context.Background())
 		require.ErrorIs(t, err, ErrFuelExhausted)
-	})
-
-	t.Run("jit", func(t *testing.T) {
-		for _, tt := range tests {
-			t.Run(tt.program.String(), func(t *testing.T) {
-				ctx, cancel := context.WithCancel(context.TODO())
-				defer cancel()
-
-				i := New(tt.program, WithTick(1), WithThreshold(1), WithCutoff(1))
-				defer i.Close()
-
-				err := i.Run(ctx)
-				require.NoError(t, err)
-				for _, val := range tt.values {
-					v, err := i.Pop()
-					require.NoError(t, err)
-					require.Equal(t, val, v)
-				}
-			})
-		}
-	})
-
-	t.Run("profile records jit counters", func(t *testing.T) {
-		if arch == nil {
-			t.Skip("jit is not available on this architecture")
-		}
-		p := prof.New()
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 1),
-			instr.New(instr.I32_CONST, 2),
-			instr.New(instr.I32_ADD),
-		}), WithProfile(p), WithTick(1), WithThreshold(1), WithCutoff(1))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.NoError(t, err)
-
-		jit := p.Snapshot().JIT
-		require.Equal(t, uint64(1), jit.Attempts)
-		require.NotZero(t, jit.Emits)
-		require.NotZero(t, jit.Links)
-		require.NotZero(t, jit.Bytes)
 	})
 
 	t.Run("jit links branches", func(t *testing.T) {
@@ -3132,117 +3272,6 @@ func TestInterpreter_Run(t *testing.T) {
 		require.Equal(t, uint64(1), jit.Skips)
 	})
 
-	t.Run("jit compiles numeric globals", func(t *testing.T) {
-		if arch == nil {
-			t.Skip("jit is not available on this architecture")
-		}
-		p := prof.New()
-		p.Add(0, 0, byte(instr.I32_CONST))
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 9),
-			instr.New(instr.GLOBAL_SET, 0),
-			instr.New(instr.GLOBAL_GET, 0),
-		}), WithProfile(p), WithCutoff(1))
-		defer i.Close()
-		i.globals = append(i.globals, types.BoxI32(1))
-
-		err := i.jit(0)
-		require.NoError(t, err)
-
-		err = i.Run(context.Background())
-		require.NoError(t, err)
-		val, err := i.Pop()
-		require.NoError(t, err)
-		require.Equal(t, types.I32(9), val)
-
-		jit := p.Snapshot().JIT
-		require.Equal(t, uint64(1), jit.Attempts)
-		require.NotZero(t, jit.Emits)
-		require.NotZero(t, jit.Links)
-	})
-
-	t.Run("jit skips ref globals", func(t *testing.T) {
-		if arch == nil {
-			t.Skip("jit is not available on this architecture")
-		}
-		p := prof.New()
-		p.Add(0, 0, byte(instr.GLOBAL_GET))
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.GLOBAL_GET, 0),
-		}), WithProfile(p), WithCutoff(1))
-		defer i.Close()
-		i.globals = append(i.globals, types.BoxedNull)
-
-		err := i.jit(0)
-		require.NoError(t, err)
-
-		err = i.Run(context.Background())
-		require.NoError(t, err)
-		val, err := i.Pop()
-		require.NoError(t, err)
-		require.Equal(t, types.Null, val)
-
-		jit := p.Snapshot().JIT
-		require.Equal(t, uint64(1), jit.Attempts)
-		require.Zero(t, jit.Emits)
-		require.Zero(t, jit.Links)
-	})
-
-	t.Run("hook cancel is observed on next jit tick", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		calls := 0
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 1),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 2),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 3),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 4),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 5),
-			instr.New(instr.DROP),
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CALL),
-		}, program.WithConstants(NewHostFunction(&types.FunctionType{}, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
-			return nil, nil
-		}))), WithTick(1), WithThreshold(1), WithCutoff(1), WithHook(func(i *Interpreter) error {
-			calls++
-			cancel()
-			return nil
-		}))
-		defer i.Close()
-
-		err := i.Run(ctx)
-		require.ErrorIs(t, err, context.Canceled)
-		require.Equal(t, 1, calls)
-	})
-
-	t.Run("fuel exhausts jit execution", func(t *testing.T) {
-		i := New(program.New([]instr.Instruction{
-			instr.New(instr.I32_CONST, 1),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 2),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 3),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 4),
-			instr.New(instr.DROP),
-			instr.New(instr.I32_CONST, 5),
-			instr.New(instr.DROP),
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CALL),
-		}, program.WithConstants(NewHostFunction(&types.FunctionType{}, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
-			return nil, nil
-		}))), WithTick(1), WithThreshold(1), WithCutoff(1), WithFuel(1))
-		defer i.Close()
-
-		err := i.Run(context.Background())
-		require.ErrorIs(t, err, ErrFuelExhausted)
-	})
-
 	t.Run("canceled jit execution", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -3309,21 +3338,59 @@ func TestInterpreter_Run(t *testing.T) {
 	})
 }
 
+func TestDebugger_Breakpoints(t *testing.T) {
+	var dbg Debugger
+	first := dbg.Break(0, 0)
+	second := dbg.Break(0, 1)
+
+	require.True(t, dbg.Enable(first, false))
+	require.False(t, dbg.Enable(99, false))
+	require.True(t, dbg.Clear(second))
+	require.False(t, dbg.Clear(second))
+
+	bps := dbg.Breakpoints()
+	require.Len(t, bps, 1)
+	require.Equal(t, first, bps[0].ID)
+	require.False(t, bps[0].Enabled)
+}
+
 func BenchmarkInterpreter_Run(b *testing.B) {
-	for _, tt := range tests {
-		b.Run(tt.program.String(), func(b *testing.B) {
-			ctx, cancel := context.WithCancel(context.TODO())
-			defer cancel()
+	b.Run("default", func(b *testing.B) {
+		for _, tt := range tests {
+			b.Run(tt.program.String(), func(b *testing.B) {
+				ctx, cancel := context.WithCancel(context.TODO())
+				defer cancel()
 
-			i := New(tt.program)
-			defer i.Close()
+				i := New(tt.program)
+				defer i.Close()
 
-			b.ResetTimer()
+				b.ResetTimer()
 
-			for n := 0; n < b.N; n++ {
-				_ = i.Run(ctx)
-				i.Reset()
-			}
-		})
-	}
+				for n := 0; n < b.N; n++ {
+					_ = i.Run(ctx)
+					i.Reset()
+				}
+			})
+		}
+	})
+
+	b.Run("jit", func(b *testing.B) {
+		for _, tt := range tests {
+			b.Run(tt.program.String(), func(b *testing.B) {
+				ctx, cancel := context.WithCancel(context.TODO())
+				defer cancel()
+
+				i := New(tt.program, WithTick(1), WithThreshold(1), WithCutoff(1))
+				defer i.Close()
+
+				b.ResetTimer()
+
+				for n := 0; n < b.N; n++ {
+					_ = i.Run(ctx)
+					i.Reset()
+				}
+			})
+		}
+	})
+
 }

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -385,19 +385,9 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 			}
 		}
 		if idx < len(c.locals) && c.locals[idx] == types.KindRef {
-			loadRef := func(i *Interpreter) types.Boxed {
+			if fused := c.fuseRefOp(func(i *Interpreter) types.Boxed {
 				return i.stack[i.fr.bp+idx]
-			}
-			if fused := c.fuse1ArgRefOp(loadRef, 2); fused != nil {
-				return fused
-			}
-			if fused := c.fuseArrayGet(loadRef, 2); fused != nil {
-				return fused
-			}
-			if fused := c.fuseStructGet(loadRef, 2); fused != nil {
-				return fused
-			}
-			if fused := c.fuse2ArgRefOp(loadRef, 2); fused != nil {
+			}, 2); fused != nil {
 				return fused
 			}
 		}
@@ -559,17 +549,7 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 				default:
 				}
 			}
-			loadRef := func(_ *Interpreter) types.Boxed { return val }
-			if fused := c.fuse1ArgRefOp(loadRef, 3); fused != nil {
-				return fused
-			}
-			if fused := c.fuseArrayGet(loadRef, 3); fused != nil {
-				return fused
-			}
-			if fused := c.fuseStructGet(loadRef, 3); fused != nil {
-				return fused
-			}
-			if fused := c.fuse2ArgRefOp(loadRef, 3); fused != nil {
+			if fused := c.fuseRefOp(func(_ *Interpreter) types.Boxed { return val }, 3); fused != nil {
 				return fused
 			}
 			return func(i *Interpreter) {
@@ -2874,99 +2854,26 @@ func (c *threadedCompiler) fuseF64(load func(*Interpreter) float64, advance int)
 	}
 }
 
-// peekRefLoader looks at the instruction at `ip` and, if it is a LOCAL_GET of a
-// Ref-typed local or a CONST_GET of a Ref-typed constant, returns a closure
-// that loads the boxed ref onto the stack-less, the byte width of the loader,
-// and true. The returned closure does not retain — callers must not push the
-// ref onto the stack permanently.
-func (c *threadedCompiler) peekRefLoader(ip int) (func(*Interpreter) types.Boxed, int, bool) {
-	if ip >= len(c.code) {
-		return nil, 0, false
-	}
-	switch instr.Opcode(c.code[ip]) {
-	case instr.LOCAL_GET:
-		if ip+1 >= len(c.code) {
-			return nil, 0, false
-		}
-		idx := int(c.code[ip+1])
-		if idx < 0 || idx >= len(c.locals) || c.locals[idx] != types.KindRef {
-			return nil, 0, false
-		}
-		return func(i *Interpreter) types.Boxed {
-			return i.stack[i.fr.bp+idx]
-		}, 2, true
-	case instr.CONST_GET:
-		if ip+2 >= len(c.code) {
-			return nil, 0, false
-		}
-		cidx := int(*(*uint16)(unsafe.Pointer(&c.code[ip+1])))
-		if cidx < 0 || cidx >= len(c.constants) || c.constants[cidx].Kind() != types.KindRef {
-			return nil, 0, false
-		}
-		val := c.constants[cidx]
-		return func(_ *Interpreter) types.Boxed {
-			return val
-		}, 3, true
-	}
-	return nil, 0, false
-}
-
-// peekI32Loader is the I32 counterpart of peekRefLoader. It accepts LOCAL_GET
-// of an I32-typed local, CONST_GET of an I32-typed constant, and the literal
-// I32_CONST instruction.
-func (c *threadedCompiler) peekI32Loader(ip int) (func(*Interpreter) int32, int, bool) {
-	if ip >= len(c.code) {
-		return nil, 0, false
-	}
-	switch instr.Opcode(c.code[ip]) {
-	case instr.LOCAL_GET:
-		if ip+1 >= len(c.code) {
-			return nil, 0, false
-		}
-		idx := int(c.code[ip+1])
-		if idx < 0 || idx >= len(c.locals) || c.locals[idx] != types.KindI32 {
-			return nil, 0, false
-		}
-		return func(i *Interpreter) int32 {
-			return i.stack[i.fr.bp+idx].I32()
-		}, 2, true
-	case instr.CONST_GET:
-		if ip+2 >= len(c.code) {
-			return nil, 0, false
-		}
-		cidx := int(*(*uint16)(unsafe.Pointer(&c.code[ip+1])))
-		if cidx < 0 || cidx >= len(c.constants) || c.constants[cidx].Kind() != types.KindI32 {
-			return nil, 0, false
-		}
-		v := c.constants[cidx].I32()
-		return func(_ *Interpreter) int32 { return v }, 3, true
-	case instr.I32_CONST:
-		if ip+4 >= len(c.code) {
-			return nil, 0, false
-		}
-		v := *(*int32)(unsafe.Pointer(&c.code[ip+1]))
-		return func(_ *Interpreter) int32 { return v }, 5, true
-	}
-	return nil, 0, false
-}
-
-// fuse1ArgRefOp peeks the next opcode and, when it is a 1-arg ref op
-// (STRING_LEN, ARRAY_LEN, REF_IS_NULL), consumes it and returns a closure that
-// loads the ref via `loadRef`, applies the op directly against the heap value,
-// and pushes the result. `advance` is the producer's instruction width.
-func (c *threadedCompiler) fuse1ArgRefOp(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
+// fuseRefOp peeks ahead of the current ip and, when the layout matches a
+// ref-producer chain ending in a ref op, returns a single fused closure for
+// the whole sequence. `loadRef` reads the boxed ref produced by the outer
+// instruction (LOCAL_GET ref / CONST_GET ref); `advance` is the byte width of
+// that producer. Mirrors the shape of fuseI32 / fuseI64 / fuseF32 / fuseF64.
+func (c *threadedCompiler) fuseRefOp(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
 	if c.precise || c.ip >= len(c.code) {
 		return nil
 	}
-	var op func(*Interpreter, types.Boxed) types.Boxed
+
+	// 1-arg ref op directly after the outer producer.
+	var op1 func(*Interpreter, types.Boxed) types.Boxed
 	switch instr.Opcode(c.code[c.ip]) {
 	case instr.STRING_LEN:
-		op = func(i *Interpreter, b types.Boxed) types.Boxed {
+		op1 = func(i *Interpreter, b types.Boxed) types.Boxed {
 			s, _ := i.heap[b.Ref()].(types.String)
 			return types.BoxI32(int32(len(s)))
 		}
 	case instr.ARRAY_LEN:
-		op = func(i *Interpreter, b types.Boxed) types.Boxed {
+		op1 = func(i *Interpreter, b types.Boxed) types.Boxed {
 			switch arr := i.heap[b.Ref()].(type) {
 			case types.I32Array:
 				return types.BoxI32(int32(len(arr)))
@@ -2983,218 +2890,226 @@ func (c *threadedCompiler) fuse1ArgRefOp(loadRef func(*Interpreter) types.Boxed,
 			}
 		}
 	case instr.REF_IS_NULL:
-		op = func(_ *Interpreter, b types.Boxed) types.Boxed {
+		op1 = func(_ *Interpreter, b types.Boxed) types.Boxed {
 			return types.BoxBool(b.Ref() == 0)
 		}
-	default:
-		return nil
 	}
-	c.ip++
-	return func(i *Interpreter) {
-		if i.sp == len(i.stack) {
-			panic(ErrStackOverflow)
+	if op1 != nil {
+		c.ip++
+		return func(i *Interpreter) {
+			if i.sp == len(i.stack) {
+				panic(ErrStackOverflow)
+			}
+			i.stack[i.sp] = op1(i, loadRef(i))
+			i.sp++
+			i.fr.ip += advance + 1
 		}
-		i.stack[i.sp] = op(i, loadRef(i))
-		i.sp++
-		i.fr.ip += advance + 1
 	}
-}
 
-// fuse2ArgRefOp peeks the next loader and the op after it. When the layout is
-// (outer producer) ; (ref loader) ; (REF_EQ|REF_NE|STRING_EQ|NE|LT|GT|LE|GE),
-// consumes both consecutive ops and returns a single fused closure.
-func (c *threadedCompiler) fuse2ArgRefOp(loadRef1 func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
-	if c.precise || c.ip >= len(c.code) {
-		return nil
-	}
-	loadRef2, w2, ok := c.peekRefLoader(c.ip)
-	if !ok {
-		return nil
-	}
-	opIp := c.ip + w2
-	if opIp >= len(c.code) {
-		return nil
-	}
-	var op func(*Interpreter, types.Boxed, types.Boxed) types.Boxed
-	switch instr.Opcode(c.code[opIp]) {
-	case instr.REF_EQ:
-		op = func(_ *Interpreter, a, b types.Boxed) types.Boxed {
-			return types.BoxBool(a == b)
+	// Peek a second loader. Either i32 (for ARRAY_GET / STRUCT_GET) or ref
+	// (for 2-arg ref ops). Only one of loadIdx / loadRef2 is populated.
+	var (
+		loadIdx  func(*Interpreter) int32
+		loadRef2 func(*Interpreter) types.Boxed
+		w2       int
+	)
+	switch instr.Opcode(c.code[c.ip]) {
+	case instr.LOCAL_GET:
+		if c.ip+1 >= len(c.code) {
+			return nil
 		}
-	case instr.REF_NE:
-		op = func(_ *Interpreter, a, b types.Boxed) types.Boxed {
-			return types.BoxBool(a != b)
+		lidx := int(c.code[c.ip+1])
+		if lidx < 0 || lidx >= len(c.locals) {
+			return nil
 		}
-	case instr.STRING_EQ:
-		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
-			sa, _ := i.heap[a.Ref()].(types.String)
-			sb, _ := i.heap[b.Ref()].(types.String)
-			return types.BoxBool(sa == sb)
-		}
-	case instr.STRING_NE:
-		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
-			sa, _ := i.heap[a.Ref()].(types.String)
-			sb, _ := i.heap[b.Ref()].(types.String)
-			return types.BoxBool(sa != sb)
-		}
-	case instr.STRING_LT:
-		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
-			sa, _ := i.heap[a.Ref()].(types.String)
-			sb, _ := i.heap[b.Ref()].(types.String)
-			return types.BoxBool(sa < sb)
-		}
-	case instr.STRING_GT:
-		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
-			sa, _ := i.heap[a.Ref()].(types.String)
-			sb, _ := i.heap[b.Ref()].(types.String)
-			return types.BoxBool(sa > sb)
-		}
-	case instr.STRING_LE:
-		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
-			sa, _ := i.heap[a.Ref()].(types.String)
-			sb, _ := i.heap[b.Ref()].(types.String)
-			return types.BoxBool(sa <= sb)
-		}
-	case instr.STRING_GE:
-		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
-			sa, _ := i.heap[a.Ref()].(types.String)
-			sb, _ := i.heap[b.Ref()].(types.String)
-			return types.BoxBool(sa >= sb)
-		}
-	default:
-		return nil
-	}
-	c.ip = opIp + 1
-	return func(i *Interpreter) {
-		if i.sp == len(i.stack) {
-			panic(ErrStackOverflow)
-		}
-		a := loadRef1(i)
-		b := loadRef2(i)
-		i.stack[i.sp] = op(i, a, b)
-		i.sp++
-		i.fr.ip += advance + w2 + 1
-	}
-}
-
-// fuseArrayGet peeks the next i32 loader and ARRAY_GET. When the layout is
-// (outer producer) ; (i32 loader) ; ARRAY_GET, consumes them and returns a
-// fused closure that loads the array ref, the index, performs the bounds and
-// type-switched element access, and pushes the result.
-func (c *threadedCompiler) fuseArrayGet(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
-	if c.precise || c.ip >= len(c.code) {
-		return nil
-	}
-	loadIdx, w2, ok := c.peekI32Loader(c.ip)
-	if !ok {
-		return nil
-	}
-	opIp := c.ip + w2
-	if opIp >= len(c.code) {
-		return nil
-	}
-	if instr.Opcode(c.code[opIp]) != instr.ARRAY_GET {
-		return nil
-	}
-	c.ip = opIp + 1
-	return func(i *Interpreter) {
-		if i.sp == len(i.stack) {
-			panic(ErrStackOverflow)
-		}
-		ref := loadRef(i)
-		idx := int(loadIdx(i))
-		addr := ref.Ref()
-		var val types.Boxed
-		switch arr := i.heap[addr].(type) {
-		case types.I32Array:
-			if idx < 0 || idx >= len(arr) {
-				panic(ErrIndexOutOfRange)
+		switch c.locals[lidx] {
+		case types.KindI32:
+			loadIdx = func(i *Interpreter) int32 {
+				return i.stack[i.fr.bp+lidx].I32()
 			}
-			val = types.BoxI32(int32(arr[idx]))
-		case types.I64Array:
-			if idx < 0 || idx >= len(arr) {
-				panic(ErrIndexOutOfRange)
-			}
-			val = i.boxI64(int64(arr[idx]))
-		case types.F32Array:
-			if idx < 0 || idx >= len(arr) {
-				panic(ErrIndexOutOfRange)
-			}
-			val = types.BoxF32(float32(arr[idx]))
-		case types.F64Array:
-			if idx < 0 || idx >= len(arr) {
-				panic(ErrIndexOutOfRange)
-			}
-			val = types.BoxF64(float64(arr[idx]))
-		case *types.Array:
-			if idx < 0 || idx >= len(arr.Elems) {
-				panic(ErrIndexOutOfRange)
-			}
-			elem := arr.Elems[idx]
-			if elem.Kind() == types.KindRef {
-				i.retain(elem.Ref())
-			}
-			val = elem
-		default:
-			panic(ErrTypeMismatch)
-		}
-		i.stack[i.sp] = val
-		i.sp++
-		i.fr.ip += advance + w2 + 1
-	}
-}
-
-// fuseStructGet mirrors fuseArrayGet for STRUCT_GET. The field kind is read
-// from the struct's runtime type metadata.
-func (c *threadedCompiler) fuseStructGet(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
-	if c.precise || c.ip >= len(c.code) {
-		return nil
-	}
-	loadIdx, w2, ok := c.peekI32Loader(c.ip)
-	if !ok {
-		return nil
-	}
-	opIp := c.ip + w2
-	if opIp >= len(c.code) {
-		return nil
-	}
-	if instr.Opcode(c.code[opIp]) != instr.STRUCT_GET {
-		return nil
-	}
-	c.ip = opIp + 1
-	return func(i *Interpreter) {
-		if i.sp == len(i.stack) {
-			panic(ErrStackOverflow)
-		}
-		ref := loadRef(i)
-		idx := int(loadIdx(i))
-		addr := ref.Ref()
-		s, ok := i.heap[addr].(*types.Struct)
-		if !ok {
-			panic(ErrTypeMismatch)
-		}
-		if idx < 0 || idx >= len(s.Typ.Fields) {
-			panic(ErrSegmentationFault)
-		}
-		field := s.Typ.Fields[idx]
-		var val types.Boxed
-		switch field.Kind {
-		case types.KindI32, types.KindF32, types.KindF64:
-			val = s.Field(idx)
-		case types.KindI64:
-			val = i.boxI64(int64(s.Raw(idx)))
+			w2 = 2
 		case types.KindRef:
-			val = types.Boxed(s.Raw(idx))
-			if val.Kind() == types.KindRef {
-				i.retain(val.Ref())
+			loadRef2 = func(i *Interpreter) types.Boxed {
+				return i.stack[i.fr.bp+lidx]
 			}
-		default:
-			panic(ErrTypeMismatch)
+			w2 = 2
 		}
-		i.stack[i.sp] = val
-		i.sp++
-		i.fr.ip += advance + w2 + 1
+	case instr.CONST_GET:
+		if c.ip+2 >= len(c.code) {
+			return nil
+		}
+		cidx := int(*(*uint16)(unsafe.Pointer(&c.code[c.ip+1])))
+		if cidx < 0 || cidx >= len(c.constants) {
+			return nil
+		}
+		v := c.constants[cidx]
+		switch v.Kind() {
+		case types.KindI32:
+			iv := v.I32()
+			loadIdx = func(_ *Interpreter) int32 { return iv }
+			w2 = 3
+		case types.KindRef:
+			loadRef2 = func(_ *Interpreter) types.Boxed { return v }
+			w2 = 3
+		}
+	case instr.I32_CONST:
+		if c.ip+4 >= len(c.code) {
+			return nil
+		}
+		v := *(*int32)(unsafe.Pointer(&c.code[c.ip+1]))
+		loadIdx = func(_ *Interpreter) int32 { return v }
+		w2 = 5
 	}
+	if w2 == 0 {
+		return nil
+	}
+	opIp := c.ip + w2
+	if opIp >= len(c.code) {
+		return nil
+	}
+
+	// (ref) ; (i32 loader) ; ARRAY_GET | STRUCT_GET
+	if loadIdx != nil {
+		var op2 func(i *Interpreter, ref types.Boxed, idx int) types.Boxed
+		switch instr.Opcode(c.code[opIp]) {
+		case instr.ARRAY_GET:
+			op2 = func(i *Interpreter, ref types.Boxed, idx int) types.Boxed {
+				addr := ref.Ref()
+				switch arr := i.heap[addr].(type) {
+				case types.I32Array:
+					if idx < 0 || idx >= len(arr) {
+						panic(ErrIndexOutOfRange)
+					}
+					return types.BoxI32(int32(arr[idx]))
+				case types.I64Array:
+					if idx < 0 || idx >= len(arr) {
+						panic(ErrIndexOutOfRange)
+					}
+					return i.boxI64(int64(arr[idx]))
+				case types.F32Array:
+					if idx < 0 || idx >= len(arr) {
+						panic(ErrIndexOutOfRange)
+					}
+					return types.BoxF32(float32(arr[idx]))
+				case types.F64Array:
+					if idx < 0 || idx >= len(arr) {
+						panic(ErrIndexOutOfRange)
+					}
+					return types.BoxF64(float64(arr[idx]))
+				case *types.Array:
+					if idx < 0 || idx >= len(arr.Elems) {
+						panic(ErrIndexOutOfRange)
+					}
+					elem := arr.Elems[idx]
+					if elem.Kind() == types.KindRef {
+						i.retain(elem.Ref())
+					}
+					return elem
+				default:
+					panic(ErrTypeMismatch)
+				}
+			}
+		case instr.STRUCT_GET:
+			op2 = func(i *Interpreter, ref types.Boxed, idx int) types.Boxed {
+				s, ok := i.heap[ref.Ref()].(*types.Struct)
+				if !ok {
+					panic(ErrTypeMismatch)
+				}
+				if idx < 0 || idx >= len(s.Typ.Fields) {
+					panic(ErrSegmentationFault)
+				}
+				switch s.Typ.Fields[idx].Kind {
+				case types.KindI32, types.KindF32, types.KindF64:
+					return s.Field(idx)
+				case types.KindI64:
+					return i.boxI64(int64(s.Raw(idx)))
+				case types.KindRef:
+					v := types.Boxed(s.Raw(idx))
+					if v.Kind() == types.KindRef {
+						i.retain(v.Ref())
+					}
+					return v
+				default:
+					panic(ErrTypeMismatch)
+				}
+			}
+		}
+		if op2 != nil {
+			c.ip = opIp + 1
+			return func(i *Interpreter) {
+				if i.sp == len(i.stack) {
+					panic(ErrStackOverflow)
+				}
+				i.stack[i.sp] = op2(i, loadRef(i), int(loadIdx(i)))
+				i.sp++
+				i.fr.ip += advance + w2 + 1
+			}
+		}
+	}
+
+	// (ref) ; (ref loader) ; 2-arg ref op
+	if loadRef2 != nil {
+		var op2 func(*Interpreter, types.Boxed, types.Boxed) types.Boxed
+		switch instr.Opcode(c.code[opIp]) {
+		case instr.REF_EQ:
+			op2 = func(_ *Interpreter, a, b types.Boxed) types.Boxed {
+				return types.BoxBool(a == b)
+			}
+		case instr.REF_NE:
+			op2 = func(_ *Interpreter, a, b types.Boxed) types.Boxed {
+				return types.BoxBool(a != b)
+			}
+		case instr.STRING_EQ:
+			op2 = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+				sa, _ := i.heap[a.Ref()].(types.String)
+				sb, _ := i.heap[b.Ref()].(types.String)
+				return types.BoxBool(sa == sb)
+			}
+		case instr.STRING_NE:
+			op2 = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+				sa, _ := i.heap[a.Ref()].(types.String)
+				sb, _ := i.heap[b.Ref()].(types.String)
+				return types.BoxBool(sa != sb)
+			}
+		case instr.STRING_LT:
+			op2 = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+				sa, _ := i.heap[a.Ref()].(types.String)
+				sb, _ := i.heap[b.Ref()].(types.String)
+				return types.BoxBool(sa < sb)
+			}
+		case instr.STRING_GT:
+			op2 = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+				sa, _ := i.heap[a.Ref()].(types.String)
+				sb, _ := i.heap[b.Ref()].(types.String)
+				return types.BoxBool(sa > sb)
+			}
+		case instr.STRING_LE:
+			op2 = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+				sa, _ := i.heap[a.Ref()].(types.String)
+				sb, _ := i.heap[b.Ref()].(types.String)
+				return types.BoxBool(sa <= sb)
+			}
+		case instr.STRING_GE:
+			op2 = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+				sa, _ := i.heap[a.Ref()].(types.String)
+				sb, _ := i.heap[b.Ref()].(types.String)
+				return types.BoxBool(sa >= sb)
+			}
+		}
+		if op2 != nil {
+			c.ip = opIp + 1
+			return func(i *Interpreter) {
+				if i.sp == len(i.stack) {
+					panic(ErrStackOverflow)
+				}
+				i.stack[i.sp] = op2(i, loadRef(i), loadRef2(i))
+				i.sp++
+				i.fr.ip += advance + w2 + 1
+			}
+		}
+	}
+
+	return nil
 }
 
 func (c *threadedCompiler) Compile(code []byte, locals []types.Kind) []func(*Interpreter) {

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -385,7 +385,7 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 			}
 		}
 		if idx < len(c.locals) && c.locals[idx] == types.KindRef {
-			if fused := c.fuseRefOp(func(i *Interpreter) types.Boxed {
+			if fused := c.fuseRef(func(i *Interpreter) types.Boxed {
 				return i.stack[i.fr.bp+idx]
 			}, 2); fused != nil {
 				return fused
@@ -549,7 +549,7 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 				default:
 				}
 			}
-			if fused := c.fuseRefOp(func(_ *Interpreter) types.Boxed { return val }, 3); fused != nil {
+			if fused := c.fuseRef(func(_ *Interpreter) types.Boxed { return val }, 3); fused != nil {
 				return fused
 			}
 			return func(i *Interpreter) {
@@ -2581,6 +2581,24 @@ func init() {
 	}
 }
 
+func (c *threadedCompiler) Compile(code []byte, locals []types.Kind) []func(*Interpreter) {
+	c.code = code
+	c.locals = locals
+	c.ip = 0
+
+	compiled := make([]func(*Interpreter), len(code))
+	for c.ip < len(code) {
+		ip := c.ip
+		compiled[ip] = threaded[code[ip]](c)
+	}
+	for ip := 0; ip < len(code); ip++ {
+		if compiled[ip] == nil {
+			compiled[ip] = unknown
+		}
+	}
+	return compiled
+}
+
 // fuseI32 peeks the next opcode and, when it is a fusible I32 binary op,
 // consumes it and returns a closure that loads the right-hand operand via
 // `load`, pops the left-hand from the stack, and pushes the result.
@@ -2854,12 +2872,12 @@ func (c *threadedCompiler) fuseF64(load func(*Interpreter) float64, advance int)
 	}
 }
 
-// fuseRefOp peeks ahead of the current ip and, when the layout matches a
+// fuseRef peeks ahead of the current ip and, when the layout matches a
 // ref-producer chain ending in a ref op, returns a single fused closure for
 // the whole sequence. `loadRef` reads the boxed ref produced by the outer
 // instruction (LOCAL_GET ref / CONST_GET ref); `advance` is the byte width of
 // that producer. Mirrors the shape of fuseI32 / fuseI64 / fuseF32 / fuseF64.
-func (c *threadedCompiler) fuseRefOp(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
+func (c *threadedCompiler) fuseRef(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
 	if c.precise || c.ip >= len(c.code) {
 		return nil
 	}
@@ -3110,22 +3128,4 @@ func (c *threadedCompiler) fuseRefOp(loadRef func(*Interpreter) types.Boxed, adv
 	}
 
 	return nil
-}
-
-func (c *threadedCompiler) Compile(code []byte, locals []types.Kind) []func(*Interpreter) {
-	c.code = code
-	c.locals = locals
-	c.ip = 0
-
-	compiled := make([]func(*Interpreter), len(code))
-	for c.ip < len(code) {
-		ip := c.ip
-		compiled[ip] = threaded[code[ip]](c)
-	}
-	for ip := 0; ip < len(code); ip++ {
-		if compiled[ip] == nil {
-			compiled[ip] = unknown
-		}
-	}
-	return compiled
 }

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -384,6 +384,23 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 				f.ip += 2
 			}
 		}
+		if idx < len(c.locals) && c.locals[idx] == types.KindRef {
+			loadRef := func(i *Interpreter) types.Boxed {
+				return i.stack[i.fr.bp+idx]
+			}
+			if fused := c.fuse1ArgRefOp(loadRef, 2); fused != nil {
+				return fused
+			}
+			if fused := c.fuseArrayGet(loadRef, 2); fused != nil {
+				return fused
+			}
+			if fused := c.fuseStructGet(loadRef, 2); fused != nil {
+				return fused
+			}
+			if fused := c.fuse2ArgRefOp(loadRef, 2); fused != nil {
+				return fused
+			}
+		}
 		return func(i *Interpreter) {
 			if i.sp == len(i.stack) {
 				panic(ErrStackOverflow)
@@ -541,6 +558,19 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 					}
 				default:
 				}
+			}
+			loadRef := func(_ *Interpreter) types.Boxed { return val }
+			if fused := c.fuse1ArgRefOp(loadRef, 3); fused != nil {
+				return fused
+			}
+			if fused := c.fuseArrayGet(loadRef, 3); fused != nil {
+				return fused
+			}
+			if fused := c.fuseStructGet(loadRef, 3); fused != nil {
+				return fused
+			}
+			if fused := c.fuse2ArgRefOp(loadRef, 3); fused != nil {
+				return fused
 			}
 			return func(i *Interpreter) {
 				if i.sp == len(i.stack) {
@@ -2158,6 +2188,31 @@ var threaded = [256]func(c *threadedCompiler) func(i *Interpreter){
 			}
 		}
 	},
+	instr.ARRAY_LEN: func(c *threadedCompiler) func(i *Interpreter) {
+		c.ip++
+		return func(i *Interpreter) {
+			if i.sp == 0 {
+				panic(ErrStackUnderflow)
+			}
+			var n int32
+			switch arr := i.unbox(i.stack[i.sp-1]).(type) {
+			case types.I32Array:
+				n = int32(len(arr))
+			case types.I64Array:
+				n = int32(len(arr))
+			case types.F32Array:
+				n = int32(len(arr))
+			case types.F64Array:
+				n = int32(len(arr))
+			case *types.Array:
+				n = int32(len(arr.Elems))
+			default:
+				panic(ErrTypeMismatch)
+			}
+			i.stack[i.sp-1] = types.BoxI32(n)
+			i.frames[i.fp-1].ip++
+		}
+	},
 	instr.ARRAY_GET: func(c *threadedCompiler) func(i *Interpreter) {
 		c.ip++
 		return func(i *Interpreter) {
@@ -2816,6 +2871,329 @@ func (c *threadedCompiler) fuseF64(load func(*Interpreter) float64, advance int)
 		lhs := i.stack[i.sp-1].F64()
 		i.stack[i.sp-1] = op(i, lhs, rhs)
 		i.fr.ip += advance + 1
+	}
+}
+
+// peekRefLoader looks at the instruction at `ip` and, if it is a LOCAL_GET of a
+// Ref-typed local or a CONST_GET of a Ref-typed constant, returns a closure
+// that loads the boxed ref onto the stack-less, the byte width of the loader,
+// and true. The returned closure does not retain — callers must not push the
+// ref onto the stack permanently.
+func (c *threadedCompiler) peekRefLoader(ip int) (func(*Interpreter) types.Boxed, int, bool) {
+	if ip >= len(c.code) {
+		return nil, 0, false
+	}
+	switch instr.Opcode(c.code[ip]) {
+	case instr.LOCAL_GET:
+		if ip+1 >= len(c.code) {
+			return nil, 0, false
+		}
+		idx := int(c.code[ip+1])
+		if idx < 0 || idx >= len(c.locals) || c.locals[idx] != types.KindRef {
+			return nil, 0, false
+		}
+		return func(i *Interpreter) types.Boxed {
+			return i.stack[i.fr.bp+idx]
+		}, 2, true
+	case instr.CONST_GET:
+		if ip+2 >= len(c.code) {
+			return nil, 0, false
+		}
+		cidx := int(*(*uint16)(unsafe.Pointer(&c.code[ip+1])))
+		if cidx < 0 || cidx >= len(c.constants) || c.constants[cidx].Kind() != types.KindRef {
+			return nil, 0, false
+		}
+		val := c.constants[cidx]
+		return func(_ *Interpreter) types.Boxed {
+			return val
+		}, 3, true
+	}
+	return nil, 0, false
+}
+
+// peekI32Loader is the I32 counterpart of peekRefLoader. It accepts LOCAL_GET
+// of an I32-typed local, CONST_GET of an I32-typed constant, and the literal
+// I32_CONST instruction.
+func (c *threadedCompiler) peekI32Loader(ip int) (func(*Interpreter) int32, int, bool) {
+	if ip >= len(c.code) {
+		return nil, 0, false
+	}
+	switch instr.Opcode(c.code[ip]) {
+	case instr.LOCAL_GET:
+		if ip+1 >= len(c.code) {
+			return nil, 0, false
+		}
+		idx := int(c.code[ip+1])
+		if idx < 0 || idx >= len(c.locals) || c.locals[idx] != types.KindI32 {
+			return nil, 0, false
+		}
+		return func(i *Interpreter) int32 {
+			return i.stack[i.fr.bp+idx].I32()
+		}, 2, true
+	case instr.CONST_GET:
+		if ip+2 >= len(c.code) {
+			return nil, 0, false
+		}
+		cidx := int(*(*uint16)(unsafe.Pointer(&c.code[ip+1])))
+		if cidx < 0 || cidx >= len(c.constants) || c.constants[cidx].Kind() != types.KindI32 {
+			return nil, 0, false
+		}
+		v := c.constants[cidx].I32()
+		return func(_ *Interpreter) int32 { return v }, 3, true
+	case instr.I32_CONST:
+		if ip+4 >= len(c.code) {
+			return nil, 0, false
+		}
+		v := *(*int32)(unsafe.Pointer(&c.code[ip+1]))
+		return func(_ *Interpreter) int32 { return v }, 5, true
+	}
+	return nil, 0, false
+}
+
+// fuse1ArgRefOp peeks the next opcode and, when it is a 1-arg ref op
+// (STRING_LEN, ARRAY_LEN, REF_IS_NULL), consumes it and returns a closure that
+// loads the ref via `loadRef`, applies the op directly against the heap value,
+// and pushes the result. `advance` is the producer's instruction width.
+func (c *threadedCompiler) fuse1ArgRefOp(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
+	if c.precise || c.ip >= len(c.code) {
+		return nil
+	}
+	var op func(*Interpreter, types.Boxed) types.Boxed
+	switch instr.Opcode(c.code[c.ip]) {
+	case instr.STRING_LEN:
+		op = func(i *Interpreter, b types.Boxed) types.Boxed {
+			s, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxI32(int32(len(s)))
+		}
+	case instr.ARRAY_LEN:
+		op = func(i *Interpreter, b types.Boxed) types.Boxed {
+			switch arr := i.heap[b.Ref()].(type) {
+			case types.I32Array:
+				return types.BoxI32(int32(len(arr)))
+			case types.I64Array:
+				return types.BoxI32(int32(len(arr)))
+			case types.F32Array:
+				return types.BoxI32(int32(len(arr)))
+			case types.F64Array:
+				return types.BoxI32(int32(len(arr)))
+			case *types.Array:
+				return types.BoxI32(int32(len(arr.Elems)))
+			default:
+				panic(ErrTypeMismatch)
+			}
+		}
+	case instr.REF_IS_NULL:
+		op = func(_ *Interpreter, b types.Boxed) types.Boxed {
+			return types.BoxBool(b.Ref() == 0)
+		}
+	default:
+		return nil
+	}
+	c.ip++
+	return func(i *Interpreter) {
+		if i.sp == len(i.stack) {
+			panic(ErrStackOverflow)
+		}
+		i.stack[i.sp] = op(i, loadRef(i))
+		i.sp++
+		i.fr.ip += advance + 1
+	}
+}
+
+// fuse2ArgRefOp peeks the next loader and the op after it. When the layout is
+// (outer producer) ; (ref loader) ; (REF_EQ|REF_NE|STRING_EQ|NE|LT|GT|LE|GE),
+// consumes both consecutive ops and returns a single fused closure.
+func (c *threadedCompiler) fuse2ArgRefOp(loadRef1 func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
+	if c.precise || c.ip >= len(c.code) {
+		return nil
+	}
+	loadRef2, w2, ok := c.peekRefLoader(c.ip)
+	if !ok {
+		return nil
+	}
+	opIp := c.ip + w2
+	if opIp >= len(c.code) {
+		return nil
+	}
+	var op func(*Interpreter, types.Boxed, types.Boxed) types.Boxed
+	switch instr.Opcode(c.code[opIp]) {
+	case instr.REF_EQ:
+		op = func(_ *Interpreter, a, b types.Boxed) types.Boxed {
+			return types.BoxBool(a == b)
+		}
+	case instr.REF_NE:
+		op = func(_ *Interpreter, a, b types.Boxed) types.Boxed {
+			return types.BoxBool(a != b)
+		}
+	case instr.STRING_EQ:
+		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+			sa, _ := i.heap[a.Ref()].(types.String)
+			sb, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxBool(sa == sb)
+		}
+	case instr.STRING_NE:
+		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+			sa, _ := i.heap[a.Ref()].(types.String)
+			sb, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxBool(sa != sb)
+		}
+	case instr.STRING_LT:
+		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+			sa, _ := i.heap[a.Ref()].(types.String)
+			sb, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxBool(sa < sb)
+		}
+	case instr.STRING_GT:
+		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+			sa, _ := i.heap[a.Ref()].(types.String)
+			sb, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxBool(sa > sb)
+		}
+	case instr.STRING_LE:
+		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+			sa, _ := i.heap[a.Ref()].(types.String)
+			sb, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxBool(sa <= sb)
+		}
+	case instr.STRING_GE:
+		op = func(i *Interpreter, a, b types.Boxed) types.Boxed {
+			sa, _ := i.heap[a.Ref()].(types.String)
+			sb, _ := i.heap[b.Ref()].(types.String)
+			return types.BoxBool(sa >= sb)
+		}
+	default:
+		return nil
+	}
+	c.ip = opIp + 1
+	return func(i *Interpreter) {
+		if i.sp == len(i.stack) {
+			panic(ErrStackOverflow)
+		}
+		a := loadRef1(i)
+		b := loadRef2(i)
+		i.stack[i.sp] = op(i, a, b)
+		i.sp++
+		i.fr.ip += advance + w2 + 1
+	}
+}
+
+// fuseArrayGet peeks the next i32 loader and ARRAY_GET. When the layout is
+// (outer producer) ; (i32 loader) ; ARRAY_GET, consumes them and returns a
+// fused closure that loads the array ref, the index, performs the bounds and
+// type-switched element access, and pushes the result.
+func (c *threadedCompiler) fuseArrayGet(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
+	if c.precise || c.ip >= len(c.code) {
+		return nil
+	}
+	loadIdx, w2, ok := c.peekI32Loader(c.ip)
+	if !ok {
+		return nil
+	}
+	opIp := c.ip + w2
+	if opIp >= len(c.code) {
+		return nil
+	}
+	if instr.Opcode(c.code[opIp]) != instr.ARRAY_GET {
+		return nil
+	}
+	c.ip = opIp + 1
+	return func(i *Interpreter) {
+		if i.sp == len(i.stack) {
+			panic(ErrStackOverflow)
+		}
+		ref := loadRef(i)
+		idx := int(loadIdx(i))
+		addr := ref.Ref()
+		var val types.Boxed
+		switch arr := i.heap[addr].(type) {
+		case types.I32Array:
+			if idx < 0 || idx >= len(arr) {
+				panic(ErrIndexOutOfRange)
+			}
+			val = types.BoxI32(int32(arr[idx]))
+		case types.I64Array:
+			if idx < 0 || idx >= len(arr) {
+				panic(ErrIndexOutOfRange)
+			}
+			val = i.boxI64(int64(arr[idx]))
+		case types.F32Array:
+			if idx < 0 || idx >= len(arr) {
+				panic(ErrIndexOutOfRange)
+			}
+			val = types.BoxF32(float32(arr[idx]))
+		case types.F64Array:
+			if idx < 0 || idx >= len(arr) {
+				panic(ErrIndexOutOfRange)
+			}
+			val = types.BoxF64(float64(arr[idx]))
+		case *types.Array:
+			if idx < 0 || idx >= len(arr.Elems) {
+				panic(ErrIndexOutOfRange)
+			}
+			elem := arr.Elems[idx]
+			if elem.Kind() == types.KindRef {
+				i.retain(elem.Ref())
+			}
+			val = elem
+		default:
+			panic(ErrTypeMismatch)
+		}
+		i.stack[i.sp] = val
+		i.sp++
+		i.fr.ip += advance + w2 + 1
+	}
+}
+
+// fuseStructGet mirrors fuseArrayGet for STRUCT_GET. The field kind is read
+// from the struct's runtime type metadata.
+func (c *threadedCompiler) fuseStructGet(loadRef func(*Interpreter) types.Boxed, advance int) func(*Interpreter) {
+	if c.precise || c.ip >= len(c.code) {
+		return nil
+	}
+	loadIdx, w2, ok := c.peekI32Loader(c.ip)
+	if !ok {
+		return nil
+	}
+	opIp := c.ip + w2
+	if opIp >= len(c.code) {
+		return nil
+	}
+	if instr.Opcode(c.code[opIp]) != instr.STRUCT_GET {
+		return nil
+	}
+	c.ip = opIp + 1
+	return func(i *Interpreter) {
+		if i.sp == len(i.stack) {
+			panic(ErrStackOverflow)
+		}
+		ref := loadRef(i)
+		idx := int(loadIdx(i))
+		addr := ref.Ref()
+		s, ok := i.heap[addr].(*types.Struct)
+		if !ok {
+			panic(ErrTypeMismatch)
+		}
+		if idx < 0 || idx >= len(s.Typ.Fields) {
+			panic(ErrSegmentationFault)
+		}
+		field := s.Typ.Fields[idx]
+		var val types.Boxed
+		switch field.Kind {
+		case types.KindI32, types.KindF32, types.KindF64:
+			val = s.Field(idx)
+		case types.KindI64:
+			val = i.boxI64(int64(s.Raw(idx)))
+		case types.KindRef:
+			val = types.Boxed(s.Raw(idx))
+			if val.Kind() == types.KindRef {
+				i.retain(val.Ref())
+			}
+		default:
+			panic(ErrTypeMismatch)
+		}
+		i.stack[i.sp] = val
+		i.sp++
+		i.fr.ip += advance + w2 + 1
 	}
 }
 


### PR DESCRIPTION
Extend LOCAL_GET (ref local) and CONST_GET (ref const) to peek forward
for a complete ref-op pattern and emit one fused closure for the whole
sequence, eliminating the box/push/pop/unbox round-trips between the
producers and the consumer.

Patterns fused:
- (LOCAL_GET | CONST_GET) ref ; (STRING_LEN | ARRAY_LEN | REF_IS_NULL)
- (LOCAL_GET | CONST_GET) ref ; (LOCAL_GET | CONST_GET) ref ;
  (STRING_EQ/NE/LT/GT/LE/GE | REF_EQ/NE)
- (LOCAL_GET | CONST_GET) ref ; (LOCAL_GET | CONST_GET | I32_CONST) i32 ;
  (ARRAY_GET | STRUCT_GET)

Also implement the previously-missing ARRAY_LEN standalone handler.

https://claude.ai/code/session_01RrSBvV6e6HJPo6sFrX24Vq