### PR TITLE
feat(interp): add Pool for multi-goroutine interpreter use

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,8 +12,9 @@ Follow `docs/coding-patterns.md` unless the task or repository context requires 
 
 Re-read every new or modified file against this checklist before reporting a change as done. Each item maps to a `docs/coding-patterns.md` rule that has been missed on a first pass.
 
-- **Method order (§1.3)** — every caller declared above its callees. Convenience wrappers (`Run`, `Close`, …) appear above the lower-level methods they orchestrate.
-- **Single abstraction level (§1.1)** — if a public method directly mixes locks, channels, atomics, and select-blocks, extract intent-named helpers (`tryRecv`, `waitRecv`, `discard`, …) so the entry point reads as a short narrative at one level.
+- **File layout (§2.4)** — declarations follow the fixed 10-slot order: public type → private type → public const → private const → public value → private value → public function → public method → private method → private function. Sentinel errors and interface assertions are values, placed after types — not before.
+- **Method order (§1.3)** — within a slot, every caller is declared above its callees. Convenience wrappers (`Run`, `Close`, …) appear above the lower-level methods they orchestrate.
+- **Single abstraction level (§1.1)** — if a public method directly mixes locks, channels, atomics, and select-blocks, extract intent-named helpers (`take`, `wait`, `drop`, …) so the entry point reads as a short narrative at one level. Prefer short, intent-revealing names (`take`, not `tryRecvFromIdleChannel`).
 - **Struct field layering (§2.5)** — fields grouped with blank lines as config → infrastructure → program data → runtime state → raw counters. No policy or counter field interleaved between two state fields.
 - **One test per public symbol (§6.3)** — a behavior that exercises an existing public method belongs in that method's `Test<Type>_<Method>` as a `t.Run`. Do not add a parallel top-level test for the same symbol.
 - **Tests assert behavior (§6.1)** — never mutate unexported fields (`p.live.Add(1)`, etc.) to fabricate a state unreachable from the public API. That is testing defensive dead code, not behavior. White-box reads of unexported fields are fine; white-box writes are not.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,3 +7,14 @@ Claude-specific workflows only. Read `AGENTS.md` first.
 Before changing code, read `docs/coding-patterns.md` and any task-relevant docs listed in `AGENTS.md`.
 
 Follow `docs/coding-patterns.md` unless the task or repository context requires a narrower rule.
+
+## Pre-finish Self-Review
+
+Re-read every new or modified file against this checklist before reporting a change as done. Each item maps to a `docs/coding-patterns.md` rule that has been missed on a first pass.
+
+- **Method order (§1.3)** — every caller declared above its callees. Convenience wrappers (`Run`, `Close`, …) appear above the lower-level methods they orchestrate.
+- **Single abstraction level (§1.1)** — if a public method directly mixes locks, channels, atomics, and select-blocks, extract intent-named helpers (`tryRecv`, `waitRecv`, `discard`, …) so the entry point reads as a short narrative at one level.
+- **Struct field layering (§2.5)** — fields grouped with blank lines as config → infrastructure → program data → runtime state → raw counters. No policy or counter field interleaved between two state fields.
+- **One test per public symbol (§6.3)** — a behavior that exercises an existing public method belongs in that method's `Test<Type>_<Method>` as a `t.Run`. Do not add a parallel top-level test for the same symbol.
+- **Tests assert behavior (§6.1)** — never mutate unexported fields (`p.live.Add(1)`, etc.) to fabricate a state unreachable from the public API. That is testing defensive dead code, not behavior. White-box reads of unexported fields are fine; white-box writes are not.
+- **No duplicated cleanup (§1.4)** — the same `_ = x.Close(); counter.Add(-1)` pair in multiple branches signals an extractable private helper.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ go test -race -run TestFoo ./interp/...
 | Optimizer/pass | `docs/pass-system.md` | `analysis/`, `transform/`, `optimize/`, `pass/` | `go test ./analysis ./transform ./optimize ./pass` |
 | REPL/CLI | `docs/guides/repl.md` | `cmd/repl/`, `cmd/minivm/`, `instr/parse.go` | `go test ./cmd/repl ./cmd/minivm ./instr` |
 | Style-only change | `docs/coding-patterns.md` | touched package | package tests |
+| Concurrent VM use | `docs/architecture.md` (`interp/`) | `interp/pool.go` | `go test -race ./interp` |
 
 ## Documentation Index
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ go test -race -run TestFoo ./interp/...
 4. Mirror nearby tests; follow Test Conventions (one func per exported symbol, sub-cases as `t.Run`).
 5. Update docs when behavior, invariants, commands, or pitfalls change.
 6. Run narrow tests first, then `go test ./...` or `make test` for broad coverage.
