### PR TITLE
test: Add byte typed-array array unmarshal coverage

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -4408,6 +4408,23 @@ func TestInterpreter_Unmarshal(t *testing.T) {
 		require.Equal(t, []int8{-1, 0x7F}, i8s)
 	})
 
+	t.Run("array", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		var bs [3]byte
+		require.NoError(t, i.Unmarshal(types.TypedArray[int8]{0x00, 0x7F, -1}, &bs))
+		require.Equal(t, [3]byte{0x00, 0x7F, 0xFF}, bs)
+
+		var i8s [2]int8
+		require.NoError(t, i.Unmarshal(types.TypedArray[int8]{-1, 0x7F}, &i8s))
+		require.Equal(t, [2]int8{-1, 0x7F}, i8s)
+
+		var mismatch [2]byte
+		err := i.Unmarshal(types.TypedArray[int8]{1, 2, 3}, &mismatch)
+		require.ErrorIs(t, err, ErrValueOverflow)
+	})
+
 	t.Run("map", func(t *testing.T) {
 		i := New(program.New(nil))
 		defer i.Close()


### PR DESCRIPTION
## Summary
- add fixed-array unmarshal coverage for the recent `TypedArray[int8]` path in `interp/marshal.go`
- verify byte and int8 array decoding from `types.TypedArray[int8]`
- verify fixed-array length mismatches return `ErrValueOverflow`

## Changed Paths Tested
- `interp/marshal.go`: `unmarshalArray` fast path for `TypedArray[int8]` into `[N]byte` and `[N]int8`

## Added Tests
- `TestInterpreter_Unmarshal/array` in `interp/interp_test.go`
  - `[3]byte` decodes `0x00, 0x7F, -1` as `0x00, 0x7F, 0xFF`
  - `[2]int8` preserves signed bytes
  - mismatched fixed-array length returns `ErrValueOverflow`

## Validation
- `go test ./interp -run TestInterpreter_Unmarshal`

## Skipped Targets
- `interp/marshal.go` slice fast path: already covered by existing `[]byte` and `[]int8` unmarshal tests in `TestInterpreter_Unmarshal/slice`
- broader typed-array interpreter ops: already covered by the `i8` opcode tests added with the feature commit in `TestInterpreter_Run`
