### PR TITLE
[codex] Add coverage for fib benchmark minivm modes

### DIFF
--- a/benchmarks/fib_test.go
+++ b/benchmarks/fib_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 
 	"github.com/siyul-park/minivm/interp"
+	"github.com/siyul-park/minivm/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,6 +67,46 @@ func fibGo(n int32) int32 {
 		return n
 	}
 	return fibGo(n-1) + fibGo(n-2)
+}
+
+func TestFib35MinivmModes(t *testing.T) {
+	ctx := context.Background()
+	want := types.I32(fibGo(fibN))
+	modes := []struct {
+		name string
+		new  func() *interp.Interpreter
+	}{
+		{
+			name: "interp",
+			new: func() *interp.Interpreter {
+				return interp.New(Fib(fibN), interp.WithThreshold(-1))
+			},
+		},
+		{
+			name: "jit",
+			new: func() *interp.Interpreter {
+				return interp.New(Fib(fibN))
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		mode := mode
+		t.Run(mode.name, func(t *testing.T) {
+			i := mode.new()
+			defer i.Close()
+
+			for run := 0; run < 2; run++ {
+				require.NoError(t, i.Run(ctx))
+
+				got, err := i.Pop()
+				require.NoError(t, err)
+				require.Equal(t, want, got)
+
+				i.Reset()
+			}
+		})
+	}
 }
 
 // BenchmarkFib35 compares recursive fib(35) across six runtimes.


### PR DESCRIPTION
## Summary
- add `TestFib35MinivmModes` in `benchmarks/fib_test.go`
- verify both recently split benchmark paths, `minivm_interp` and `minivm_jit`, compute `fib(35)` correctly
- cover the shared benchmark reuse path by asserting `Reset()` allows a second successful run in each mode

## Validation
- `cd benchmarks && go test -run TestFib35MinivmModes ./...`
- `cd benchmarks && go test ./...`

## Changed paths tested
- `benchmarks/fib_test.go`

## Skipped targets
- docs-only changes in `README.md`, `README_kr.md`, `docs/architecture.md`, and `docs/benchmarks.md`: no executable paths to cover
- wider interpreter/JIT coverage outside `benchmarks/fib_test.go`: out of scope because this automation is limited to recently changed files and directly affected behavior
