### PR TITLE
feat(program): add label-based program builder

### DIFF
--- a/analysis/blocks_test.go
+++ b/analysis/blocks_test.go
@@ -19,7 +19,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 		{
 			fn: types.NewFunctionBuilder(nil).Emit(
 				instr.New(instr.NOP),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -32,7 +32,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 		{
 			fn: types.NewFunctionBuilder(nil).Emit(
 				instr.New(instr.UNREACHABLE),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -45,7 +45,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 		{
 			fn: types.NewFunctionBuilder(nil).Emit(
 				instr.New(instr.RETURN),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -60,7 +60,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 				instr.New(instr.BR, 5),
 				instr.New(instr.I32_CONST, 1),
 				instr.New(instr.I32_CONST, 2),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -88,7 +88,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 				instr.New(instr.BR_IF, 5),
 				instr.New(instr.I32_CONST, 2),
 				instr.New(instr.I32_CONST, 3),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -117,7 +117,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 				instr.New(instr.BR_TABLE, 1, 5, 0),
 				instr.New(instr.I32_CONST, 2),
 				instr.New(instr.I32_CONST, 3),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -144,7 +144,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 				instr.New(instr.NOP),
 				instr.New(instr.I32_CONST, 1),
 				instr.New(instr.BR, uint64(uint16(-9+1<<16))),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -160,7 +160,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 				instr.New(instr.I32_CONST, 1),
 				instr.New(instr.BR_IF, uint64(uint16(-9+1<<16))),
 				instr.New(instr.I32_CONST, 2),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -181,7 +181,7 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 				instr.New(instr.I32_CONST, 0),
 				instr.New(instr.BR_TABLE, 1, uint64(uint16(-11+1<<16)), 0),
 				instr.New(instr.I32_CONST, 2),
-			).Build(),
+			).MustBuild(),
 			blocks: []*BasicBlock{
 				{
 					Start: 0,
@@ -201,14 +201,14 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 			name: "invalid br target",
 			fn: types.NewFunctionBuilder(nil).Emit(
 				instr.New(instr.BR, 10),
-			).Build(),
+			).MustBuild(),
 			err: ErrInvalidJump,
 		},
 		{
 			name: "invalid br_table target",
 			fn: types.NewFunctionBuilder(nil).Emit(
 				instr.New(instr.BR_TABLE, 1, 0, 10),
-			).Build(),
+			).MustBuild(),
 			err: ErrInvalidJump,
 		},
 	}

--- a/benchmarks/jit_issue60_test.go
+++ b/benchmarks/jit_issue60_test.go
@@ -46,7 +46,6 @@ func BenchmarkJITIssue60(b *testing.B) {
 					tt.program,
 					interp.WithTick(1),
 					interp.WithThreshold(1),
-					interp.WithCutoff(1),
 				), tt.want)
 			})
 		})

--- a/benchmarks/programs.go
+++ b/benchmarks/programs.go
@@ -13,97 +13,100 @@ import (
 // Fib returns a program that computes fibonacci(n) via recursive descent.
 // The function is self-referential: it pushes itself via CONST_GET and calls
 // recursively.  fib(35) = 9_227_465 with ~29.8 M recursive calls.
-//
-// BR_IF operands are byte offsets from the branch instruction end, matching
-// the threaded compiler's encoding (see interp/threaded.go).
 func Fib(n int32) *program.Program {
-	fibFn := types.NewFunctionBuilder(&types.FunctionType{
+	fib := types.NewFunctionBuilder(&types.FunctionType{
 		Params:  []types.Type{types.TypeI32},
 		Returns: []types.Type{types.TypeI32},
-	}).Emit(
+	})
+	base := fib.Label()
+	fn := fib.
 		// if n < 2 { return n }
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.I32_CONST, 2),
-		instr.New(instr.I32_LT_S),
-		instr.New(instr.BR_IF, 26), // jump forward 26 bytes to base-case LOCAL_GET
+		Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.I32_LT_S),
+		).BrIf(base).
 		// return fib(n-1) + fib(n-2)
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.I32_CONST, 1),
-		instr.New(instr.I32_SUB),
-		instr.New(instr.CONST_GET, 0),
-		instr.New(instr.CALL),
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.I32_CONST, 2),
-		instr.New(instr.I32_SUB),
-		instr.New(instr.CONST_GET, 0),
-		instr.New(instr.CALL),
-		instr.New(instr.I32_ADD),
-		instr.New(instr.RETURN),
-		// base case: return n
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.RETURN),
-	).Build()
-
-	return program.New(
-		[]instr.Instruction{
-			instr.New(instr.I32_CONST, uint64(n)),
+		Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 1),
+			instr.New(instr.I32_SUB),
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
-		},
-		program.WithConstants(fibFn),
-	)
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.I32_SUB),
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+			instr.New(instr.I32_ADD),
+			instr.New(instr.RETURN),
+		).
+		// base case: return n
+		Bind(base).Emit(
+		instr.New(instr.LOCAL_GET, 0),
+		instr.New(instr.RETURN),
+	).MustBuild()
+
+	b := program.NewBuilder()
+	b.Emit(instr.I32_CONST, uint64(n)).ConstGet(fn).Emit(instr.CALL)
+	return build(b)
 }
 
 // indirectFibViaLocal returns a recursive fibonacci program where each
 // recursive call flows the function ref through a local before CALL.
 func indirectFibViaLocal(n int32) *program.Program {
-	fibCode := []instr.Instruction{
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.I32_CONST, 2),
-		instr.New(instr.I32_LT_S),
-		instr.New(instr.BR_IF, 0),
-		instr.New(instr.CONST_GET, 0),
-		instr.New(instr.LOCAL_SET, 1),
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.I32_CONST, 1),
-		instr.New(instr.I32_SUB),
-		instr.New(instr.LOCAL_GET, 1),
-		instr.New(instr.CALL),
-		instr.New(instr.CONST_GET, 0),
-		instr.New(instr.LOCAL_SET, 1),
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.I32_CONST, 2),
-		instr.New(instr.I32_SUB),
-		instr.New(instr.LOCAL_GET, 1),
-		instr.New(instr.CALL),
-		instr.New(instr.I32_ADD),
-		instr.New(instr.RETURN),
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.RETURN),
-	}
-	patchBranch(fibCode, 3, 20)
-
-	fibFn := types.NewFunctionBuilder(&types.FunctionType{
+	fib := types.NewFunctionBuilder(&types.FunctionType{
 		Params:  []types.Type{types.TypeI32},
 		Returns: []types.Type{types.TypeI32},
-	}).WithLocals(types.TypeRef).Emit(fibCode...).Build()
-
-	return program.New(
-		[]instr.Instruction{
-			instr.New(instr.I32_CONST, uint64(n)),
+	}).WithLocals(types.TypeRef)
+	base := fib.Label()
+	fn := fib.
+		Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.I32_LT_S),
+		).BrIf(base).
+		Emit(
 			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.LOCAL_SET, 1),
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 1),
+			instr.New(instr.I32_SUB),
+			instr.New(instr.LOCAL_GET, 1),
 			instr.New(instr.CALL),
