### PR TITLE
[codex] add interp regression coverage for recent marshaling changes

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2204,14 +2204,34 @@ func TestInterpreter_Len(t *testing.T) {
 }
 
 func TestInterpreter_Alloc(t *testing.T) {
-	i := New(program.New(nil))
-	defer i.Close()
+	t.Run("basic", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	for _, v := range []types.Value{types.I32(7), types.BoxI32(3)} {
-		addr, err := i.Alloc(v)
+		for _, v := range []types.Value{types.I32(7), types.BoxI32(3)} {
+			addr, err := i.Alloc(v)
+			require.NoError(t, err)
+			require.Greater(t, addr, 0)
+		}
+	})
+
+	t.Run("interns strings", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		first, err := i.Alloc(types.String("same"))
 		require.NoError(t, err)
-		require.Greater(t, addr, 0)
-	}
+		second, err := i.Alloc(types.String("same"))
+		require.NoError(t, err)
+		require.Equal(t, first, second)
+		require.Equal(t, 2, i.rc[first])
+
+		require.NoError(t, i.Release(first))
+		require.Contains(t, i.interned, "same")
+
+		require.NoError(t, i.Release(second))
+		require.NotContains(t, i.interned, "same")
+	})
 }
 
 func TestInterpreter_Load(t *testing.T) {
@@ -3829,6 +3849,24 @@ func TestInterpreter_Unmarshal(t *testing.T) {
 		require.NoError(t, i.Unmarshal(types.I32(4), &out))
 		require.NotNil(t, out)
 		require.Equal(t, int32(4), *out)
+	})
+
+	t.Run("host object pointer target", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		id := hostUserID(41)
+		got, err := i.Marshal(&id)
+		require.NoError(t, err)
+
+		ho, ok := got.(*HostObject)
+		require.True(t, ok)
+		ho.SetField(0, types.BoxI64(99))
+
+		var out *hostUserID
+		require.NoError(t, i.Unmarshal(got, &out))
+		require.NotNil(t, out)
+		require.Equal(t, hostUserID(99), *out)
 	})
 
 	t.Run("value target", func(t *testing.T) {


### PR DESCRIPTION
## What changed
- add `TestInterpreter_Alloc/interns strings` to cover the recent `Interpreter.Alloc(types.String)` interning path
- add `TestInterpreter_Unmarshal/host object pointer target` to cover round-tripping pointer-hostable defined scalars after HostObject mutation

## Why
Recent marshaling changes introduced new behavior for pointer-hostable defined scalars and direct string interning in the interpreter heap. These paths were changed recently but were not protected by focused regression tests.

## Validation
- `go test ./interp -run 'TestInterpreter_(Alloc|Unmarshal)$'`
- `go test ./interp`
- `make lint`

## Changed paths tested
- `interp/interp.go`: direct string interning through `Alloc` and release cleanup
- `interp/marshal.go`: pointer-hostable scalar `HostObject` unmarshaling path
- `interp/interp_test.go`

## Skipped targets
- `types/map.go` and threaded map fast paths: recent map refactor already added broad package coverage nearby; I did not find a smaller changed branch with a clearer fail-before regression than the interp marshaling paths above.
- additional `marshal.go` helper branches: several remaining uncovered helpers are generic error or unsupported-type paths and would require more synthetic setup than warranted for this narrow coverage pass.
