### PR TITLE
[codex] test JIT ref global tee overwrite

### DIFF
--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -4941,6 +4941,42 @@ func TestInterpreter_JIT(t *testing.T) {
 		require.NotZero(t, jit.Links)
 	})
 
+	t.Run("compiles ref global tee and releases overwritten ref", func(t *testing.T) {
+		requireJIT(t)
+		p := prof.New()
+		i := New(program.New([]instr.Instruction{
+			instr.New(instr.GLOBAL_TEE, 0),
+			instr.New(instr.GLOBAL_GET, 0),
+			instr.New(instr.REF_EQ),
+		}), WithProfile(p), WithCutoff(1))
+		defer i.Close()
+		p.Add(0, 0, byte(instr.GLOBAL_TEE))
+
+		old, err := i.Alloc(types.String("old"))
+		require.NoError(t, err)
+		next, err := i.Alloc(types.String("next"))
+		require.NoError(t, err)
+		i.globals = append(i.globals, types.BoxRef(old))
+		require.NoError(t, i.Push(types.Ref(next)))
+
+		require.NoError(t, i.jit(0))
+		require.NoError(t, i.Run(context.Background()))
+		require.Zero(t, i.rc[old])
+
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(1), v)
+
+		live, err := i.Load(next)
+		require.NoError(t, err)
+		require.Equal(t, types.String("next"), live)
+
+		jit := p.Snapshot().JIT
+		require.Equal(t, uint64(1), jit.Attempts)
+		require.NotZero(t, jit.Emits)
+		require.NotZero(t, jit.Links)
+	})
+
 	t.Run("compiles ref get for scalar cell", func(t *testing.T) {
 		requireJIT(t)
 		p := prof.New()


### PR DESCRIPTION
## What changed
- add a focused JIT regression for ref `GLOBAL_TEE` overwrite behavior in `interp/interp_test.go`
- cover the changed `globalPut(..., pop=false)` path introduced by recent ARM64 JIT refcount work

## Paths tested
- `interp/jit_arm64.go`: JIT `GLOBAL_TEE` ref overwrite path
- `interp/interp.go`: overwritten ref release remains observable through runtime RC state
- `interp/interp_test.go`: new regression in `TestInterpreter_JIT`

## Added tests
- `TestInterpreter_JIT/compiles_ref_global_tee_and_releases_overwritten_ref`
  - compiles `GLOBAL_TEE` for a ref global
  - verifies the overwritten ref is released
  - verifies the new ref remains live and equal through `GLOBAL_GET` + `REF_EQ`

## Validation
- `go test ./interp -run 'TestInterpreter_JIT/compiles_ref_global_tee_and_releases_overwritten_ref|TestInterpreter_JIT/compiles_ref_global_get|TestInterpreter_Run' -count=1`
- `go test ./interp -count=1`

## Skipped targets
- `GLOBAL_SET` ref JIT overwrite: skipped because numeric globals already cover the pop=true store shape; this patch targeted the untested `GLOBAL_TEE` branch.
- closure upval ref/i64 overwrite cases: skipped due higher setup cost and lower confidence for a smallest regression pass.