-		},
-		program.WithConstants(fibFn),
-	)
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.LOCAL_SET, 1),
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.I32_SUB),
+			instr.New(instr.LOCAL_GET, 1),
+			instr.New(instr.CALL),
+			instr.New(instr.I32_ADD),
+			instr.New(instr.RETURN),
+		).
+		Bind(base).Emit(
+		instr.New(instr.LOCAL_GET, 0),
+		instr.New(instr.RETURN),
+	).MustBuild()
+
+	b := program.NewBuilder()
+	b.Emit(instr.I32_CONST, uint64(n)).ConstGet(fn).Emit(instr.CALL)
+	return build(b)
 }
 
 // closureCounter returns a program that creates one closure and runs a hot
 // upvalue increment loop in the closure body.
 func closureCounter(iterations int32) *program.Program {
-	body := []instr.Instruction{
-		instr.New(instr.I32_CONST, uint64(iterations)),
-		instr.New(instr.LOCAL_SET, 0),
+	body := types.NewFunctionBuilder(&types.FunctionType{
+		Returns: []types.Type{types.TypeI32},
+	}).WithLocals(types.TypeI32).WithCaptures(types.TypeI32)
+	loop := body.Label()
+	fn := body.
+		Emit(
+			instr.New(instr.I32_CONST, uint64(iterations)),
+			instr.New(instr.LOCAL_SET, 0),
+		).
+		Bind(loop).Emit(
 		instr.New(instr.UPVAL_GET, 0),
 		instr.New(instr.I32_CONST, 1),
 		instr.New(instr.I32_ADD),
@@ -112,25 +115,15 @@ func closureCounter(iterations int32) *program.Program {
 		instr.New(instr.I32_CONST, 1),
 		instr.New(instr.I32_SUB),
 		instr.New(instr.LOCAL_TEE, 0),
-		instr.New(instr.BR_IF, 0),
-		instr.New(instr.UPVAL_GET, 0),
-		instr.New(instr.RETURN),
-	}
-	patchBranch(body, 10, 2)
+	).BrIf(loop).
+		Emit(
+			instr.New(instr.UPVAL_GET, 0),
+			instr.New(instr.RETURN),
+		).MustBuild()
 
-	fn := types.NewFunctionBuilder(&types.FunctionType{
-		Returns: []types.Type{types.TypeI32},
-	}).WithLocals(types.TypeI32).WithCaptures(types.TypeI32).Emit(body...).Build()
-
-	return program.New(
-		[]instr.Instruction{
-			instr.New(instr.I32_CONST, 0),
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CLOSURE_NEW),
-			instr.New(instr.CALL),
-		},
-		program.WithConstants(fn),
-	)
+	b := program.NewBuilder()
+	b.Emit(instr.I32_CONST, 0).ConstGet(fn).Emit(instr.CLOSURE_NEW).Emit(instr.CALL)
+	return build(b)
 }
 
 // typedArraySum returns a program that passes a rooted []i32 array into a hot
@@ -141,54 +134,53 @@ func typedArraySum(size int32) *program.Program {
 		array[j] = int32(j + 1)
 	}
 
-	sumCode := []instr.Instruction{
-		instr.New(instr.I32_CONST, 0),
-		instr.New(instr.LOCAL_SET, 1),
-		instr.New(instr.I32_CONST, 0),
-		instr.New(instr.LOCAL_SET, 2),
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.ARRAY_LEN),
-		instr.New(instr.LOCAL_SET, 3),
+	sum := types.NewFunctionBuilder(&types.FunctionType{
+		Params:  []types.Type{types.TypeRef},
+		Returns: []types.Type{types.TypeI32},
+	}).WithLocals(types.TypeI32, types.TypeI32, types.TypeI32)
+	loop := sum.Label()
+	end := sum.Label()
+	fn := sum.
+		Emit(
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.LOCAL_SET, 1),
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.LOCAL_SET, 2),
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.ARRAY_LEN),
+			instr.New(instr.LOCAL_SET, 3),
+		).
+		Bind(loop).Emit(
 		instr.New(instr.LOCAL_GET, 2),
 		instr.New(instr.LOCAL_GET, 3),
 		instr.New(instr.I32_GE_S),
-		instr.New(instr.BR_IF, 0),
-		instr.New(instr.LOCAL_GET, 1),
-		instr.New(instr.LOCAL_GET, 0),
-		instr.New(instr.LOCAL_GET, 2),
-		instr.New(instr.ARRAY_GET),
-		instr.New(instr.I32_ADD),
-		instr.New(instr.LOCAL_SET, 1),
-		instr.New(instr.LOCAL_GET, 2),
-		instr.New(instr.I32_CONST, 1),
-		instr.New(instr.I32_ADD),
-		instr.New(instr.LOCAL_SET, 2),
-		instr.New(instr.BR, 0),
+	).BrIf(end).
+		Emit(
+			instr.New(instr.LOCAL_GET, 1),
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.LOCAL_GET, 2),
+			instr.New(instr.ARRAY_GET),
+			instr.New(instr.I32_ADD),
+			instr.New(instr.LOCAL_SET, 1),
+			instr.New(instr.LOCAL_GET, 2),
+			instr.New(instr.I32_CONST, 1),
+			instr.New(instr.I32_ADD),
+			instr.New(instr.LOCAL_SET, 2),
+		).Br(loop).
+		Bind(end).Emit(
 		instr.New(instr.LOCAL_GET, 1),
 		instr.New(instr.RETURN),
-	}
-	patchBranch(sumCode, 10, 22)
-	patchBranch(sumCode, 21, 7)
+	).MustBuild()
 
-	sumFn := types.NewFunctionBuilder(&types.FunctionType{
-		Params:  []types.Type{types.TypeRef},
-		Returns: []types.Type{types.TypeI32},
-	}).WithLocals(types.TypeI32, types.TypeI32, types.TypeI32).Emit(sumCode...).Build()
-
-	return program.New(
-		[]instr.Instruction{
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.CONST_GET, 1),
-			instr.New(instr.CALL),
-		},
-		program.WithConstants(array, sumFn),
-	)
+	b := program.NewBuilder()
+	b.ConstGet(array).ConstGet(fn).Emit(instr.CALL)
+	return build(b)
 }
 
