### PR TITLE
[codex] test archived grow mappings

### DIFF
--- a/asm/buffer_test.go
+++ b/asm/buffer_test.go
@@ -2,6 +2,7 @@ package asm
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
@@ -39,5 +40,23 @@ func TestBuffer_Write(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, b.old, 1)
 		require.Equal(t, 3, b.offset)
+	})
+
+	t.Run("writeAt patches archived region after grow", func(t *testing.T) {
+		b, err := NewBuffer(1)
+		require.NoError(t, err)
+		defer b.Free()
+
+		ptr, err := b.Write([]byte{0x01})
+		require.NoError(t, err)
+
+		_, err = b.Write(make([]byte, len(b.mem)))
+		require.NoError(t, err)
+		require.Len(t, b.old, 1)
+
+		n, err := b.writeAt(ptr, []byte{0x7F})
+		require.NoError(t, err)
+		require.Equal(t, 1, n)
+		require.Equal(t, byte(0x7F), unsafe.Slice((*byte)(ptr), 1)[0])
 	})
 }

--- a/asm/data_test.go
+++ b/asm/data_test.go
@@ -80,4 +80,28 @@ func TestData_Alloc(t *testing.T) {
 		require.Len(t, d.old, 1)
 		require.Equal(t, slotSize, d.offset)
 	})
+
+	t.Run("set and load archived slot after grow", func(t *testing.T) {
+		d, err := NewData(1)
+		require.NoError(t, err)
+		defer d.Free()
+
+		slot, err := d.Alloc()
+		require.NoError(t, err)
+
+		slotSize := int(unsafe.Sizeof(uintptr(0)))
+		for range len(d.mem)/slotSize - 1 {
+			_, err = d.Alloc()
+			require.NoError(t, err)
+		}
+
+		_, err = d.Alloc()
+		require.NoError(t, err)
+		require.Len(t, d.old, 1)
+
+		target := 99
+		want := unsafe.Pointer(&target)
+		d.Set(slot, want)
+		require.Equal(t, want, d.Load(slot))
+	})
 }


### PR DESCRIPTION
## Summary
- add an `asm.Buffer` regression test that patches a pointer from an archived executable mapping after grow
- add an `asm.Data` regression test that stores to and loads from a slot allocated before grow

## Why
The JIT redesign commit on 2026-06-04 included a late correctness fix to retain old mmap regions across `Buffer`/`Data` growth. Existing tests only covered offset resets and archived-region bookkeeping, not the behavior that originally regressed: continuing to use pointers into archived mappings after grow.

## Changed Paths Tested
- `asm/buffer.go`: `Buffer.writeAt` locating and patching archived mappings through `locate`
- `asm/data.go`: `Data.Alloc` grow path with subsequent `Set`/`Load` on a slot from the archived mapping

## Validation
- `go test ./asm`

## Skipped Targets
- `jit/register.go` RWMutex change: behavior is concurrency-safety oriented and already exercised indirectly; a direct unit test here would be low-signal without race-specific failure reproduction.
- `jit/arm64/lowerer.go` large global offset guard: already covered by existing `global_tee rejects large offset` coverage added in the follow-up test commit.
- `jit/amd64/register.go` stub de-registration: interpreter tests already gate on `jit.Active()` and import the amd64 package, so adding another narrow assertion would duplicate that behavior.
