### PR TITLE
test: recent map edge cases

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1908,6 +1908,20 @@ var tests = []test{
 	{
 		program: program.New(
 			[]instr.Instruction{
+				instr.New(instr.F32_CONST, uint64(math.Float32bits(float32(math.Copysign(0, -1))))),
+				instr.New(instr.I32_CONST, 42),
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.MAP_NEW, 0),
+				instr.New(instr.F32_CONST, uint64(math.Float32bits(0))),
+				instr.New(instr.MAP_GET),
+			},
+			program.WithTypes(types.NewMapType(types.TypeF32, types.TypeI32)),
+		),
+		values: []types.Value{types.I32(42)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
 				instr.New(instr.I32_CONST, 1),
 				instr.New(instr.I32_CONST, 42),
 				instr.New(instr.I32_CONST, 1),
@@ -1918,6 +1932,22 @@ var tests = []test{
 			program.WithTypes(types.NewMapType(types.TypeI32, types.TypeI32)),
 		),
 		values: []types.Value{types.I32(1), types.I32(42)},
+	},
+	{
+		program: program.New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.I32_CONST, 41),
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.I32_CONST, 42),
+				instr.New(instr.I32_CONST, 2),
+				instr.New(instr.MAP_NEW, 0),
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.MAP_GET),
+			},
+			program.WithTypes(types.NewMapType(types.TypeI32, types.TypeI32)),
+		),
+		values: []types.Value{types.I32(42)},
 	},
 	{
 		program: program.New(

--- a/types/parse_test.go
+++ b/types/parse_test.go
@@ -24,11 +24,14 @@ func TestParse(t *testing.T) {
 		{"[]f64", NewArrayType(TypeF64), false},
 		{"map[i32]string", NewMapType(TypeI32, TypeString), false},
 		{"map[string][]i32", NewMapType(TypeString, NewArrayType(TypeI32)), false},
+		{"map[[]i32]f64", NewMapType(NewArrayType(TypeI32), TypeF64), false},
 		{"func()", &FunctionType{}, false},
 		{"func(i32) i64", &FunctionType{Params: []Type{TypeI32}, Returns: []Type{TypeI64}}, false},
 		{"func(i32, f64) i32", &FunctionType{Params: []Type{TypeI32, TypeF64}, Returns: []Type{TypeI32}}, false},
 		{"func(i32) (i32, i64)", &FunctionType{Params: []Type{TypeI32}, Returns: []Type{TypeI32, TypeI64}}, false},
 		{"struct {i32; f64}", NewStructType(NewStructField(TypeI32), NewStructField(TypeF64)), false},
+		{"map[]i32", nil, true},
+		{"map[i32]", nil, true},
 		{"bad", nil, true},
 	}
 


### PR DESCRIPTION
## Summary
- add interpreter regression coverage for recent map runtime edge cases
- add parser coverage for nested and invalid `map[...]` type syntax

## Changed paths tested
- `interp/map.go` / `interp/threaded.go`
- `types/parse.go`

## Added tests
- `MAP_GET` returns the same entry for `-0.0` and `0.0` float keys
- `MAP_NEW` keeps the last value when duplicate keys are provided
- `types.Parse` handles nested bracketed map keys and rejects missing key/elem map syntax

## Validation
- `go test ./types`
- `go test ./interp`

## Skipped targets
- map ref/string retain-release branches: behavior is clear but would require heap-lifetime assertions with higher setup cost than this narrow coverage task
- docs and opcode metadata files: already exercised indirectly by existing type/opcode tests and not a behavior gap for this change