-func patchBranch(code []instr.Instruction, branch int, target int) {
-	start := len(instr.Marshal(code[:branch]))
-	end := start + len(code[branch])
-	dst := len(instr.Marshal(code[:target]))
-	offset := int16(dst - end)
-	code[branch].SetOperand(0, uint64(uint16(offset)))
+func build(b *program.Builder) *program.Program {
+	prog, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return prog
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,8 @@ type Program struct {
 
 `Code` holds top-level bytecode. `Constants` hold functions, strings, arrays, and other values. `Types` holds descriptors for `ARRAY_NEW` and `STRUCT_NEW`. `*types.Function` constants have their own `Code []byte`. `interp.New()` compiles function constant `j` into slot `j+1`; slot `0` is program code.
 
+`program.Builder` is the high-level way to author a `Program`. It wraps an `instr.Builder` (label-patching assembler: branch to a `Label`, offsets back-patched on `Build`) and interned constant/type pools (`Const`/`ConstGet`/`Type` dedup by `String()` and return a stable index), so authors never hand-compute branch byte offsets or pool indices. `types.FunctionBuilder` carries the same `Label`/`Bind`/`Br`/`BrIf`/`BrTable` methods for function bodies. Branch targets are PC-relative signed-i16 byte offsets relative to the end of the branch instruction (see `interp/threaded.go`); `instr.Builder.Assemble` is the single source of that encoding.
+
 ### `instr/`
 
 Instruction set: byte-sized `Opcode`. Each opcode has `Type` metadata in `instr/type.go`: mnemonic plus `Widths []int` for variable-width encoding/decoding.

--- a/instr/builder.go
+++ b/instr/builder.go
@@ -1,0 +1,114 @@
+package instr
+
+import (
+	"errors"
+	"fmt"
+	"math"
+)
+
+// Builder assembles a single code stream with symbolic branch targets. Emit
+// instructions and Label positions in program order, branch to labels with
+// Br/BrIf/BrTable, then Assemble to back-patch each branch into the signed
+// 16-bit byte offset the interpreter expects (relative to the end of the
+// branch instruction). Builders are mutable; discard after Assemble.
+type Builder struct {
+	instrs []Instruction
+	labels []int
+	fixups []fixup
+}
+
+// Label is an opaque handle to a branch target. Allocate with Builder.Label
+// and place with Builder.Bind.
+type Label int
+
+type fixup struct {
+	branch  int
+	operand int
+	label   Label
+}
+
+var (
+	ErrUnboundLabel = errors.New("unbound label")
+	ErrOffsetRange  = errors.New("branch offset out of range")
+)
+
+func NewBuilder() *Builder {
+	return &Builder{}
+}
+
+// Label allocates an unbound target. Place it later with Bind.
+func (b *Builder) Label() Label {
+	b.labels = append(b.labels, -1)
+	return Label(len(b.labels) - 1)
+}
+
+// Bind fixes l to the next instruction emitted.
+func (b *Builder) Bind(l Label) *Builder {
+	b.labels[l] = len(b.instrs)
+	return b
+}
+
+// Emit appends one instruction built from op and operands.
+func (b *Builder) Emit(op Opcode, operands ...uint64) *Builder {
+	return b.Append(New(op, operands...))
+}
+
+// Append appends pre-built instructions verbatim.
+func (b *Builder) Append(instrs ...Instruction) *Builder {
+	b.instrs = append(b.instrs, instrs...)
+	return b
+}
+
+// Br emits an unconditional branch to l.
+func (b *Builder) Br(l Label) *Builder {
+	return b.branch(BR, l)
+}
+
+// BrIf emits a conditional branch to l.
+func (b *Builder) BrIf(l Label) *Builder {
+	return b.branch(BR_IF, l)
+}
+
+// BrTable emits a jump table: targets are selected by the index on the stack,
+// def is taken when the index is out of range.
+func (b *Builder) BrTable(def Label, targets ...Label) *Builder {
+	operands := make([]uint64, len(targets)+2)
+	operands[0] = uint64(len(targets))
+	b.instrs = append(b.instrs, New(BR_TABLE, operands...))
+
+	branch := len(b.instrs) - 1
+	for i, target := range targets {
+		b.fixups = append(b.fixups, fixup{branch: branch, operand: i + 1, label: target})
+	}
+	b.fixups = append(b.fixups, fixup{branch: branch, operand: len(targets) + 1, label: def})
+	return b
+}
+
+// Assemble resolves every branch and returns the patched instructions. It
+// fails when a target label was never bound or a branch displacement does not
+// fit a signed 16-bit operand.
+func (b *Builder) Assemble() ([]Instruction, error) {
+	pos := make([]int, len(b.instrs)+1)
+	for i, inst := range b.instrs {
+		pos[i+1] = pos[i] + inst.Width()
+	}
+
+	for _, fx := range b.fixups {
+		target := b.labels[fx.label]
+		if target < 0 {
+			return nil, fmt.Errorf("%w: %d", ErrUnboundLabel, fx.label)
+		}
+		offset := pos[target] - (pos[fx.branch] + b.instrs[fx.branch].Width())
+		if offset < math.MinInt16 || offset > math.MaxInt16 {
+			return nil, fmt.Errorf("%w: %d", ErrOffsetRange, offset)
+		}
+		b.instrs[fx.branch].SetOperand(fx.operand, uint64(uint16(int16(offset))))
+	}
+	return b.instrs, nil
+}
+
+func (b *Builder) branch(op Opcode, l Label) *Builder {
+	b.instrs = append(b.instrs, New(op, 0))
+	b.fixups = append(b.fixups, fixup{branch: len(b.instrs) - 1, operand: 0, label: l})
+	return b
+}

--- a/instr/builder_test.go
+++ b/instr/builder_test.go
@@ -1,0 +1,101 @@
+package instr
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_Br(t *testing.T) {
+	t.Run("backward", func(t *testing.T) {
+		b := NewBuilder()
+		loop := b.Label()
+		b.Bind(loop).Emit(NOP).Emit(NOP).Br(loop)
+
+		instrs, err := b.Assemble()
+		require.NoError(t, err)
+		require.Equal(t, BR, instrs[2].Opcode())
+		require.Equal(t, -5, ParseI16(instrs[2], 1))
+	})
+
+	t.Run("forward", func(t *testing.T) {
+		b := NewBuilder()
+		end := b.Label()
+		b.Br(end).Emit(NOP).Bind(end).Emit(RETURN)
+
+		instrs, err := b.Assemble()
+		require.NoError(t, err)
+		require.Equal(t, 1, ParseI16(instrs[0], 1))
+	})
+}
+
+func TestBuilder_BrIf(t *testing.T) {
+	b := NewBuilder()
+	end := b.Label()
+	b.BrIf(end).Emit(NOP).Bind(end).Emit(RETURN)
+
+	instrs, err := b.Assemble()
+	require.NoError(t, err)
+	require.Equal(t, BR_IF, instrs[0].Opcode())
+	require.Equal(t, 1, ParseI16(instrs[0], 1))
+}
+
+func TestBuilder_BrTable(t *testing.T) {
+	b := NewBuilder()
+	zero := b.Label()
+	one := b.Label()
+	def := b.Label()
+	b.BrTable(def, zero, one).
+		Bind(zero).Emit(NOP).
+		Bind(one).Emit(NOP).
+		Bind(def).Emit(RETURN)
+
+	instrs, err := b.Assemble()
+	require.NoError(t, err)
+	require.Equal(t, BR_TABLE, instrs[0].Opcode())
+	require.Equal(t, []uint64{2, 0, 1, 2}, instrs[0].Operands())
+}
+
+func TestBuilder_Assemble(t *testing.T) {
+	t.Run("unbound label", func(t *testing.T) {
+		b := NewBuilder()
+		b.Br(b.Label())
+
+		_, err := b.Assemble()
+		require.ErrorIs(t, err, ErrUnboundLabel)
+	})
+
+	t.Run("offset out of range", func(t *testing.T) {
+		b := NewBuilder()
+		end := b.Label()
+		b.Br(end)
+		for i := 0; i < math.MaxInt16+1; i++ {
+			b.Emit(NOP)
+		}
+		b.Bind(end).Emit(RETURN)
+
+		_, err := b.Assemble()
+		require.ErrorIs(t, err, ErrOffsetRange)
+	})
+}
+
+func TestBuilder_Emit(t *testing.T) {
+	b := NewBuilder()
+	b.Emit(I32_CONST, 42)
+
+	instrs, err := b.Assemble()
+	require.NoError(t, err)
+	require.Equal(t, I32_CONST, instrs[0].Opcode())
+	require.Equal(t, uint64(42), instrs[0].Operand(0))
+}
+
+func TestBuilder_Append(t *testing.T) {
+	b := NewBuilder()
+	b.Append(New(NOP), New(RETURN))
+
+	instrs, err := b.Assemble()
+	require.NoError(t, err)
+	require.Equal(t, NOP, instrs[0].Opcode())
+	require.Equal(t, RETURN, instrs[1].Opcode())
+}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -185,7 +185,7 @@ var tests = []test{
 			program.WithConstants(
 				types.NewFunctionBuilder(nil).Emit(
 					instr.New(instr.I32_CONST, 1),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(1)},
@@ -221,7 +221,7 @@ var tests = []test{
 				}).Emit(
 					instr.New(instr.I32_CONST, 1),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(1)},
@@ -251,7 +251,7 @@ var tests = []test{
 					instr.New(instr.RETURN_CALL),
 					instr.New(instr.I32_CONST, 0),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(0)},
@@ -269,13 +269,13 @@ var tests = []test{
 				}).Emit(
 					instr.New(instr.CONST_GET, 1),
 					instr.New(instr.RETURN_CALL),
-				).Build(),
+				).MustBuild(),
 				types.NewFunctionBuilder(&types.FunctionType{
 					Returns: []types.Type{types.TypeI32},
 				}).Emit(
 					instr.New(instr.I32_CONST, 42),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(42)},
@@ -352,7 +352,7 @@ var tests = []test{
 					instr.New(instr.I32_CONST, 1),
 					instr.New(instr.LOCAL_SET, 0),
 					instr.New(instr.LOCAL_GET, 0),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(1)},
@@ -367,7 +367,7 @@ var tests = []test{
 				types.NewFunctionBuilder(nil).WithLocals(types.TypeI32).Emit(
 					instr.New(instr.I32_CONST, 1),
 					instr.New(instr.LOCAL_SET, 0),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: nil,
@@ -382,7 +382,7 @@ var tests = []test{
 				types.NewFunctionBuilder(nil).WithLocals(types.TypeI32).Emit(
 					instr.New(instr.I32_CONST, 1),
 					instr.New(instr.LOCAL_TEE, 0),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(1)},
@@ -392,9 +392,9 @@ var tests = []test{
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
 			},
-			program.WithConstants(types.NewFunctionBuilder(nil).Build()),
+			program.WithConstants(types.NewFunctionBuilder(nil).MustBuild()),
 		),
-		values: []types.Value{types.NewFunctionBuilder(nil).Build()},
+		values: []types.Value{types.NewFunctionBuilder(nil).MustBuild()},
 	},
 	// --- refs: REF_NEW, REF_GET, REF_SET, REF_NULL, REF_TEST, REF_CAST, REF_IS_NULL, REF_EQ, REF_NE ---
 	{
@@ -2880,7 +2880,7 @@ var tests = []test{
 				}).Emit(
 					instr.New(instr.I32_CONST, 42),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(42)},
@@ -2912,7 +2912,7 @@ var tests = []test{
 					instr.New(instr.UPVAL_SET, 0),
 					instr.New(instr.UPVAL_GET, 0),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(3)},
@@ -2947,14 +2947,14 @@ var tests = []test{
 					instr.New(instr.I32_ADD),
 					instr.New(instr.REF_SET),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 				types.NewFunctionBuilder(&types.FunctionType{
 					Returns: []types.Type{types.TypeI32},
 				}).WithCaptures(types.TypeRef).Emit(
 					instr.New(instr.UPVAL_GET, 0),
 					instr.New(instr.REF_GET),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(2)},
@@ -2990,7 +2990,7 @@ var tests = []test{
 					instr.New(instr.RETURN),
 					instr.New(instr.LOCAL_GET, 0),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I32(6765)},
@@ -3021,7 +3021,7 @@ var tests = []test{
 					instr.New(instr.RETURN),
 					instr.New(instr.I64_CONST, 1),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		),
 		values: []types.Value{types.I64(3628800)},
@@ -3581,7 +3581,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.BR, 0xFFE6), // -26 -> header
 			instr.New(instr.LOCAL_GET, 1),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.I32_CONST, 200),
 			instr.New(instr.CONST_GET, 0),
@@ -3609,7 +3609,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.I64_CONST, 3),
 			instr.New(instr.I64_MUL),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		const big = int64(1) << 50
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.I64_CONST, uint64(big)),
@@ -3635,7 +3635,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.F32_CONST, uint64(math.Float32bits(1.5))),
 			instr.New(instr.F32_SUB),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.F32_CONST, uint64(math.Float32bits(10.5))),
 			instr.New(instr.CONST_GET, 0),
