### PR TITLE
feat: reduce warm JIT safepoint checks

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,14 +4,15 @@ Claude-specific workflows only. Read `AGENTS.md` first.
 
 ## Code Changes
 
-Before changing code, read `docs/coding-patterns.md` and any task-relevant docs listed in `AGENTS.md`.
+Before changing code or tests, read `docs/coding-patterns.md` and any task-relevant docs listed in `AGENTS.md`. Treat that read as mandatory for each editing task, not optional background context.
 
-Follow `docs/coding-patterns.md` unless the task or repository context requires a narrower rule.
+Follow `docs/coding-patterns.md` unless the task or repository context requires a narrower rule. Before reporting done, re-read touched files against the checklist below and the relevant `docs/coding-patterns.md` sections.
 
 ## Coding Style Summary
 
 `docs/coding-patterns.md` is the authority; this is the short form.
 
+- **Always consult style docs before editing** — read `docs/coding-patterns.md` before any code/test modification, then apply the task-relevant sections during self-review.
 - **Layout** — declarations follow the fixed 11-slot order (§2.4); callers above callees, `New` above `With*` (§1.3).
 - **Methods over functions** — a private function used by one type becomes a method on it, even with an unused receiver (§1.5); but a single-use ≤~15-line helper stays inline (§1.4).
 - **One abstraction level** — entry points read as a narrative; push mechanics into intent-named helpers (§1.1).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ go test -race -run 'TestInterpreter_WithDebugger|TestDebugger_Breakpoints' ./int
 1. `git status --short`; don't overwrite unrelated changes.
 2. **For code exploration, prefer `codegraph` MCP tools over grep/read** (see Code Exploration below).
 3. **Read task-relevant docs from Documentation Index before writing code or tests.**
-4. **Before modifying code, read `docs/coding-patterns.md` and follow relevant sections.**
+4. **Before modifying code or tests, read `docs/coding-patterns.md` and apply the task-relevant sections. No code change is complete until the touched files pass that checklist.**
 5. Mirror nearby tests; follow Test Conventions (one func per exported symbol, sub-cases as `t.Run`).
 6. Update docs when behavior, invariants, commands, or pitfalls change.
 7. On a fresh environment or CI-like run, start with `make init`; CI does this before lint/coverage.
@@ -173,7 +173,7 @@ Incorrect ordering crashes on Apple Silicon.
 
 ## Coding Expectations
 
-- Apply `docs/coding-patterns.md` for every code change.
+- Apply `docs/coding-patterns.md` for every code or test change; re-read it before editing when context has shifted.
 - Error design: explicit errors with context, preserve sentinels for `errors.Is`, panic only in interpreter-threaded paths recovered by `Run`.
 - Test design: describe behavior, cover error paths + boundaries, organize under exported symbol.
 - Match existing package structure and naming.
@@ -182,6 +182,19 @@ Incorrect ordering crashes on Apple Silicon.
 - Keep opcode handlers explicit and predictable.
 - Preserve interpreter/JIT behavioral parity.
 - Avoid hidden control flow.
+
+### Coding Convention Core
+
+`docs/coding-patterns.md` is the style authority. In practice:
+
+- Keep entry points top-down: orchestration first, mechanics below, callers above callees.
+- Prefer clear inline code over tiny single-use helpers; extract only real repeated decisions or named domain steps.
+- Private package functions used by one type become methods on that type; constructors remain package functions.
+- Use role-based private names; do not repeat package/subsystem prefixes already supplied by file, package, or receiver.
+- Preserve declaration order: types, consts, vars, constructors, public funcs/methods, private methods, private funcs.
+- Keep struct fields layered: policy, infrastructure, program data, runtime state, counters, read-only config, mutexes.
+- Tests target public behavior, use one test function per exported symbol, inline setup/run/assertions, and avoid test helpers.
+- Record non-viable refactor steps in the final summary instead of silently dropping them.
 
 ### Frequent Style Traps
 

--- a/benchmarks/jit_issue101_test.go
+++ b/benchmarks/jit_issue101_test.go
@@ -1,0 +1,18 @@
+package bench
+
+import (
+	"testing"
+
+	"github.com/siyul-park/minivm/interp"
+)
+
+// BenchmarkJITIssue101 tracks a LightGBM-style batch path: many tiny tree-score
+// functions called from one top-level accumulator over a stable feature row.
+func BenchmarkJITIssue101(b *testing.B) {
+	prog, want := batchTreeEvaluation(30)
+
+	b.Run("interp", func(b *testing.B) {
+		vm := interp.New(prog, interp.WithThreshold(-1))
+		runMiniVMProgram(b, vm, want)
+	})
+}

--- a/benchmarks/programs.go
+++ b/benchmarks/programs.go
@@ -177,6 +177,46 @@ func typedArraySum(size int32) *program.Program {
 	return build(b)
 }
 
