### PR TITLE
[codex] test nested return frame restore

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2457,6 +2457,38 @@ func TestInterpreter_Run(t *testing.T) {
 	t.Run("default", func(t *testing.T) { runAll(t) })
 	t.Run("jit", func(t *testing.T) { runAll(t, WithTick(1), WithThreshold(1), WithCutoff(1)) })
 
+	t.Run("nested return restores caller frame for locals", func(t *testing.T) {
+		callee := types.NewFunctionBuilder(&types.FunctionType{
+			Returns: []types.Type{types.TypeI32},
+		}).Emit(
+			instr.New(instr.I32_CONST, 7),
+			instr.New(instr.RETURN),
+		).Build()
+		caller := types.NewFunctionBuilder(&types.FunctionType{
+			Returns: []types.Type{types.TypeI32},
+		}).WithLocals(types.TypeI32).Emit(
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+			instr.New(instr.LOCAL_SET, 0),
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.RETURN),
+		).Build()
+
+		i := New(program.New(
+			[]instr.Instruction{
+				instr.New(instr.CONST_GET, 1),
+				instr.New(instr.CALL),
+			},
+			program.WithConstants(callee, caller),
+		), WithThreshold(-1))
+		defer i.Close()
+
+		require.NoError(t, i.Run(context.Background()))
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(7), v)
+	})
+
 	t.Run("canceled context", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()


### PR DESCRIPTION
## What changed
Added a focused interpreter regression test for nested function returns in [`/Users/siyulpark/.codex/worktrees/d9b2/minivm/interp/interp_test.go`](/Users/siyulpark/.codex/worktrees/d9b2/minivm/interp/interp_test.go).

The new case exercises a recent `interp/threaded.go` change that replaced repeated `frames[fp-1]` lookups with the cached current-frame pointer `i.fr`. It verifies that after an inner function returns, the caller frame is restored before the caller executes `LOCAL_SET` and `LOCAL_GET`.

## Changed paths tested
- `interp/threaded.go`: `CALL`/`RETURN` frame restoration through subsequent caller-local access
- `interp/interp_test.go`: added `nested return restores caller frame for locals`

## Validation
- `go test ./interp -run 'TestInterpreter_Run/nested return restores caller frame for locals'`
- `go test ./interp -run 'TestInterpreter_Run|TestInterpreter_WithThreshold'`

## Skipped targets
- Broad opcode re-coverage in `interp/threaded.go`: skipped because the recent refactor mostly changed frame-pointer access patterns, and existing table-driven runtime coverage already exercises many opcodes.
- JIT-only coverage: skipped because this change was isolated to threaded execution and the smallest reliable regression target is the threaded nested-return path.