@@ -3660,7 +3660,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.F64_CONST, math.Float64bits(2.5)),
 			instr.New(instr.F64_ADD),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.F64_CONST, math.Float64bits(39.5)),
 			instr.New(instr.CONST_GET, 0),
@@ -3700,7 +3700,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.BR, 0xFFE6), // -26 -> header
 			instr.New(instr.LOCAL_GET, 1),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.I32_CONST, 200),
 			instr.New(instr.CONST_GET, 0),
@@ -3801,12 +3801,12 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.I32_CONST, 0),
 			instr.New(instr.I32_DIV_S),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		outer := types.NewFunctionBuilder(&types.FunctionType{}).Emit(
 			instr.New(instr.CONST_GET, 1),
 			instr.New(instr.CALL),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New(
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
@@ -3890,7 +3890,7 @@ func TestInterpreter_Run(t *testing.T) {
 		fn := types.NewFunctionBuilder(&types.FunctionType{
 			Params:  []types.Type{types.TypeI64},
 			Returns: []types.Type{types.TypeI64},
-		}).Emit(code...).Build()
+		}).Emit(code...).MustBuild()
 
 		want := types.I64(int64(depth) * (depth + 1) / 2 * step)
 
@@ -3933,7 +3933,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.RETURN),
 			instr.New(instr.I32_CONST, 0),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		p := newStats()
 		i := New(program.New(
 			[]instr.Instruction{
@@ -3961,7 +3961,7 @@ func TestInterpreter_Run(t *testing.T) {
 		}).Emit(
 			instr.New(instr.GLOBAL_GET, 0),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		p := newStats()
 		i := New(program.New(
 			[]instr.Instruction{
@@ -3994,7 +3994,7 @@ func TestInterpreter_Run(t *testing.T) {
 		}).Emit(
 			instr.New(instr.I32_CONST, 7),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		caller := types.NewFunctionBuilder(&types.FunctionType{
 			Returns: []types.Type{types.TypeI32},
 		}).WithLocals(types.TypeI32).Emit(
@@ -4003,7 +4003,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.LOCAL_SET, 0),
 			instr.New(instr.LOCAL_GET, 0),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 
 		i := New(program.New(
 			[]instr.Instruction{
@@ -4023,7 +4023,7 @@ func TestInterpreter_Run(t *testing.T) {
 	t.Run("fused direct call clears stale release flag", func(t *testing.T) {
 		fn := types.NewFunctionBuilder(&types.FunctionType{}).Emit(
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
@@ -4074,7 +4074,7 @@ func TestInterpreter_Run(t *testing.T) {
 			instr.New(instr.CALL),
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
@@ -4353,7 +4353,7 @@ func TestInterpreter_withLocal(t *testing.T) {
 			instr.New(instr.I32_CONST, 2),
 			instr.New(instr.I32_ADD),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		var addr int
 		i := New(program.New([]instr.Instruction{
 			instr.New(instr.CONST_GET, 0),
@@ -4419,7 +4419,7 @@ func TestInterpreter_WithFuel(t *testing.T) {
 		recursiveFn := types.NewFunctionBuilder(nil).Emit(
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
@@ -4435,7 +4435,7 @@ func TestInterpreter_WithFuel(t *testing.T) {
 		recursiveFn := types.NewFunctionBuilder(nil).Emit(
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
-		).Build()
+		).MustBuild()
 		calls := 0
 		i := New(program.New(
 			[]instr.Instruction{
@@ -4577,7 +4577,7 @@ func TestInterpreter_WithDebugger(t *testing.T) {
 		}).Emit(
 			instr.New(instr.I32_CONST, 7),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		return program.New([]instr.Instruction{
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
@@ -4689,7 +4689,7 @@ func TestInterpreter_JIT(t *testing.T) {
 		fn := types.NewFunctionBuilder(nil).WithReturns(types.TypeI32).Emit(
 			instr.New(instr.I32_CONST, 9),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New([]instr.Instruction{
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
@@ -4717,7 +4717,7 @@ func TestInterpreter_JIT(t *testing.T) {
 		}).WithCaptures(types.TypeI32).Emit(
 			instr.New(instr.UPVAL_GET, 0),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		closure := types.NewClosure(fn.Typ, 1, []types.Boxed{types.BoxI32(11)})
 		i := New(program.New([]instr.Instruction{
 			instr.New(instr.CONST_GET, 1),
@@ -4762,7 +4762,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			instr.New(instr.RETURN),
 			instr.New(instr.I64_CONST, 1),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.I64_CONST, 20),
@@ -4807,7 +4807,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			instr.New(instr.CALL),
 			instr.New(instr.RETURN),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.I32_CONST, 0),
@@ -4855,7 +4855,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			instr.New(instr.RETURN),
 			instr.New(instr.F32_CONST, uint64(math.Float32bits(0))),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.I32_CONST, 20),
@@ -4917,7 +4917,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).Emit(body...).Build()
+			}).Emit(body...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 200),
@@ -4958,7 +4958,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32, types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).WithLocals(types.TypeI32).Emit(body...).Build()
+			}).WithLocals(types.TypeI32).Emit(body...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 200),
@@ -4997,7 +4997,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).Emit(body...).Build()
+			}).Emit(body...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 20000),
@@ -5049,11 +5049,11 @@ func TestInterpreter_JIT(t *testing.T) {
 			isEven := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).Emit(even...).Build()
+			}).Emit(even...).MustBuild()
 			isOdd := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).Emit(odd...).Build()
+			}).Emit(odd...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 200),
@@ -5123,7 +5123,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).WithLocals(types.TypeI32, types.TypeI32).Emit(body...).Build()
+			}).WithLocals(types.TypeI32, types.TypeI32).Emit(body...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 1000),
@@ -5164,7 +5164,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).WithLocals(types.TypeI32, types.TypeI32).Emit(body...).Build()
+			}).WithLocals(types.TypeI32, types.TypeI32).Emit(body...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 1000),
@@ -5200,7 +5200,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{types.TypeI32},
-			}).WithLocals(types.TypeI32, types.TypeI32).Emit(body...).Build()
+			}).WithLocals(types.TypeI32, types.TypeI32).Emit(body...).MustBuild()
 			i := New(program.New(
 				[]instr.Instruction{
 					instr.New(instr.I32_CONST, 2000000000),
@@ -5235,14 +5235,14 @@ func TestInterpreter_JIT(t *testing.T) {
 				instr.New(instr.I32_CONST, 1),
 				instr.New(instr.I32_ADD),
 				instr.New(instr.RETURN),
-			).Build()
+			).MustBuild()
 			caller := types.NewFunctionBuilder(&types.FunctionType{
 				Returns: []types.Type{types.TypeI32},
 			}).Emit(
 				instr.New(instr.CONST_GET, 1),
 				instr.New(instr.CALL),
 				instr.New(instr.RETURN),
-			).Build()
+			).MustBuild()
 			closure := types.NewClosure(body.Typ, 1, []types.Boxed{types.BoxI32(41)})
 			var addr int
 			i := New(program.New(
@@ -5288,7 +5288,7 @@ func TestInterpreter_JIT(t *testing.T) {
 				instr.New(instr.I32_CONST, 1),
 				instr.New(instr.I32_ADD),
 				instr.New(instr.RETURN),
-			).Build()
+			).MustBuild()
 			caller := types.NewFunctionBuilder(&types.FunctionType{
 				Returns: []types.Type{types.TypeI32},
 			}).WithLocals(types.TypeRef).Emit(
@@ -5298,7 +5298,7 @@ func TestInterpreter_JIT(t *testing.T) {
 				instr.New(instr.LOCAL_GET, 0),
 				instr.New(instr.CALL),
 				instr.New(instr.RETURN),
-			).Build()
+			).MustBuild()
 			var addr int
 			i := New(program.New(
 				[]instr.Instruction{
@@ -5353,7 +5353,7 @@ func TestInterpreter_JIT(t *testing.T) {
 				instr.New(instr.STRUCT_GET),
 				instr.New(instr.I32_ADD),
 				instr.New(instr.RETURN),
-			).Build()
+			).MustBuild()
 			var addr int
 			i := New(program.New(
 				[]instr.Instruction{
@@ -5413,7 +5413,7 @@ func TestInterpreter_JIT(t *testing.T) {
 				instr.New(instr.BR, 0),
 				instr.New(instr.NOP),
 				instr.New(instr.RETURN),
-			).Build()
+			).MustBuild()
 			var addr int
 			i := New(program.New(
 				[]instr.Instruction{
@@ -5457,13 +5457,13 @@ func TestInterpreter_JIT(t *testing.T) {
 			instr.New(instr.I32_CONST, 2),
 			instr.New(instr.I32_MUL),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		caller := types.NewFunctionBuilder(nil).WithParams(types.TypeI32).WithReturns(types.TypeI32).Emit(
 			instr.New(instr.LOCAL_GET, 0),
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		p := newStats()
 		i := New(program.New(
 			[]instr.Instruction{
@@ -5488,7 +5488,7 @@ func TestInterpreter_JIT(t *testing.T) {
 		fn := types.NewFunctionBuilder(&types.FunctionType{}).Emit(
 			instr.New(instr.NOP),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New(nil, program.WithConstants(fn)))
 		defer i.Close()
 
@@ -5518,7 +5518,7 @@ func TestInterpreter_JIT(t *testing.T) {
 	t.Run("restore frame metadata keeps closure upvals", func(t *testing.T) {
 		fn := types.NewFunctionBuilder(&types.FunctionType{}).WithCaptures(types.TypeI32).Emit(
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		i := New(program.New(nil, program.WithConstants(fn)))
 		defer i.Close()
 
@@ -5569,7 +5569,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			instr.New(instr.CALL),
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
-		).Build()
+		).MustBuild()
 		i := New(program.New(
 			[]instr.Instruction{
 				instr.New(instr.CONST_GET, 0),
@@ -5651,7 +5651,7 @@ func TestInterpreter_JIT(t *testing.T) {
 			fn := types.NewFunctionBuilder(&types.FunctionType{
 				Params:  []types.Type{types.TypeI32},
 				Returns: []types.Type{accType},
-			}).WithLocals(accType).Emit(loop...).Build()
+			}).WithLocals(accType).Emit(loop...).MustBuild()
 			return program.New([]instr.Instruction{
 				instr.New(instr.I32_CONST, 200),
 				instr.New(instr.CONST_GET, 0),

--- a/interp/pool_test.go
+++ b/interp/pool_test.go
@@ -296,7 +296,7 @@ func TestPool_Profile(t *testing.T) {
 			instr.New(instr.NOP),
 			instr.New(instr.NOP),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),
@@ -345,7 +345,7 @@ func TestPool_Profile(t *testing.T) {
 			instr.New(instr.NOP),
 			instr.New(instr.NOP),
 			instr.New(instr.RETURN),
-		).Build()
+		).MustBuild()
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.CONST_GET, 0),
 			instr.New(instr.CALL),

--- a/optimize/optimizer_test.go
+++ b/optimize/optimizer_test.go
@@ -71,7 +71,7 @@ func TestOptimizer_Optimize(t *testing.T) {
 					instr.New(instr.RETURN),
 					instr.New(instr.LOCAL_GET, 0),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		)
 		_, err := o.Optimize(prog)
@@ -109,7 +109,7 @@ func TestOptimizer_Optimize(t *testing.T) {
 					instr.New(instr.RETURN),
 					instr.New(instr.LOCAL_GET, 0),
 					instr.New(instr.RETURN),
-				).Build(),
+				).MustBuild(),
 			),
 		)
 		_, err := o.Optimize(prog)

--- a/program/builder.go
+++ b/program/builder.go
@@ -1,0 +1,112 @@
+package program
+
+import (
+	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/types"
+)
+
+// Builder assembles a whole program: a main code stream with symbolic branch
+// targets plus interned constant and type pools. Emit and branch like
+// instr.Builder, reference constants and types by value (ConstGet/Type), then
+// Build to resolve branches and collect the pools. Builders are mutable;
+// discard after Build.
+type Builder struct {
+	code      *instr.Builder
+	constants []types.Value
+	typs      []types.Type
+
+	constIndex map[string]int
+	typeIndex  map[string]int
+}
+
+func NewBuilder() *Builder {
+	return &Builder{
+		code:       instr.NewBuilder(),
+		constIndex: map[string]int{},
+		typeIndex:  map[string]int{},
+	}
+}
+
+// Emit appends one instruction built from op and operands.
+func (b *Builder) Emit(op instr.Opcode, operands ...uint64) *Builder {
+	b.code.Emit(op, operands...)
+	return b
+}
+
+// Label allocates an unbound branch target.
+func (b *Builder) Label() instr.Label {
+	return b.code.Label()
+}
+
+// Bind fixes l to the next instruction emitted.
+func (b *Builder) Bind(l instr.Label) *Builder {
+	b.code.Bind(l)
+	return b
+}
+
+// Br emits an unconditional branch to l.
+func (b *Builder) Br(l instr.Label) *Builder {
+	b.code.Br(l)
+	return b
+}
+
+// BrIf emits a conditional branch to l.
+func (b *Builder) BrIf(l instr.Label) *Builder {
+	b.code.BrIf(l)
+	return b
+}
+
+// BrTable emits a jump table to targets with def as the out-of-range case.
+func (b *Builder) BrTable(def instr.Label, targets ...instr.Label) *Builder {
+	b.code.BrTable(def, targets...)
+	return b
+}
+
+// ConstGet interns v and emits CONST_GET for its index.
+func (b *Builder) ConstGet(v types.Value) *Builder {
+	return b.Emit(instr.CONST_GET, uint64(b.Const(v)))
+}
+
+// Const interns v into the constant pool and returns its index, reusing an
+// existing slot when an equal value is already present.
+func (b *Builder) Const(v types.Value) int {
+	key := v.String()
+	if idx, ok := b.constIndex[key]; ok {
+		return idx
+	}
+	idx := len(b.constants)
+	b.constants = append(b.constants, v)
+	b.constIndex[key] = idx
+	return idx
+}
+
+// Type interns t into the type pool and returns its index, reusing an existing
+// slot when an equal type is already present.
+func (b *Builder) Type(t types.Type) int {
+	key := t.String()
+	if idx, ok := b.typeIndex[key]; ok {
+		return idx
+	}
+	idx := len(b.typs)
+	b.typs = append(b.typs, t)
+	b.typeIndex[key] = idx
+	return idx
+}
+
+// Build resolves every branch and returns the assembled program with its
+// constant and type pools.
+func (b *Builder) Build() (*Program, error) {
+	instrs, err := b.code.Assemble()
+	if err != nil {
+		return nil, err
+	}
+
+	var opts []func(*Program)
+	if len(b.constants) > 0 {
+		opts = append(opts, WithConstants(b.constants...))
+	}
+	if len(b.typs) > 0 {
+		opts = append(opts, WithTypes(b.typs...))
+	}
+	return New(instrs, opts...), nil
+}

--- a/program/builder_test.go
+++ b/program/builder_test.go
@@ -1,0 +1,73 @@
+package program
+
+import (
+	"testing"
+
+	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuilder_Const(t *testing.T) {
+	b := NewBuilder()
+
+	require.Equal(t, 0, b.Const(types.String("a")))
+	require.Equal(t, 1, b.Const(types.String("b")))
+	require.Equal(t, 0, b.Const(types.String("a")))
+}
+
+func TestBuilder_Type(t *testing.T) {
+	b := NewBuilder()
+
+	require.Equal(t, 0, b.Type(types.TypeI32))
+	require.Equal(t, 1, b.Type(types.NewArrayType(types.TypeI32)))
+	require.Equal(t, 0, b.Type(types.TypeI32))
+}
+
+func TestBuilder_ConstGet(t *testing.T) {
+	b := NewBuilder()
+	b.ConstGet(types.String("x")).ConstGet(types.String("x"))
+
+	prog, err := b.Build()
+	require.NoError(t, err)
+	require.Equal(t, []types.Value{types.String("x")}, prog.Constants)
+
+	instrs := instr.Unmarshal(prog.Code)
+	require.Equal(t, instr.CONST_GET, instrs[0].Opcode())
+	require.Equal(t, uint64(0), instrs[0].Operand(0))
+	require.Equal(t, uint64(0), instrs[1].Operand(0))
+}
+
+func TestBuilder_Build(t *testing.T) {
+	t.Run("resolves branch to label", func(t *testing.T) {
+		b := NewBuilder()
+		skip := b.Label()
+		b.Emit(instr.I32_CONST, 1).
+			BrIf(skip).
+			ConstGet(types.String("x")).
+			Bind(skip).
+			Emit(instr.RETURN)
+
+		got, err := b.Build()
+		require.NoError(t, err)
+
+		want := New(
+			[]instr.Instruction{
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.BR_IF, 3),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.RETURN),
+			},
+			WithConstants(types.String("x")),
+		)
+		require.Equal(t, want.String(), got.String())
+	})
+
+	t.Run("unbound label", func(t *testing.T) {
+		b := NewBuilder()
+		b.Br(b.Label())
+
+		_, err := b.Build()
+		require.ErrorIs(t, err, instr.ErrUnboundLabel)
+	})
+}

--- a/program/parse_test.go
+++ b/program/parse_test.go
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 				WithConstants(
 					types.NewFunctionBuilder(&types.FunctionType{Returns: []types.Type{types.TypeI32}}).
 						Emit(instr.New(instr.I32_CONST, 42), instr.New(instr.RETURN)).
-						Build(),
+						MustBuild(),
 				),
 			),
 		},
@@ -43,7 +43,7 @@ func TestParse(t *testing.T) {
 					}).
 						WithLocals(types.TypeI32).
 						Emit(instr.New(instr.I32_CONST, 7), instr.New(instr.RETURN)).
-						Build(),
+						MustBuild(),
 				),
 			),
 		},

--- a/types/function.go
+++ b/types/function.go
@@ -8,10 +8,11 @@ import (
 )
 
 type FunctionBuilder struct {
+	code *instr.Builder
+
 	typ      *FunctionType
 	locals   []Type
 	captures []Type
-	instrs   []instr.Instruction
 }
 
 type Function struct {
@@ -33,7 +34,7 @@ func NewFunctionBuilder(typ *FunctionType) *FunctionBuilder {
 	if typ == nil {
 		typ = &FunctionType{}
 	}
-	return &FunctionBuilder{typ: typ}
+	return &FunctionBuilder{code: instr.NewBuilder(), typ: typ}
 }
 
 func (b *FunctionBuilder) WithParams(ps ...Type) *FunctionBuilder {
@@ -57,17 +58,62 @@ func (b *FunctionBuilder) WithCaptures(cs ...Type) *FunctionBuilder {
 }
 
 func (b *FunctionBuilder) Emit(instrs ...instr.Instruction) *FunctionBuilder {
-	b.instrs = append(b.instrs, instrs...)
+	b.code.Append(instrs...)
 	return b
 }
 
-func (b *FunctionBuilder) Build() *Function {
+// Label allocates an unbound branch target for the function body.
+func (b *FunctionBuilder) Label() instr.Label {
+	return b.code.Label()
+}
+
+// Bind fixes l to the next instruction emitted.
+func (b *FunctionBuilder) Bind(l instr.Label) *FunctionBuilder {
+	b.code.Bind(l)
+	return b
+}
+
+// Br emits an unconditional branch to l.
+func (b *FunctionBuilder) Br(l instr.Label) *FunctionBuilder {
+	b.code.Br(l)
+	return b
+}
+
+// BrIf emits a conditional branch to l.
+func (b *FunctionBuilder) BrIf(l instr.Label) *FunctionBuilder {
+	b.code.BrIf(l)
+	return b
+}
+
+// BrTable emits a jump table to targets with def as the out-of-range case.
+func (b *FunctionBuilder) BrTable(def instr.Label, targets ...instr.Label) *FunctionBuilder {
+	b.code.BrTable(def, targets...)
+	return b
+}
+
+// MustBuild is like Build but panics on failure. Use it only with statically
+// known-good bodies, such as in tests and fixtures.
+func (b *FunctionBuilder) MustBuild() *Function {
+	fn, err := b.Build()
+	if err != nil {
+		panic(err)
+	}
+	return fn
+}
+
+// Build resolves the body's branches and returns the function. It fails when a
+// branch references an unbound label or overflows the offset operand.
+func (b *FunctionBuilder) Build() (*Function, error) {
+	instrs, err := b.code.Assemble()
+	if err != nil {
+		return nil, err
+	}
 	return &Function{
 		Typ:      b.typ,
 		Locals:   b.locals,
 		Captures: b.captures,
-		Code:     instr.Marshal(b.instrs),
-	}
+		Code:     instr.Marshal(instrs),
+	}, nil
 }
 
 func NewFunction(typ *FunctionType, locals []Type, instrs []instr.Instruction) *Function {

--- a/types/function_test.go
+++ b/types/function_test.go
@@ -28,7 +28,7 @@ func TestFunction_String(t *testing.T) {
 			WithCaptures(TypeI32, TypeRef).
 			WithLocals(TypeI64).
 			Emit(instr.New(instr.I32_CONST, 1), instr.New(instr.RETURN)).
-			Build()
+			MustBuild()
 		require.Contains(t, fn.String(), "capture i32\ncapture ref\n")
 	})
 }
@@ -52,17 +52,17 @@ func TestFunction_LocalKinds(t *testing.T) {
 }
 
 func TestFunctionBuilder_WithParams(t *testing.T) {
-	fn := NewFunctionBuilder(nil).WithParams(TypeI32, TypeRef).Build()
+	fn := NewFunctionBuilder(nil).WithParams(TypeI32, TypeRef).MustBuild()
 	require.Equal(t, []Type{TypeI32, TypeRef}, fn.Typ.Params)
 }
 
 func TestFunctionBuilder_WithReturns(t *testing.T) {
-	fn := NewFunctionBuilder(nil).WithReturns(TypeI32, TypeRef).Build()
+	fn := NewFunctionBuilder(nil).WithReturns(TypeI32, TypeRef).MustBuild()
 	require.Equal(t, []Type{TypeI32, TypeRef}, fn.Typ.Returns)
 }
 
 func TestFunctionBuilder_WithCaptures(t *testing.T) {
-	fn := NewFunctionBuilder(nil).WithCaptures(TypeI32, TypeF64).Build()
+	fn := NewFunctionBuilder(nil).WithCaptures(TypeI32, TypeF64).MustBuild()
 	require.Equal(t, []Type{TypeI32, TypeF64}, fn.Captures)
 }
 

--- a/types/parse_test.go
+++ b/types/parse_test.go
@@ -59,7 +59,7 @@ func TestParseFunction(t *testing.T) {
 			lines: strings.Split(
 				NewFunctionBuilder(&FunctionType{Returns: []Type{TypeI32}}).
 					Emit(instr.New(instr.I32_CONST, 1), instr.New(instr.RETURN)).
-					Build().String(),
+					MustBuild().String(),
 				"\n",
 			),
 		},
@@ -69,7 +69,7 @@ func TestParseFunction(t *testing.T) {
 				NewFunctionBuilder(&FunctionType{Params: []Type{TypeI32}, Returns: []Type{TypeI32}}).
 					WithLocals(TypeI32, TypeI64).
 					Emit(instr.New(instr.I32_CONST, 42), instr.New(instr.RETURN)).
-					Build().String(),
+					MustBuild().String(),
 				"\n",
 			),
 		},
@@ -80,7 +80,7 @@ func TestParseFunction(t *testing.T) {
 					WithCaptures(TypeI32, TypeRef).
 					WithLocals(TypeI64).
 					Emit(instr.New(instr.I32_CONST, 42), instr.New(instr.RETURN)).
-					Build().String(),
+					MustBuild().String(),
 				"\n",
 			),
 		},


### PR DESCRIPTION
### **Changes Made**

Hand-writing minivm bytecode meant computing PC-relative branch byte offsets and tracking constant/type pool indices by hand — see the duplicated `patchBranch` helper and the hardcoded `BR_IF, 26` in the benchmarks. This adds a label-patching assembler and an ergonomic facade, modeled on LLVM's `IRBuilder` and classic two-pass assemblers.

- **`instr.Builder`** (new) — emit instructions and symbolic `Label`s, branch with `Br`/`BrIf`/`BrTable`, then `Assemble` to back-patch each branch into the signed-16-bit byte offset the interpreter expects (relative to the end of the branch instruction). One rule covers every branch incl. `BR_TABLE`: `offset = bytePos[target] − (bytePos[branch] + width)`. Sentinels `ErrUnboundLabel`, `ErrOffsetRange`.
- **`program.Builder`** (new) — wraps `instr.Builder` with interned constant/type pools: `Const`/`ConstGet`/`Type` dedup by `String()` and return a stable index, so authors never track pool indices. `Build() (*Program, error)`.
- **`types.FunctionBuilder`** — gains `Label`/`Bind`/`Br`/`BrIf`/`BrTable` for function bodies (routes through an internal `instr.Builder`). `Build` now returns an `error`; `MustBuild` panics for statically-known fixtures (like `regexp.MustCompile`). `Emit` unchanged.
- **`benchmarks/programs.go`** — migrated to the builders; `patchBranch` and the hardcoded offsets deleted. Also drops a stale `interp.WithCutoff(1)` (removed option) that broke the bench test binary.
- **`docs/architecture.md`** — documents the builder in the `program/` section.

Before → after:
```go
instr.New(instr.BR_IF, 26)        // hardcoded byte offset
patchBranch(sumCode, 10, 22)      // manual index→byte arithmetic
// →
base := fib.Label(); ...; .BrIf(base)   // symbolic, resolved on Build
```

### **Related Issues**

<!-- none -->

### **Additional Information**

**Test plan**
- [x] `go test -race ./...` green across the repo.
- [x] `go vet ./...` clean (main + benchmarks modules).
- [x] New unit tests: forward/backward branch resolution, `BR_TABLE`, unbound-label + offset-overflow errors, constant/type dedup, golden `Program.String()` match vs a hand-patched program.
- [x] e2e: `BenchmarkJITIssue60` (indirect-fib, closure-counter, typed-array-sum) passes through interp **and** JIT — results asserted, so migrated programs are functionally identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)