+// batchTreeEvaluation returns a batch-prediction-shaped program: a top-level
+// accumulator calls many tiny tree-score functions over one stable feature row.
+func batchTreeEvaluation(trees int) (*program.Program, types.Value) {
+	features := []int32{15, 35, 75, 125, 175, 225, 275, 325}
+	fns := make([]types.Value, 0, trees)
+	var want int32
+
+	for tree := range trees {
+		feature := tree % len(features)
+		weight := int32(tree%7 + 1)
+		bias := -int32(tree%5 + 1)
+		want += features[feature]*weight + bias
+
+		fn := types.NewFunctionBuilder(&types.FunctionType{
+			Params:  []types.Type{types.TypeI32},
+			Returns: []types.Type{types.TypeI32},
+		})
+		fn.Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, uint64(uint32(weight))),
+			instr.New(instr.I32_MUL),
+			instr.New(instr.I32_CONST, uint64(uint32(bias))),
+			instr.New(instr.I32_ADD),
+			instr.New(instr.RETURN),
+		)
+		fns = append(fns, fn.MustBuild())
+	}
+
+	b := program.NewBuilder()
+	b.Emit(instr.I32_CONST, 0)
+	for tree, fn := range fns {
+		feature := tree % len(features)
+		b.Emit(instr.I32_CONST, uint64(uint32(features[feature]))).
+			ConstGet(fn).
+			Emit(instr.CALL).
+			Emit(instr.I32_ADD)
+	}
+	return build(b), types.I32(want)
+}
+
 func build(b *program.Builder) *program.Program {
 	prog, err := b.Build()
 	if err != nil {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -809,7 +809,7 @@ func (i *Interpreter) safepoint() error {
 	}
 
 	i.local.Add(f.addr, f.ip, i.instrs[f.addr][f.ip])
-	if f.ip == 0 && !i.tracer.hasEntry(f.addr) {
+	if f.ip == 0 && i.fallbacks[anchor{addr: f.addr, ip: 0}] == nil && !i.tracer.hasEntry(f.addr) {
 		if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: 0}); err != nil {
 			return err
 		}
@@ -821,19 +821,23 @@ func (i *Interpreter) safepoint() error {
 	// installs anything; compile here, once the function is hot and the loop
 	// trace first appears, so the loop header gets its own native. The hotness
 	// gate keeps WithThreshold(-1) a pure interpreter.
+	samples := i.local.Samples(f.addr)
 	if i.threshold >= 0 && f.ip > 0 &&
-		i.local.Samples(f.addr) >= uint64(i.threshold) &&
-		!i.tracer.hasLoop(f.addr, f.ip) {
+		samples >= uint64(i.threshold) &&
+		i.fallbacks[anchor{addr: f.addr, ip: 0}] == nil &&
+		i.fallbacks[anchor{addr: f.addr, ip: f.ip}] == nil {
 		for _, h := range i.tracer.headers(i, f.addr) {
 			if h != f.ip {
 				continue
 			}
-			if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: f.ip}); err != nil {
-				return err
-			}
-			if i.tracer.hasLoop(f.addr, f.ip) {
-				if err := i.compile(f.addr); err != nil {
+			if !i.tracer.hasLoop(f.addr, f.ip) {
+				if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: f.ip}); err != nil {
 					return err
+				}
+				if i.tracer.hasLoop(f.addr, f.ip) {
+					if err := i.compile(f.addr); err != nil {
+						return err
+					}
 				}
 			}
 			break
@@ -848,7 +852,7 @@ func (i *Interpreter) safepoint() error {
 		i.sync()
 		return nil
 	}
-	if i.threshold >= 0 && i.local.Samples(f.addr) == uint64(i.threshold) {
+	if i.threshold >= 0 && samples == uint64(i.threshold) {
 		if err := i.compile(f.addr); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary

Refs #101.

- Avoid repeated trace entry capture checks once a native entry fallback is installed.
- Avoid loop-header trace checks unless the sampled IP is hot, uninstalled, and statically identified as a loop header.
- Reuse the current sample count in `safepoint` instead of querying it twice.
- Add `BenchmarkJITIssue101` and a batch-shaped benchmark fixture for the current interpreter baseline.
- Strengthen `AGENTS.md` and `.claude/CLAUDE.md` so agents must consult `docs/coding-patterns.md` before code/test edits.

## Validation

- `go test ./interp -run 'TestWithThreshold|TestTracer_Capture'`
- `go test ./asm/... ./interp/...`
- `go test ./...`
- `(cd benchmarks && go test ./...)`
- `(cd benchmarks && go test -run '^$' -bench BenchmarkJITIssue101 -benchmem ./...)`
- `make lint`
- `git diff --check`

## Notes

The issue #101 JIT benchmark currently keeps only the runnable interpreter baseline. While building the benchmark, the analogous tiny native-call JIT case exposed an existing arm64 native-call crash, so this PR does not add a skipped or failing JIT sub-benchmark.