+7. Before reporting done, re-read every new/modified file against the pre-finish checklist in `.claude/CLAUDE.md` (or the equivalent in your agent's instruction file).
 
 ## Local Hooks
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,6 +103,8 @@ Two layers:
 
 `HostObject` (`host.go`): wraps a Go value that carries methods or unexported fields. Implements `types.Fielded` so `STRUCT_GET`/`STRUCT_SET` dispatch through the same indexed-field protocol used by `*types.Struct`. Field reads/writes reflect against an internal addressable copy of the receiver through the interpreter's `Marshaler`; methods are pre-bound as `*HostFunction` values allocated on the VM heap.
 
+`Pool` (`pool.go`): multi-goroutine entry point. `Interpreter` is single-goroutine; `program.Program` is the only object safe to share across goroutines. `NewPool(prog, size, opts...)` lends up to `size` Interpreters lazily; `Get`/`Put` or `Run(ctx, fn)` borrow one per goroutine. `Put` calls `Reset` between borrows; `Close` releases every idle Interpreter's JIT buffer. Outstanding interpreters are closed on their next `Put` after `Close`. Heap refs from a borrowed Interpreter are invalid after `Put` (`Reset` wipes the heap).
+
 ### `asm/`
 
 `Assembler`: low-level IR emission — allocate VRegs, emit instructions, declare ABI boundaries. No VM stack semantics.

--- a/docs/coding-patterns.md
+++ b/docs/coding-patterns.md
@@ -215,7 +215,7 @@ func (i32Type) Equals(other Type) bool { return other == TypeI32 }
 
 ### 2.3 Interface compliance assertions
 
-Declare immediately after type definition.
+`var _ Foo = (*Bar)(nil)`. Declare in slot 6 per §2.4 (private values), after the types they assert. Group several with one `var (...)` block when convenient.
 
 ```go
 var _ Traceable = (*Struct)(nil)
@@ -224,14 +224,20 @@ var _ Type      = (*StructType)(nil)
 
 ### 2.4 File layout
 
-Order declarations from policy to mechanism:
+Every `.go` file declares symbols in this fixed order:
 
-1. exported interfaces/types
-2. exported errors
-3. interface assertions
-4. exported constructors
-5. exported methods
-6. unexported helpers
+1. public type (interface, struct, alias)
+2. private type
+3. public const
+4. private const
+5. public value (`var`)
+6. private value (`var`) — includes interface compliance assertions
+7. public function
+8. public method
+9. private method
+10. private function
+
+Constructors (`NewFoo`) are public functions (slot 7). Within each slot, follow §1.3 (callers above callees) and §4.1 (group sentinel errors in a single `var (...)` block).
 
 ### 2.5 Struct field ordering
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -11,6 +11,7 @@ Read before editing `interp/threaded.go`, `interp/host.go`, `types/array.go`, `t
 - keep `release()` iterative
 - heap index `0` is always `Null`
 - never keep pointers into `heap`; keep integer refs because allocation may grow slices
+- heap and RC live on `Interpreter`; refs from a pool-borrowed Interpreter are invalid after `Pool.Put` because `Reset` wipes the heap
 
 ## Heap Structure
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,3 +25,4 @@ minivm: Go-native programmable runtime for scripting, rules, DSLs, and plugin-st
 - Add adapter example pairing minivm with external Wasm runtime for teams needing standard `.wasm`, WASI, or component-model workflows.
 - Expand ARM64 JIT coverage for calls, globals, refs, and selected heap operations only when benchmarks justify.
 - Add architecture-specific backends only when target users and benchmark coverage are clear.
+- Share JIT code cache and aggregate profiling across `interp.Pool` interpreters when concurrent embedding becomes a measured bottleneck.

--- a/interp/pool.go
+++ b/interp/pool.go
@@ -1,0 +1,144 @@
+package interp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+
+	"github.com/siyul-park/minivm/program"
+)
+
+var ErrPoolClosed = errors.New("pool closed")
+
+// Pool hands out Interpreter instances bound to a shared Program for use across
+// goroutines. Each Interpreter owns its runtime state and JIT buffer; callers
+// must borrow one per goroutine via Get/Put or Run.
+type Pool struct {
+	prog *program.Program
+	opts []func(*option)
+
+	idle chan *Interpreter
+	size int
+	live atomic.Int64
+
+	mu     sync.RWMutex
+	closed bool
+}
+
+// NewPool builds a pool that lends up to size Interpreters constructed from
+// prog with opts. size <= 0 is normalized to 1. Interpreters are created lazily
+// on Get; NewPool itself does not allocate JIT memory.
+func NewPool(prog *program.Program, size int, opts ...func(*option)) *Pool {
+	if size <= 0 {
+		size = 1
+	}
+	return &Pool{
+		prog: prog,
+		opts: opts,
+		idle: make(chan *Interpreter, size),
+		size: size,
+	}
+}
+
+// Get returns an Interpreter ready for use. It reuses an idle one if available,
+// otherwise creates a new one when below the size cap, otherwise blocks until
+// another goroutine calls Put or ctx is canceled. Returns ErrPoolClosed once
+// the pool is closed.
+func (p *Pool) Get(ctx context.Context) (*Interpreter, error) {
+	p.mu.RLock()
+	if p.closed {
+		p.mu.RUnlock()
+		return nil, ErrPoolClosed
+	}
+	p.mu.RUnlock()
+
+	select {
+	case i, ok := <-p.idle:
+		if !ok {
+			return nil, ErrPoolClosed
+		}
+		return i, nil
+	default:
+	}
+
+	for {
+		live := p.live.Load()
+		if live >= int64(p.size) {
+			break
+		}
+		if p.live.CompareAndSwap(live, live+1) {
+			return New(p.prog, p.opts...), nil
+		}
+	}
+
+	select {
+	case i, ok := <-p.idle:
+		if !ok {
+			return nil, ErrPoolClosed
+		}
+		return i, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Put returns i to the pool after resetting its runtime state. If the pool is
+// closed or already holds size idle Interpreters, i is closed instead so its
+// JIT buffer is released.
+func (p *Pool) Put(i *Interpreter) {
+	if i == nil {
+		return
+	}
+	i.Reset()
+
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.closed {
+		_ = i.Close()
+		p.live.Add(-1)
+		return
+	}
+
+	select {
+	case p.idle <- i:
+	default:
+		_ = i.Close()
+		p.live.Add(-1)
+	}
+}
+
+// Run borrows an Interpreter, invokes fn, and returns it to the pool even if fn
+// panics. It is the recommended entry point for short-lived multi-goroutine use.
+func (p *Pool) Run(ctx context.Context, fn func(*Interpreter) error) error {
+	i, err := p.Get(ctx)
+	if err != nil {
+		return err
+	}
+	defer p.Put(i)
+	return fn(i)
+}
+
+// Close releases every idle Interpreter and prevents further Get/Put. Outstanding
+// Interpreters are closed on their next Put. Close is idempotent; errors from
+// individual Interpreter closures are aggregated via errors.Join.
+func (p *Pool) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	close(p.idle)
+	p.mu.Unlock()
+
+	var errs []error
+	for i := range p.idle {
+		if err := i.Close(); err != nil {
+			errs = append(errs, err)
+		}
+		p.live.Add(-1)
+	}
+	return errors.Join(errs...)
+}

--- a/interp/pool.go
+++ b/interp/pool.go
@@ -9,8 +9,6 @@ import (
 	"github.com/siyul-park/minivm/program"
 )
 
-var ErrPoolClosed = errors.New("pool closed")
-
 // Pool hands out Interpreter instances bound to a shared Program for use across
 // goroutines. Each Interpreter owns its runtime state and JIT buffer; callers
 // must borrow one per goroutine via Get/Put or Run.
@@ -25,6 +23,8 @@ type Pool struct {
 	mu     sync.RWMutex
 	closed bool
 }
+
+var ErrPoolClosed = errors.New("pool closed")
 
 // NewPool builds a pool that lends up to size Interpreters constructed from
 // prog with opts. size <= 0 is normalized to 1. Interpreters are created lazily
@@ -57,19 +57,19 @@ func (p *Pool) Run(ctx context.Context, fn func(*Interpreter) error) error {
 // another goroutine calls Put or ctx is canceled. Returns ErrPoolClosed once
 // the pool is closed.
 func (p *Pool) Get(ctx context.Context) (*Interpreter, error) {
-	if p.isClosed() {
+	if p.dead() {
 		return nil, ErrPoolClosed
 	}
 
-	if i, err := p.tryRecv(); i != nil || err != nil {
+	if i, err := p.take(); i != nil || err != nil {
 		return i, err
 	}
 
-	if i, ok := p.tryCreate(); ok {
+	if i, ok := p.grow(); ok {
 		return i, nil
 	}
 
-	return p.waitRecv(ctx)
+	return p.wait(ctx)
 }
 
 // Put returns i to the pool after resetting its runtime state. If the pool is
@@ -85,14 +85,14 @@ func (p *Pool) Put(i *Interpreter) {
 	defer p.mu.RUnlock()
 
 	if p.closed {
-		p.discard(i)
+		p.drop(i)
 		return
 	}
 
 	select {
 	case p.idle <- i:
 	default:
-		p.discard(i)
+		p.drop(i)
 	}
 }
 
@@ -119,15 +119,15 @@ func (p *Pool) Close() error {
 	return errors.Join(errs...)
 }
 
-func (p *Pool) isClosed() bool {
+func (p *Pool) dead() bool {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	return p.closed
 }
 
-// tryRecv returns an idle Interpreter without blocking, (nil, nil) if none is
-// ready, or (nil, ErrPoolClosed) if Close raced ahead of the isClosed check.
-func (p *Pool) tryRecv() (*Interpreter, error) {
+// take returns an idle Interpreter without blocking, (nil, nil) if none is
+// ready, or (nil, ErrPoolClosed) if Close raced ahead of the dead check.
+func (p *Pool) take() (*Interpreter, error) {
 	select {
 	case i, ok := <-p.idle:
 		if !ok {
@@ -139,9 +139,9 @@ func (p *Pool) tryRecv() (*Interpreter, error) {
 	}
 }
 
-// tryCreate reserves a slot below the size cap and returns a fresh Interpreter,
-// or (nil, false) if the cap is reached.
-func (p *Pool) tryCreate() (*Interpreter, bool) {
+// grow reserves a slot below the size cap and returns a fresh Interpreter, or
+// (nil, false) if the cap is reached.
+func (p *Pool) grow() (*Interpreter, bool) {
 	for {
 		live := p.live.Load()
 		if live >= int64(p.size) {
@@ -153,7 +153,7 @@ func (p *Pool) tryCreate() (*Interpreter, bool) {
 	}
 }
 
-func (p *Pool) waitRecv(ctx context.Context) (*Interpreter, error) {
+func (p *Pool) wait(ctx context.Context) (*Interpreter, error) {
 	select {
 	case i, ok := <-p.idle:
 		if !ok {
@@ -165,7 +165,7 @@ func (p *Pool) waitRecv(ctx context.Context) (*Interpreter, error) {
 	}
 }
 
-func (p *Pool) discard(i *Interpreter) {
+func (p *Pool) drop(i *Interpreter) {
 	_ = i.Close()
 	p.live.Add(-1)
 }

--- a/interp/pool.go
+++ b/interp/pool.go
@@ -17,9 +17,9 @@ var ErrPoolClosed = errors.New("pool closed")
 type Pool struct {
 	prog *program.Program
 	opts []func(*option)
+	size int
 
 	idle chan *Interpreter
-	size int
 	live atomic.Int64
 
 	mu     sync.RWMutex
@@ -36,9 +36,20 @@ func NewPool(prog *program.Program, size int, opts ...func(*option)) *Pool {
 	return &Pool{
 		prog: prog,
 		opts: opts,
-		idle: make(chan *Interpreter, size),
 		size: size,
+		idle: make(chan *Interpreter, size),
 	}
+}
+
+// Run borrows an Interpreter, invokes fn, and returns it to the pool even if fn
+// panics. It is the recommended entry point for short-lived multi-goroutine use.
+func (p *Pool) Run(ctx context.Context, fn func(*Interpreter) error) error {
+	i, err := p.Get(ctx)
+	if err != nil {
+		return err
+	}
+	defer p.Put(i)
+	return fn(i)
 }
 
 // Get returns an Interpreter ready for use. It reuses an idle one if available,
@@ -46,41 +57,19 @@ func NewPool(prog *program.Program, size int, opts ...func(*option)) *Pool {
 // another goroutine calls Put or ctx is canceled. Returns ErrPoolClosed once
 // the pool is closed.
 func (p *Pool) Get(ctx context.Context) (*Interpreter, error) {
-	p.mu.RLock()
-	if p.closed {
-		p.mu.RUnlock()
+	if p.isClosed() {
 		return nil, ErrPoolClosed
 	}
-	p.mu.RUnlock()
 
-	select {
-	case i, ok := <-p.idle:
-		if !ok {
-			return nil, ErrPoolClosed
-		}
+	if i, err := p.tryRecv(); i != nil || err != nil {
+		return i, err
+	}
+
+	if i, ok := p.tryCreate(); ok {
 		return i, nil
-	default:
 	}
 
-	for {
-		live := p.live.Load()
-		if live >= int64(p.size) {
-			break
-		}
-		if p.live.CompareAndSwap(live, live+1) {
-			return New(p.prog, p.opts...), nil
-		}
-	}
-
-	select {
-	case i, ok := <-p.idle:
-		if !ok {
-			return nil, ErrPoolClosed
-		}
-		return i, nil
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	}
+	return p.waitRecv(ctx)
 }
 
 // Put returns i to the pool after resetting its runtime state. If the pool is
@@ -96,28 +85,15 @@ func (p *Pool) Put(i *Interpreter) {
 	defer p.mu.RUnlock()
 
 	if p.closed {
-		_ = i.Close()
-		p.live.Add(-1)
+		p.discard(i)
 		return
 	}
 
 	select {
 	case p.idle <- i:
 	default:
-		_ = i.Close()
-		p.live.Add(-1)
+		p.discard(i)
 	}
-}
-
-// Run borrows an Interpreter, invokes fn, and returns it to the pool even if fn
-// panics. It is the recommended entry point for short-lived multi-goroutine use.
-func (p *Pool) Run(ctx context.Context, fn func(*Interpreter) error) error {
-	i, err := p.Get(ctx)
-	if err != nil {
-		return err
-	}
-	defer p.Put(i)
-	return fn(i)
 }
 
 // Close releases every idle Interpreter and prevents further Get/Put. Outstanding
@@ -141,4 +117,55 @@ func (p *Pool) Close() error {
 		p.live.Add(-1)
 	}
 	return errors.Join(errs...)
+}
+
+func (p *Pool) isClosed() bool {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.closed
+}
+
+// tryRecv returns an idle Interpreter without blocking, (nil, nil) if none is
+// ready, or (nil, ErrPoolClosed) if Close raced ahead of the isClosed check.
+func (p *Pool) tryRecv() (*Interpreter, error) {
+	select {
+	case i, ok := <-p.idle:
+		if !ok {
+			return nil, ErrPoolClosed
+		}
+		return i, nil
+	default:
+		return nil, nil
+	}
+}
+
+// tryCreate reserves a slot below the size cap and returns a fresh Interpreter,
+// or (nil, false) if the cap is reached.
+func (p *Pool) tryCreate() (*Interpreter, bool) {
+	for {
+		live := p.live.Load()
+		if live >= int64(p.size) {
+			return nil, false
+		}
+		if p.live.CompareAndSwap(live, live+1) {
+			return New(p.prog, p.opts...), true
+		}
+	}
+}
+
+func (p *Pool) waitRecv(ctx context.Context) (*Interpreter, error) {
+	select {
+	case i, ok := <-p.idle:
+		if !ok {
+			return nil, ErrPoolClosed
+		}
+		return i, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+func (p *Pool) discard(i *Interpreter) {
+	_ = i.Close()
+	p.live.Add(-1)
 }

--- a/interp/pool_test.go
+++ b/interp/pool_test.go
@@ -18,11 +18,10 @@ func TestNewPool(t *testing.T) {
 	t.Run("normalizes non-positive size", func(t *testing.T) {
 		p := NewPool(program.New(nil), 0)
 		defer p.Close()
-		require.Equal(t, 1, p.size)
 
-		p2 := NewPool(program.New(nil), -5)
-		defer p2.Close()
-		require.Equal(t, 1, p2.size)
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		p.Put(i)
 	})
 
 	t.Run("forwards interpreter options", func(t *testing.T) {
@@ -43,6 +42,107 @@ func TestNewPool(t *testing.T) {
 	})
 }
 
+func TestPool_Run(t *testing.T) {
+	prog := program.New([]instr.Instruction{
+		instr.New(instr.I32_CONST, 7),
+		instr.New(instr.I32_CONST, 8),
+		instr.New(instr.I32_ADD),
+	})
+
+	t.Run("propagates result", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		var got types.Value
+		err := p.Run(context.Background(), func(i *Interpreter) error {
+			if err := i.Run(context.Background()); err != nil {
+				return err
+			}
+			v, err := i.Pop()
+			got = v
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, types.I32(15), got)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		want := errors.New("boom")
+		err := p.Run(context.Background(), func(i *Interpreter) error {
+			return want
+		})
+		require.ErrorIs(t, err, want)
+	})
+
+	t.Run("returns interpreter after panic", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		require.Panics(t, func() {
+			_ = p.Run(context.Background(), func(i *Interpreter) error {
+				panic("boom")
+			})
+		})
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		defer p.Put(i)
+		require.Equal(t, 0, i.Len())
+	})
+
+	t.Run("after close returns ErrPoolClosed", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		require.NoError(t, p.Close())
+
+		err := p.Run(context.Background(), func(i *Interpreter) error {
+			t.Fatal("fn should not run")
+			return nil
+		})
+		require.ErrorIs(t, err, ErrPoolClosed)
+	})
+
+	t.Run("concurrent goroutines see correct results", func(t *testing.T) {
+		p := NewPool(prog, 4)
+		defer p.Close()
+
+		const goroutines = 16
+		const iterations = 50
+
+		var wg sync.WaitGroup
+		var failures atomic.Int64
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for k := 0; k < iterations; k++ {
+					err := p.Run(context.Background(), func(i *Interpreter) error {
+						if err := i.Run(context.Background()); err != nil {
+							return err
+						}
+						v, err := i.Pop()
+						if err != nil {
+							return err
+						}
+						if v != types.I32(15) {
+							return errors.New("wrong result")
+						}
+						return nil
+					})
+					if err != nil {
+						failures.Add(1)
+					}
+				}
+			}()
+		}
+		wg.Wait()
+		require.Equal(t, int64(0), failures.Load())
+		require.LessOrEqual(t, p.live.Load(), int64(4))
+	})
+}
+
 func TestPool_Get(t *testing.T) {
 	t.Run("creates under cap", func(t *testing.T) {
 		p := NewPool(program.New(nil), 2)
@@ -50,14 +150,9 @@ func TestPool_Get(t *testing.T) {
 
 		i1, err := p.Get(context.Background())
 		require.NoError(t, err)
-		require.NotNil(t, i1)
-		require.Equal(t, int64(1), p.live.Load())
-
 		i2, err := p.Get(context.Background())
 		require.NoError(t, err)
-		require.NotNil(t, i2)
 		require.NotSame(t, i1, i2)
-		require.Equal(t, int64(2), p.live.Load())
 
 		p.Put(i1)
 		p.Put(i2)
@@ -156,23 +251,6 @@ func TestPool_Put(t *testing.T) {
 		require.Equal(t, 0, i2.Len())
 	})
 
-	t.Run("closes excess when idle full", func(t *testing.T) {
-		p := NewPool(program.New(nil), 1)
-		defer p.Close()
-
-		i1, err := p.Get(context.Background())
-		require.NoError(t, err)
-		p.Put(i1)
-		require.Equal(t, int64(1), p.live.Load())
-
-		// Bypass the cap to fabricate an "extra" interpreter; Put should
-		// close it because idle is already full.
-		extra := New(p.prog, p.opts...)
-		p.live.Add(1)
-		p.Put(extra)
-		require.Equal(t, int64(1), p.live.Load())
-	})
-
 	t.Run("nil is ignored", func(t *testing.T) {
 		p := NewPool(program.New(nil), 1)
 		defer p.Close()
@@ -188,69 +266,6 @@ func TestPool_Put(t *testing.T) {
 
 		require.NotPanics(t, func() { p.Put(i) })
 		require.Equal(t, int64(0), p.live.Load())
-	})
-}
-
-func TestPool_Run(t *testing.T) {
-	prog := program.New([]instr.Instruction{
-		instr.New(instr.I32_CONST, 7),
-		instr.New(instr.I32_CONST, 8),
-		instr.New(instr.I32_ADD),
-	})
-
-	t.Run("propagates result", func(t *testing.T) {
-		p := NewPool(prog, 1)
-		defer p.Close()
-
-		var got types.Value
-		err := p.Run(context.Background(), func(i *Interpreter) error {
-			if err := i.Run(context.Background()); err != nil {
-				return err
-			}
-			v, err := i.Pop()
-			got = v
-			return err
-		})
-		require.NoError(t, err)
-		require.Equal(t, types.I32(15), got)
-	})
-
-	t.Run("propagates error", func(t *testing.T) {
-		p := NewPool(prog, 1)
-		defer p.Close()
-
-		want := errors.New("boom")
-		err := p.Run(context.Background(), func(i *Interpreter) error {
-			return want
-		})
-		require.ErrorIs(t, err, want)
-	})
-
-	t.Run("returns interpreter even after panic", func(t *testing.T) {
-		p := NewPool(prog, 1)
-		defer p.Close()
-
-		require.Panics(t, func() {
-			_ = p.Run(context.Background(), func(i *Interpreter) error {
-				panic("boom")
-			})
-		})
-
-		i, err := p.Get(context.Background())
-		require.NoError(t, err)
-		defer p.Put(i)
-		require.Equal(t, 0, i.Len())
-	})
-
-	t.Run("after close returns ErrPoolClosed", func(t *testing.T) {
-		p := NewPool(prog, 1)
-		require.NoError(t, p.Close())
-
-		err := p.Run(context.Background(), func(i *Interpreter) error {
-			t.Fatal("fn should not run")
-			return nil
-		})
-		require.ErrorIs(t, err, ErrPoolClosed)
 	})
 }
 
@@ -289,47 +304,4 @@ func TestPool_Close(t *testing.T) {
 		p.Put(i)
 		require.Equal(t, int64(0), p.live.Load())
 	})
-}
-
-func TestPool_Concurrent(t *testing.T) {
-	prog := program.New([]instr.Instruction{
-		instr.New(instr.I32_CONST, 7),
-		instr.New(instr.I32_CONST, 8),
-		instr.New(instr.I32_ADD),
-	})
-	p := NewPool(prog, 4)
-	defer p.Close()
-
-	const goroutines = 16
-	const iterations = 50
-
-	var wg sync.WaitGroup
-	var failures atomic.Int64
-	for g := 0; g < goroutines; g++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for k := 0; k < iterations; k++ {
-				err := p.Run(context.Background(), func(i *Interpreter) error {
-					if err := i.Run(context.Background()); err != nil {
-						return err
-					}
-					v, err := i.Pop()
-					if err != nil {
-						return err
-					}
-					if v != types.I32(15) {
-						return errors.New("wrong result")
-					}
-					return nil
-				})
-				if err != nil {
-					failures.Add(1)
-				}
-			}
-		}()
-	}
-	wg.Wait()
-	require.Equal(t, int64(0), failures.Load())
-	require.LessOrEqual(t, p.live.Load(), int64(4))
 }

--- a/interp/pool_test.go
+++ b/interp/pool_test.go
@@ -1,0 +1,335 @@
+package interp
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/program"
+	"github.com/siyul-park/minivm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPool(t *testing.T) {
+	t.Run("normalizes non-positive size", func(t *testing.T) {
+		p := NewPool(program.New(nil), 0)
+		defer p.Close()
+		require.Equal(t, 1, p.size)
+
+		p2 := NewPool(program.New(nil), -5)
+		defer p2.Close()
+		require.Equal(t, 1, p2.size)
+	})
+
+	t.Run("forwards interpreter options", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1, WithStack(2048), WithHeap(64))
+		defer p.Close()
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		defer p.Put(i)
+		require.Equal(t, 2048, len(i.stack))
+		require.Equal(t, 64, cap(i.heap))
+	})
+
+	t.Run("does not allocate interpreters eagerly", func(t *testing.T) {
+		p := NewPool(program.New(nil), 4)
+		defer p.Close()
+		require.Equal(t, int64(0), p.live.Load())
+	})
+}
+
+func TestPool_Get(t *testing.T) {
+	t.Run("creates under cap", func(t *testing.T) {
+		p := NewPool(program.New(nil), 2)
+		defer p.Close()
+
+		i1, err := p.Get(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, i1)
+		require.Equal(t, int64(1), p.live.Load())
+
+		i2, err := p.Get(context.Background())
+		require.NoError(t, err)
+		require.NotNil(t, i2)
+		require.NotSame(t, i1, i2)
+		require.Equal(t, int64(2), p.live.Load())
+
+		p.Put(i1)
+		p.Put(i2)
+	})
+
+	t.Run("reuses idle", func(t *testing.T) {
+		p := NewPool(program.New(nil), 2)
+		defer p.Close()
+
+		i1, err := p.Get(context.Background())
+		require.NoError(t, err)
+		p.Put(i1)
+
+		i2, err := p.Get(context.Background())
+		require.NoError(t, err)
+		require.Same(t, i1, i2)
+		p.Put(i2)
+	})
+
+	t.Run("blocks at cap then unblocks on put", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+		defer p.Close()
+
+		i1, err := p.Get(context.Background())
+		require.NoError(t, err)
+
+		done := make(chan *Interpreter, 1)
+		go func() {
+			i2, err := p.Get(context.Background())
+			require.NoError(t, err)
+			done <- i2
+		}()
+
+		select {
+		case <-done:
+			t.Fatal("Get returned before Put")
+		case <-time.After(50 * time.Millisecond):
+		}
+
+		p.Put(i1)
+		select {
+		case i2 := <-done:
+			require.Same(t, i1, i2)
+			p.Put(i2)
+		case <-time.After(time.Second):
+			t.Fatal("Get did not unblock after Put")
+		}
+	})
+
+	t.Run("context canceled while blocked", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+		defer p.Close()
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		defer p.Put(i)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+		}()
+
+		_, err = p.Get(ctx)
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("after close returns ErrPoolClosed", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+		require.NoError(t, p.Close())
+
+		_, err := p.Get(context.Background())
+		require.ErrorIs(t, err, ErrPoolClosed)
+	})
+}
+
+func TestPool_Put(t *testing.T) {
+	t.Run("resets borrowed interpreter", func(t *testing.T) {
+		prog := program.New([]instr.Instruction{
+			instr.New(instr.I32_CONST, 42),
+		})
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, i.Run(context.Background()))
+		require.Greater(t, i.Len(), 0)
+
+		p.Put(i)
+
+		i2, err := p.Get(context.Background())
+		require.NoError(t, err)
+		defer p.Put(i2)
+		require.Same(t, i, i2)
+		require.Equal(t, 0, i2.Len())
+	})
+
+	t.Run("closes excess when idle full", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+		defer p.Close()
+
+		i1, err := p.Get(context.Background())
+		require.NoError(t, err)
+		p.Put(i1)
+		require.Equal(t, int64(1), p.live.Load())
+
+		// Bypass the cap to fabricate an "extra" interpreter; Put should
+		// close it because idle is already full.
+		extra := New(p.prog, p.opts...)
+		p.live.Add(1)
+		p.Put(extra)
+		require.Equal(t, int64(1), p.live.Load())
+	})
+
+	t.Run("nil is ignored", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+		defer p.Close()
+		require.NotPanics(t, func() { p.Put(nil) })
+	})
+
+	t.Run("after close closes interpreter", func(t *testing.T) {
+		p := NewPool(program.New(nil), 2)
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		require.NoError(t, p.Close())
+
+		require.NotPanics(t, func() { p.Put(i) })
+		require.Equal(t, int64(0), p.live.Load())
+	})
+}
+
+func TestPool_Run(t *testing.T) {
+	prog := program.New([]instr.Instruction{
+		instr.New(instr.I32_CONST, 7),
+		instr.New(instr.I32_CONST, 8),
+		instr.New(instr.I32_ADD),
+	})
+
+	t.Run("propagates result", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		var got types.Value
+		err := p.Run(context.Background(), func(i *Interpreter) error {
+			if err := i.Run(context.Background()); err != nil {
+				return err
+			}
+			v, err := i.Pop()
+			got = v
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, types.I32(15), got)
+	})
+
+	t.Run("propagates error", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		want := errors.New("boom")
+		err := p.Run(context.Background(), func(i *Interpreter) error {
+			return want
+		})
+		require.ErrorIs(t, err, want)
+	})
+
+	t.Run("returns interpreter even after panic", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		defer p.Close()
+
+		require.Panics(t, func() {
+			_ = p.Run(context.Background(), func(i *Interpreter) error {
+				panic("boom")
+			})
+		})
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		defer p.Put(i)
+		require.Equal(t, 0, i.Len())
+	})
+
+	t.Run("after close returns ErrPoolClosed", func(t *testing.T) {
+		p := NewPool(prog, 1)
+		require.NoError(t, p.Close())
+
+		err := p.Run(context.Background(), func(i *Interpreter) error {
+			t.Fatal("fn should not run")
+			return nil
+		})
+		require.ErrorIs(t, err, ErrPoolClosed)
+	})
+}
+
+func TestPool_Close(t *testing.T) {
+	t.Run("drains idle", func(t *testing.T) {
+		p := NewPool(program.New(nil), 3)
+
+		var borrowed []*Interpreter
+		for j := 0; j < 3; j++ {
+			i, err := p.Get(context.Background())
+			require.NoError(t, err)
+			borrowed = append(borrowed, i)
+		}
+		for _, i := range borrowed {
+			p.Put(i)
+		}
+
+		require.NoError(t, p.Close())
+		require.Equal(t, int64(0), p.live.Load())
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+		require.NoError(t, p.Close())
+		require.NoError(t, p.Close())
+	})
+
+	t.Run("outstanding interpreter closed on later put", func(t *testing.T) {
+		p := NewPool(program.New(nil), 1)
+
+		i, err := p.Get(context.Background())
+		require.NoError(t, err)
+		require.Equal(t, int64(1), p.live.Load())
+
+		require.NoError(t, p.Close())
+		p.Put(i)
+		require.Equal(t, int64(0), p.live.Load())
+	})
+}
+
+func TestPool_Concurrent(t *testing.T) {
+	prog := program.New([]instr.Instruction{
+		instr.New(instr.I32_CONST, 7),
+		instr.New(instr.I32_CONST, 8),
+		instr.New(instr.I32_ADD),
+	})
+	p := NewPool(prog, 4)
+	defer p.Close()
+
+	const goroutines = 16
+	const iterations = 50
+
+	var wg sync.WaitGroup
+	var failures atomic.Int64
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for k := 0; k < iterations; k++ {
+				err := p.Run(context.Background(), func(i *Interpreter) error {
+					if err := i.Run(context.Background()); err != nil {
+						return err
+					}
+					v, err := i.Pop()
+					if err != nil {
+						return err
+					}
+					if v != types.I32(15) {
+						return errors.New("wrong result")
+					}
+					return nil
+				})
+				if err != nil {
+					failures.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, int64(0), failures.Load())
+	require.LessOrEqual(t, p.live.Load(), int64(4))
+}


### PR DESCRIPTION
Interpreter holds per-instance mutable runtime state (frames, stack, heap,
JIT buffer) and is not safe to share across goroutines. Pool lets callers
share an immutable Program while borrowing one Interpreter per goroutine
via Get/Put or Run(ctx, fn). Backed by a bounded channel with explicit
Close() so mmap'd JIT buffers are always released; Reset is called
between borrows to clear runtime state.