### PR TITLE
docs: split opcode JIT status by backend

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -9,13 +9,13 @@
 
 **어디에나 손쉽게 내장하는 빠른 바이트코드 VM.**
 
-minivm은 Go 프로그램 안에서 작은 바이트코드 프로그램을 실행하고, 호스트 함수를 호출하며, 스택/힙/fuel/hook 제한 아래에서 동작합니다. 시작은 빠른 스레디드 인터프리터, 핫 함수와 루프는 트레이스 JIT가 네이티브 ARM64 코드로 자동 컴파일합니다.
+minivm은 Go 프로그램 안에서 작은 바이트코드 프로그램을 실행하고, 호스트 함수를 호출하며, 스택/힙/fuel/hook 제한 아래에서 동작합니다. 시작은 빠른 스레디드 인터프리터, 핫 함수와 루프는 트레이스 JIT가 네이티브 ARM64 코드로 자동 컴파일합니다. 전체 문서 지도는 [`docs/README.md`](docs/README.md)에서 시작하세요. 패키지 흐름은 [`docs/architecture.md`](docs/architecture.md), 플랫폼 지원은 [`docs/compatibility.md`](docs/compatibility.md)에 정리되어 있습니다.
 
 ```bash
 go get github.com/siyul-park/minivm
 ```
 
-> Go 1.26.2 이상. VM 코어는 Go 표준 라이브러리만 사용합니다.
+> Go 1.26.2 이상. VM 코어는 Go 표준 라이브러리만 사용합니다. 지원 플랫폼과 CGO 관련 사항은 [`docs/compatibility.md`](docs/compatibility.md)를 참고하세요.
 
 ## 왜 minivm인가
 
@@ -27,12 +27,16 @@ go get github.com/siyul-park/minivm
 | JIT 전에도 빠른 실행 | 클로저 기반 스레디드 디스패치와 재귀 워크로드에서 거의 0에 가까운 할당 |
 | 필요한 곳만 네이티브 속도 | 핫 함수와 루프를 위한 적응형 ARM64 트레이스 JIT |
 
+세부 설명의 소유 문서는 실행 흐름의 [`docs/architecture.md`](docs/architecture.md), Go 경계의 [`docs/host-integration.md`](docs/host-integration.md), 힙 소유권의 [`docs/memory-model.md`](docs/memory-model.md), 네이티브 lowering의 [`docs/jit-internals.md`](docs/jit-internals.md)입니다.
+
 ## 만들 수 있는 것
 
 - **스크립팅 엔진** — 사용자 정의 로직을 호스트 정책 아래에서 실행
 - **룰 엔진** — 재배포 없이 런타임에 복잡한 조건을 평가
 - **DSL 런타임** — 검증된 VM 위에 도메인 특화 명령어 셋을 정의
 - **플러그인 시스템** — GC가 관리하는 격리 환경에서 바이트코드를 실행
+
+임베딩 패턴, 호스트 호출 계약, 값 변환 규칙은 [`docs/host-integration.md`](docs/host-integration.md)를 참고하세요. 패키지 경계와 인터프리터 파이프라인은 [`docs/architecture.md`](docs/architecture.md)에 있습니다.
 
 ## 성능
 
@@ -62,7 +66,7 @@ minivm의 JIT는 트레이스 기반입니다. 함수 진입점이나 루프 헤
 | 호스트 함수 호출 | ~18 |
 | 배열 / 구조체 연산 | ~30–44 |
 
-전체 측정 결과: [`docs/benchmarks.md`](docs/benchmarks.md)
+전체 결과와 측정 방법은 [`docs/benchmarks.md`](docs/benchmarks.md)에 있습니다. 트레이스 컴파일 세부 사항은 [`docs/jit-internals.md`](docs/jit-internals.md), NaN-boxing과 값 레이아웃은 [`docs/value-representation.md`](docs/value-representation.md)를 참고하세요.
 
 ## 사용법
 
@@ -84,6 +88,8 @@ if err := vm.Run(context.Background()); err != nil {
 
 result, _ := vm.Pop() // types.I32(42)
 ```
+
+명령어 인코딩, 스택 효과, opcode별 JIT 현황은 [`docs/instruction-set.md`](docs/instruction-set.md)에 있습니다. 신뢰할 수 없는 프로그램의 검증 규칙은 [`docs/verification.md`](docs/verification.md)를 참고하세요.
 
 ### 바이트코드에서 Go 함수 호출
 
@@ -112,7 +118,7 @@ prog := program.New(
 )
 ```
 
-파라미터는 타입 안전한 `[]Boxed`로 전달됩니다. 리플렉션이나 `interface{}` 박싱은 없습니다.
+파라미터는 타입 안전한 `[]Boxed`로 전달됩니다. 리플렉션이나 `interface{}` 박싱은 없습니다. 호스트 경계, `Marshal` / `Unmarshal`, 힙 ref 소유권은 [`docs/host-integration.md`](docs/host-integration.md)에 정리되어 있습니다.
 
 ### 함수 정의
 
@@ -140,6 +146,8 @@ factorial := types.NewFunctionBuilder(&types.FunctionType{
 ).Build()
 ```
 
+함수, 클로저, 로컬, 상수, 분기, 호출 동작은 [`docs/instruction-set.md`](docs/instruction-set.md)가 소유합니다. 패키지 수준 실행 흐름은 [`docs/architecture.md`](docs/architecture.md)를 참고하세요.
+
 ### 신뢰할 수 없는 바이트코드 검증
 
 외부에서 생성했거나 신뢰할 수 없는 바이트코드는 인터프리터를 만들기 전에 검증하세요:
@@ -165,7 +173,7 @@ prog, err := optimize.NewOptimizer(optimize.O1).Optimize(prog)
 - **상수 폴딩** — `I32_CONST 3, I32_CONST 4, I32_ADD` → `I32_CONST 7`
 - **상수 중복 제거** — 동일한 값은 하나의 슬롯으로 통합
 
-대수 단순화와 데드 코드 제거까지 원하면 `O2`, 블록 사이 전역 값 번호화까지 원하면 `O3`를 사용하세요.
+대수 단순화와 데드 코드 제거까지 원하면 `O2`, 블록 사이 전역 값 번호화까지 원하면 `O3`를 사용하세요. 패스 매니저, 분석 소유권, optimizer level은 [`docs/pass-system.md`](docs/pass-system.md)에 있습니다.
 
 ## JIT 동작 방식
 
@@ -191,6 +199,8 @@ JIT는 **트레이스 기반**입니다. 함수 진입점이나 루프 헤더가
 
 커버리지는 i32/i64/f32/f64 산술·비트·비교·변환(좁은 i1/i8 종류는 i32 표현을 공유해 i32와 함께 네이티브로 계산되며, width-closed 비트 연산에서 종류가 보존됩니다), 스택 연산·로컬·글로벌·업밸류·상수·`select`·분기, 직접/클로저/가드 간접 호출, 읽기 전용 힙 빠른 경로(`array.get/len`, `struct.get`, `error.get`, ref 읽기), 그리고 **루프**까지 포함합니다. 핫 루프는 본문을 레지스터에 유지한 채 네이티브 back-edge를 돌며 매 반복 사이에 세이프포인트를 폴링합니다. 할당·변형·호스트 호출·`error.new`·`error.code`·`throw`는 트레이스를 끝내고 인터프리터가 담당합니다. 스레디드 인터프리터는 스위치 테이블 대신 클로저 디스패치를 써서 JIT 전에도 충분히 빠릅니다.
 
+전체 trace lifecycle, lowering 계약, journal fallback, backend 책임은 [`docs/jit-internals.md`](docs/jit-internals.md)에 있습니다. 카운터와 스냅샷은 [`docs/profile.md`](docs/profile.md), backend 가용성은 [`docs/compatibility.md`](docs/compatibility.md)를 참고하세요.
+
 ## 명령어 셋
 
 WebAssembly를 참고한 커스텀 명령어 셋입니다. opcode는 1바이트, 피연산자는 고정 폭 또는 길이 접두사 형식입니다.
@@ -211,7 +221,7 @@ WebAssembly를 참고한 커스텀 명령어 셋입니다. opcode는 1바이트,
 | 클로저 | `CLOSURE_NEW` |
 | 에러 | `THROW` `ERROR_NEW` `ERROR_GET` `ERROR_CODE` |
 
-전체 opcode 참조, 스택 효과, 피연산자 폭, JIT 지원 현황은 [`docs/instruction-set.md`](docs/instruction-set.md)를 참고하세요.
+전체 opcode 참조, 스택 효과, 피연산자 폭, ARM64/AMD64 JIT 지원 현황은 [`docs/instruction-set.md`](docs/instruction-set.md)를 참고하세요.
 
 ## 옵션
 
@@ -229,11 +239,9 @@ vm := interp.New(prog,
 )
 ```
 
-`WithTick`은 프로파일 샘플, context 취소 확인, hook 호출 주기, fuel 소비를 함께 제어합니다. `WithFuel(0)`은 무제한이며, 0이 아닌 값은 내부에서 가장 가까운 tick 간격으로 올림합니다. Hook은 `Run` 고루틴에서 동기적으로 실행됩니다.
+`WithTick`은 프로파일 샘플, context 취소 확인, hook 호출 주기, fuel 소비를 함께 제어합니다. `WithFuel(0)`은 무제한이며, 0이 아닌 값은 내부에서 가장 가까운 tick 간격으로 올림합니다. Hook은 `Run` 고루틴에서 동기적으로 실행됩니다. 런타임 제한과 힙 소유권은 [`docs/memory-model.md`](docs/memory-model.md), 프로파일링 주기와 JIT 카운터는 [`docs/profile.md`](docs/profile.md)에 있습니다.
 
 바이트코드 단위 디버깅(중단점, `Step`, `Next`, `Finish`)은 `NewDebugger` + `WithDebugger`를 사용하세요. JIT는 비활성화됩니다. 자세한 내용: [`docs/debugging.md`](docs/debugging.md).
-
-프로파일 스냅샷과 JIT 카운터는 [`docs/profile.md`](docs/profile.md)를 참고하세요.
 
 ## 구현 현황
 
@@ -245,7 +253,7 @@ vm := interp.New(prog,
 | ARM64 트레이스 JIT — 호출, 업밸류, 레퍼런스, 힙 읽기, 루프 | ✅ |
 | x86-64 JIT | 🔲 계획 중 (`asm/amd64`는 아직 코드를 내보내지 않는 placeholder) |
 
-로드맵: [docs/roadmap.md](docs/roadmap.md)
+플랫폼/backend matrix는 [`docs/compatibility.md`](docs/compatibility.md), 우선순위와 향후 방향은 [`docs/roadmap.md`](docs/roadmap.md)를 참고하세요.
 
 ## 라이선스
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@
 
 **Fast bytecode VM that embeds anywhere.**
 
-minivm lets Go programs load tiny bytecode programs, call back into host functions, and run under explicit stack, heap, fuel, and hook limits. It starts as a fast threaded interpreter and compiles hot functions and loops to native ARM64 code automatically with a trace JIT.
+minivm lets Go programs load tiny bytecode programs, call back into host functions, and run under explicit stack, heap, fuel, and hook limits. It starts as a fast threaded interpreter and compiles hot functions and loops to native ARM64 code automatically with a trace JIT. For the full documentation map, start with [`docs/README.md`](docs/README.md); the package flow is expanded in [`docs/architecture.md`](docs/architecture.md) and platform support is tracked in [`docs/compatibility.md`](docs/compatibility.md).
 
 ```bash
 go get github.com/siyul-park/minivm
 ```
 
-> Requires Go 1.26.2+. The VM core depends only on the Go standard library.
+> Requires Go 1.26.2+. The VM core depends only on the Go standard library. See [`docs/compatibility.md`](docs/compatibility.md) for the supported platform matrix and CGO notes.
 
 ## Why minivm
 
@@ -27,12 +27,16 @@ go get github.com/siyul-park/minivm
 | Stay fast before JIT | closure-threaded dispatch with near-zero allocations on recursive workloads |
 | Get native speed where it matters | adaptive ARM64 trace JIT for hot functions and loops |
 
+The detailed owners are [`docs/architecture.md`](docs/architecture.md) for execution flow, [`docs/host-integration.md`](docs/host-integration.md) for Go boundaries, [`docs/memory-model.md`](docs/memory-model.md) for heap ownership, and [`docs/jit-internals.md`](docs/jit-internals.md) for native lowering.
+
 ## Build With It
 
 - **Scripting engines** — execute user-defined logic under your host policy
 - **Rule engines** — evaluate complex conditions at runtime without redeployment
 - **DSL runtimes** — define a custom instruction set on a proven VM foundation
 - **Plugin systems** — run sandboxed bytecode in a GC-managed environment
+
+For embedding patterns, host-call contracts, and value conversion rules, use [`docs/host-integration.md`](docs/host-integration.md). For package boundaries and the interpreter pipeline, use [`docs/architecture.md`](docs/architecture.md).
 
 ## Performance
 
@@ -62,7 +66,7 @@ Single-instruction throughput (threaded interpreter, JIT disabled):
 | host function call | ~18 |
 | array / struct operations | ~30–44 |
 
-Full results: [`docs/benchmarks.md`](docs/benchmarks.md)
+Full results and methodology: [`docs/benchmarks.md`](docs/benchmarks.md). Trace compilation details: [`docs/jit-internals.md`](docs/jit-internals.md). NaN-boxing and value layout: [`docs/value-representation.md`](docs/value-representation.md).
 
 ## Usage
 
@@ -84,6 +88,8 @@ if err := vm.Run(context.Background()); err != nil {
 
 result, _ := vm.Pop() // types.I32(42)
 ```
+
+Instruction encoding, stack effects, and opcode-level JIT status are documented in [`docs/instruction-set.md`](docs/instruction-set.md). Validation rules for untrusted programs are in [`docs/verification.md`](docs/verification.md).
 
 ### Call Go from bytecode
 
@@ -112,7 +118,7 @@ prog := program.New(
 )
 ```
 
-Parameters arrive as typed `[]Boxed`: no reflection, no `interface{}` boxing.
+Parameters arrive as typed `[]Boxed`: no reflection, no `interface{}` boxing. The host boundary, `Marshal` / `Unmarshal`, and heap-reference ownership are covered in [`docs/host-integration.md`](docs/host-integration.md).
 
 ### Define reusable functions
 
@@ -140,6 +146,8 @@ factorial := types.NewFunctionBuilder(&types.FunctionType{
 ).Build()
 ```
 
+Function, closure, local, constant, branch, and call behavior is owned by [`docs/instruction-set.md`](docs/instruction-set.md); the package-level execution flow is in [`docs/architecture.md`](docs/architecture.md).
+
 ### Validate untrusted bytecode
 
 Verify bytecode from untrusted or external producers before constructing an interpreter:
@@ -165,7 +173,7 @@ prog, err := optimize.NewOptimizer(optimize.O1).Optimize(prog)
 - **Constant folding** — `I32_CONST 3, I32_CONST 4, I32_ADD` → `I32_CONST 7`
 - **Constant deduplication** — identical values share a single constant slot
 
-Use `O2` when you also want algebraic simplification and dead-code elimination, or `O3` for cross-block global value numbering.
+Use `O2` when you also want algebraic simplification and dead-code elimination, or `O3` for cross-block global value numbering. The pass manager, analysis ownership, and optimizer levels are documented in [`docs/pass-system.md`](docs/pass-system.md).
 
 ## How the JIT works
 
@@ -191,6 +199,8 @@ The JIT is **trace-based**: when a function entry or loop header gets hot, it re
 
 Coverage spans arithmetic, bitwise, comparison, and conversion across i32/i64/f32/f64 (the narrow i1/i8 kinds share the i32 representation and compute natively alongside it, keeping their kind through width-closed bitwise ops); stack ops, locals, globals, upvalues, constants, `select`, and branches; direct, closure, and guarded indirect calls; read-only heap fast paths (`array.get/len`, `struct.get`, `error.get`, ref reads); and **loops** — a hot loop runs its body in registers across a native back-edge, polling a safepoint between iterations. Allocation, mutation, host calls, `error.new`, `error.code`, and `throw` end a trace and stay interpreter-owned. The threaded interpreter uses closure dispatch rather than a switch table, so it stays fast before the JIT kicks in.
 
+For the full trace lifecycle, lowering contracts, journal fallback, and per-backend responsibilities, see [`docs/jit-internals.md`](docs/jit-internals.md). For counters and snapshots, see [`docs/profile.md`](docs/profile.md); for backend availability, see [`docs/compatibility.md`](docs/compatibility.md).
+
 ## Instruction set
 
 WebAssembly-inspired, intentionally custom. Opcodes are one byte; operands are fixed-width or length-prefixed.
@@ -211,7 +221,7 @@ WebAssembly-inspired, intentionally custom. Opcodes are one byte; operands are f
 | Closures | `CLOSURE_NEW` |
 | Errors | `THROW` `ERROR_NEW` `ERROR_GET` `ERROR_CODE` |
 
-For the complete opcode reference, stack effects, operand widths, and JIT status, see [`docs/instruction-set.md`](docs/instruction-set.md).
+For the complete opcode reference, stack effects, operand widths, and ARM64/AMD64 JIT status, see [`docs/instruction-set.md`](docs/instruction-set.md).
 
 ## Options
 
@@ -229,11 +239,9 @@ vm := interp.New(prog,
 )
 ```
 
-`WithTick` governs profiling, context-cancellation checks, hook cadence, and fuel consumption together. `WithFuel(0)` is unlimited; non-zero values round up to the nearest tick interval. Hooks execute synchronously on the `Run` goroutine.
+`WithTick` governs profiling, context-cancellation checks, hook cadence, and fuel consumption together. `WithFuel(0)` is unlimited; non-zero values round up to the nearest tick interval. Hooks execute synchronously on the `Run` goroutine. Runtime limits and heap ownership are described in [`docs/memory-model.md`](docs/memory-model.md); profiling cadence and JIT counters are described in [`docs/profile.md`](docs/profile.md).
 
 For instruction-accurate debugging (breakpoints, `Step`, `Next`, `Finish`), use `NewDebugger` + `WithDebugger` — this disables JIT. See [`docs/debugging.md`](docs/debugging.md).
-
-For profile snapshots and JIT counters, see [`docs/profile.md`](docs/profile.md).
 
 ## Status
 
@@ -245,7 +253,7 @@ For profile snapshots and JIT counters, see [`docs/profile.md`](docs/profile.md)
 | ARM64 trace JIT — calls, upvalues, refs, heap reads, loops | ✅ |
 | x86-64 JIT | 🔲 planned (`asm/amd64` is a non-emitting placeholder) |
 
-See [docs/roadmap.md](docs/roadmap.md) for priorities and future direction.
+See [`docs/compatibility.md`](docs/compatibility.md) for the platform/backend matrix and [`docs/roadmap.md`](docs/roadmap.md) for priorities and future direction.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ This directory uses a single-owner model. Each topic owns one area of behavior; 
 | Need | Read |
 |---|---|
 | Package boundaries and execution flow | `architecture.md` |
-| Opcode semantics and stack effects | `instruction-set.md` |
+| Opcode semantics, stack effects, and per-backend JIT status | `instruction-set.md` |
 | Static bytecode validation | `verification.md` |
 | Value layout, kinds, boxed values, dynamic `ref` | `value-representation.md` |
 | Heap ownership, reference counting, GC | `memory-model.md` |
@@ -24,9 +24,30 @@ This directory uses a single-owner model. Each topic owns one area of behavior; 
 | Adding a JIT backend | `guides/add-architecture.md` |
 | REPL usage | `guides/repl.md` |
 
+## README Cross-Reference
+
+Top-level READMEs stay as summaries. Each README section should point to the full document that owns the details.
+
+| README section | Owning documents |
+|---|---|
+| Overview and install requirements | `architecture.md`, `compatibility.md` |
+| Why minivm / use cases | `architecture.md`, `host-integration.md`, `memory-model.md`, `jit-internals.md` |
+| Performance | `benchmarks.md`, `jit-internals.md`, `value-representation.md` |
+| Usage: execute bytecode | `instruction-set.md`, `verification.md` |
+| Usage: host calls | `host-integration.md`, `memory-model.md`, `value-representation.md` |
+| Usage: functions and calls | `instruction-set.md`, `architecture.md` |
+| Usage: verification | `verification.md` |
+| Usage: optimization | `pass-system.md` |
+| JIT overview | `jit-internals.md`, `profile.md`, `compatibility.md` |
+| Instruction set | `instruction-set.md` |
+| Options, profiling, debugging | `memory-model.md`, `profile.md`, `debugging.md` |
+| Status and roadmap | `compatibility.md`, `roadmap.md` |
+
+If a README paragraph needs more than a summary, move the detail into the owning document and link back to it.
+
 ## Document Ownership
 
-- Put detailed opcode behavior in `instruction-set.md`.
+- Put detailed opcode behavior and per-backend JIT status in `instruction-set.md`.
 - Put heap ownership and RC rules in `memory-model.md`.
 - Put boxed value layout and kind rules in `value-representation.md`.
 - Put JIT implementation contracts in `jit-internals.md`.

--- a/docs/instruction-set.md
+++ b/docs/instruction-set.md
@@ -15,6 +15,8 @@ Use this document when adding, changing, debugging, or testing bytecode instruct
 | dynamic verification rules | `program/verify.go` |
 | runtime semantics | `interp/threaded.go` |
 | ARM64 lowering | `interp/jit_arm64.go` |
+| non-ARM64 JIT stub | `interp/jit_stub.go` |
+| platform support | `docs/compatibility.md` |
 
 ## Core Rules
 
@@ -29,11 +31,16 @@ Use this document when adding, changing, debugging, or testing bytecode instruct
 
 ## JIT Status
 
+JIT status is per opcode and per backend. It describes whether a recorded trace can be lowered by that backend; every opcode remains available through the threaded interpreter.
+
 | Status | Meaning |
 |---|---|
-| ✅ | lowered to native ARM64 |
-| ◐ | partially lowered, guarded, terminal, or framed fallback |
-| ⬜ | threaded-only |
+| ✅ | native lowering exists for supported trace shapes |
+| ◐ | partial support: guarded, shape-limited, terminal fallback, or framed fallback |
+| ⬜ | threaded-only on that backend |
+| 🔲 | backend unavailable |
+
+AMD64 currently has no active JIT backend. `asm/amd64` is a placeholder and `interp/jit_stub.go` disables compiler construction on non-ARM64 platforms, so every AMD64 entry is `🔲`.
 
 ## Operand Widths
 
@@ -61,23 +68,222 @@ Narrow result rules:
 - `i32.and`, `i32.or`, and `i32.xor` preserve a shared narrow kind for `i1`/`i8`
 - other arithmetic widens narrow operands to `i32`
 
-## Opcode Families
+## Opcode Reference
 
-| Family | Representative opcodes | Notes |
-|---|---|---|
-| Stack | `NOP`, `DROP`, `DUP`, `SWAP`, `SELECT`, `UNREACHABLE` | stack manipulation and deliberate unreachable marker |
-| Control | `BR`, `BR_IF`, `BR_TABLE`, `CALL`, `RETURN`, `RETURN_CALL` | relative branches, calls, returns, and tail calls |
-| Coroutines and iterators | `YIELD`, `RESUME`, `CORO_DONE`, `CORO_VALUE` | coroutine handles and custom `types.Iterator` values |
-| Variables | `GLOBAL_*`, `LOCAL_*`, `CONST_GET`, `UPVAL_*` | global, local, constant, and closure upvalue access |
-| References | `REF_NULL`, `REF_NEW`, `REF_GET`, `REF_SET`, `REF_TEST`, `REF_CAST`, `REF_IS_NULL`, `REF_EQ`, `REF_NE` | dynamic `ref`, mutable scalar cells, and runtime type checks |
-| Closures | `CLOSURE_NEW` | function template plus captured values |
-| Integers | `I32_*`, `I64_*` | constants, arithmetic, bitwise ops, comparisons, conversions, and reinterpret casts |
-| Floating point | `F32_*`, `F64_*` | constants, arithmetic, comparisons, conversions, rounding, min/max, and reinterpret casts |
-| Strings | `STRING_NEW_UTF32`, `STRING_LEN`, `STRING_CONCAT`, `STRING_*` comparisons, `STRING_ENCODE_UTF32`, `STRING_ITER` | heap strings and UTF-32/codepoint conversion |
-| Arrays | `ARRAY_NEW`, `ARRAY_NEW_DEFAULT`, `ARRAY_LEN`, `ARRAY_GET`, `ARRAY_SET`, `ARRAY_FILL`, `ARRAY_COPY`, `ARRAY_APPEND`, `ARRAY_DELETE`, `ARRAY_SLICE` | growable typed arrays |
-| Structs | `STRUCT_NEW`, `STRUCT_NEW_DEFAULT`, `STRUCT_GET`, `STRUCT_SET` | VM structs and host-object fallback |
-| Maps | `MAP_NEW`, `MAP_NEW_DEFAULT`, `MAP_LEN`, `MAP_GET`, `MAP_LOOKUP`, `MAP_SET`, `MAP_DELETE`, `MAP_CLEAR`, `MAP_KEYS`, `MAP_ITER` | typed maps and key iteration |
-| Structured errors | `THROW`, `ERROR_NEW`, `ERROR_GET`, `ERROR_CODE` | exception tables and `types.Error` payloads |
+Do not group multiple opcodes in one row. Keep this table in opcode-value order so it can be compared directly with `instr/opcode.go`.
+
+| Family | Opcode | Mnemonic | ARM64 JIT | AMD64 JIT | Notes |
+|---|---|---|---:|---:|---|
+| Stack | `NOP` | `nop` | ✅ | 🔲 | — |
+| Stack | `UNREACHABLE` | `unreachable` | ◐ | 🔲 | terminal trap exit |
+| Stack | `DROP` | `drop` | ✅ | 🔲 | — |
+| Stack | `DUP` | `dup` | ✅ | 🔲 | — |
+| Stack | `SWAP` | `swap` | ✅ | 🔲 | — |
+| Control | `BR` | `br` | ✅ | 🔲 | linear branch or loop back-edge |
+| Control | `BR_IF` | `br_if` | ◐ | 🔲 | recorded branch guard or loop back-edge |
+| Control | `BR_TABLE` | `br_table` | ◐ | 🔲 | recorded table branch with fallback |
+| Stack | `SELECT` | `select` | ✅ | 🔲 | — |
+| Control | `CALL` | `call` | ◐ | 🔲 | bytecode/closure calls lower; host or unsupported callees fall back |
+| Control | `RETURN` | `return` | ✅ | 🔲 | trace return or stitched continuation |
+| Control | `RETURN_CALL` | `return_call` | ◐ | 🔲 | tail loop or tail morph when target shape is supported |
+| Coroutines | `YIELD` | `yield` | ◐ | 🔲 | terminal fallback to coroutine suspension |
+| Coroutines | `RESUME` | `resume` | ◐ | 🔲 | terminal fallback to coroutine resume |
+| Coroutines | `CORO_DONE` | `coro.done` | ✅ | 🔲 | native coroutine field read |
+| Coroutines | `CORO_VALUE` | `coro.value` | ✅ | 🔲 | native coroutine field read |
+| Variables | `GLOBAL_GET` | `global.get` | ✅ | 🔲 | — |
+| Variables | `GLOBAL_SET` | `global.set` | ✅ | 🔲 | — |
+| Variables | `GLOBAL_TEE` | `global.tee` | ✅ | 🔲 | — |
+| Variables | `LOCAL_GET` | `local.get` | ✅ | 🔲 | — |
+| Variables | `LOCAL_SET` | `local.set` | ✅ | 🔲 | — |
+| Variables | `LOCAL_TEE` | `local.tee` | ✅ | 🔲 | — |
+| Variables | `CONST_GET` | `const.get` | ◐ | 🔲 | scalar constants and function refs feeding calls |
+| Variables | `UPVAL_GET` | `upval.get` | ✅ | 🔲 | — |
+| Variables | `UPVAL_SET` | `upval.set` | ✅ | 🔲 | — |
+| References | `REF_NULL` | `ref.null` | ✅ | 🔲 | — |
+| References | `REF_NEW` | `ref.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| References | `REF_GET` | `ref.get` | ✅ | 🔲 | native ref-cell read |
+| References | `REF_SET` | `ref.set` | ⬜ | 🔲 | mutation stays interpreter-owned |
+| References | `REF_TEST` | `ref.test` | ⬜ | 🔲 | runtime type test stays threaded |
+| References | `REF_CAST` | `ref.cast` | ⬜ | 🔲 | runtime cast stays threaded |
+| References | `REF_IS_NULL` | `ref.is_null` | ✅ | 🔲 | — |
+| References | `REF_EQ` | `ref.eq` | ⬜ | 🔲 | two-ref release semantics stay threaded |
+| References | `REF_NE` | `ref.ne` | ⬜ | 🔲 | two-ref release semantics stay threaded |
+| Integers | `I32_CONST` | `i32.const` | ✅ | 🔲 | — |
+| Integers | `I32_ADD` | `i32.add` | ✅ | 🔲 | — |
+| Integers | `I32_SUB` | `i32.sub` | ✅ | 🔲 | — |
+| Integers | `I32_MUL` | `i32.mul` | ✅ | 🔲 | — |
+| Integers | `I32_DIV_S` | `i32.div_s` | ✅ | 🔲 | division guard for traps |
+| Integers | `I32_DIV_U` | `i32.div_u` | ✅ | 🔲 | division guard for traps |
+| Integers | `I32_REM_S` | `i32.rem_s` | ✅ | 🔲 | division guard for traps |
+| Integers | `I32_REM_U` | `i32.rem_u` | ✅ | 🔲 | division guard for traps |
+| Integers | `I32_SHL` | `i32.shl` | ✅ | 🔲 | — |
+| Integers | `I32_SHR_S` | `i32.shr_s` | ✅ | 🔲 | — |
+| Integers | `I32_SHR_U` | `i32.shr_u` | ✅ | 🔲 | — |
+| Integers | `I32_XOR` | `i32.xor` | ✅ | 🔲 | — |
+| Integers | `I32_AND` | `i32.and` | ✅ | 🔲 | — |
+| Integers | `I32_OR` | `i32.or` | ✅ | 🔲 | — |
+| Integers | `I32_CLZ` | `i32.clz` | ✅ | 🔲 | — |
+| Integers | `I32_CTZ` | `i32.ctz` | ✅ | 🔲 | — |
+| Integers | `I32_POPCNT` | `i32.popcnt` | ✅ | 🔲 | — |
+| Integers | `I32_ROTL` | `i32.rotl` | ✅ | 🔲 | — |
+| Integers | `I32_ROTR` | `i32.rotr` | ✅ | 🔲 | — |
+| Integers | `I32_EXTEND8_S` | `i32.extend8_s` | ✅ | 🔲 | — |
+| Integers | `I32_EXTEND16_S` | `i32.extend16_s` | ✅ | 🔲 | — |
+| Integers | `I32_EQZ` | `i32.eqz` | ✅ | 🔲 | — |
+| Integers | `I32_EQ` | `i32.eq` | ✅ | 🔲 | — |
+| Integers | `I32_NE` | `i32.ne` | ✅ | 🔲 | — |
+| Integers | `I32_LT_S` | `i32.lt_s` | ✅ | 🔲 | — |
+| Integers | `I32_LT_U` | `i32.lt_u` | ✅ | 🔲 | — |
+| Integers | `I32_GT_S` | `i32.gt_s` | ✅ | 🔲 | — |
+| Integers | `I32_GT_U` | `i32.gt_u` | ✅ | 🔲 | — |
+| Integers | `I32_LE_S` | `i32.le_s` | ✅ | 🔲 | — |
+| Integers | `I32_LE_U` | `i32.le_u` | ✅ | 🔲 | — |
+| Integers | `I32_GE_S` | `i32.ge_s` | ✅ | 🔲 | — |
+| Integers | `I32_GE_U` | `i32.ge_u` | ✅ | 🔲 | — |
+| Integers | `I32_TO_I64_S` | `i32.to_i64_s` | ✅ | 🔲 | — |
+| Integers | `I32_TO_I64_U` | `i32.to_i64_u` | ✅ | 🔲 | — |
+| Integers | `I32_TO_F32_U` | `i32.to_f32_u` | ✅ | 🔲 | — |
+| Integers | `I32_TO_F32_S` | `i32.to_f32_s` | ✅ | 🔲 | — |
+| Integers | `I32_TO_F64_U` | `i32.to_f64_u` | ✅ | 🔲 | — |
+| Integers | `I32_TO_F64_S` | `i32.to_f64_s` | ✅ | 🔲 | — |
+| Integers | `I32_REINTERPRET_F32` | `i32.reinterpret_f32` | ✅ | 🔲 | — |
+| Integers | `I64_CONST` | `i64.const` | ◐ | 🔲 | boxable i64 immediates only |
+| Integers | `I64_ADD` | `i64.add` | ✅ | 🔲 | boxability guard for arithmetic results |
+| Integers | `I64_SUB` | `i64.sub` | ✅ | 🔲 | boxability guard for arithmetic results |
+| Integers | `I64_MUL` | `i64.mul` | ✅ | 🔲 | boxability guard for arithmetic results |
+| Integers | `I64_DIV_S` | `i64.div_s` | ✅ | 🔲 | division and boxability guards |
+| Integers | `I64_DIV_U` | `i64.div_u` | ✅ | 🔲 | division and boxability guards |
+| Integers | `I64_REM_S` | `i64.rem_s` | ✅ | 🔲 | division and boxability guards |
+| Integers | `I64_REM_U` | `i64.rem_u` | ✅ | 🔲 | division and boxability guards |
+| Integers | `I64_SHL` | `i64.shl` | ✅ | 🔲 | boxability guard where needed |
+| Integers | `I64_SHR_S` | `i64.shr_s` | ✅ | 🔲 | — |
+| Integers | `I64_SHR_U` | `i64.shr_u` | ✅ | 🔲 | boxability guard where needed |
+| Integers | `I64_XOR` | `i64.xor` | ✅ | 🔲 | — |
+| Integers | `I64_AND` | `i64.and` | ✅ | 🔲 | — |
+| Integers | `I64_OR` | `i64.or` | ✅ | 🔲 | — |
+| Integers | `I64_CLZ` | `i64.clz` | ✅ | 🔲 | — |
+| Integers | `I64_CTZ` | `i64.ctz` | ✅ | 🔲 | — |
+| Integers | `I64_POPCNT` | `i64.popcnt` | ✅ | 🔲 | — |
+| Integers | `I64_ROTL` | `i64.rotl` | ✅ | 🔲 | — |
+| Integers | `I64_ROTR` | `i64.rotr` | ✅ | 🔲 | — |
+| Integers | `I64_EXTEND8_S` | `i64.extend8_s` | ✅ | 🔲 | — |
+| Integers | `I64_EXTEND16_S` | `i64.extend16_s` | ✅ | 🔲 | — |
+| Integers | `I64_EXTEND32_S` | `i64.extend32_s` | ✅ | 🔲 | — |
+| Integers | `I64_EQZ` | `i64.eqz` | ✅ | 🔲 | — |
+| Integers | `I64_EQ` | `i64.eq` | ✅ | 🔲 | — |
+| Integers | `I64_NE` | `i64.ne` | ✅ | 🔲 | — |
+| Integers | `I64_LT_S` | `i64.lt_s` | ✅ | 🔲 | — |
+| Integers | `I64_LT_U` | `i64.lt_u` | ✅ | 🔲 | — |
+| Integers | `I64_GT_S` | `i64.gt_s` | ✅ | 🔲 | — |
+| Integers | `I64_GT_U` | `i64.gt_u` | ✅ | 🔲 | — |
+| Integers | `I64_LE_S` | `i64.le_s` | ✅ | 🔲 | — |
+| Integers | `I64_LE_U` | `i64.le_u` | ✅ | 🔲 | — |
+| Integers | `I64_GE_S` | `i64.ge_s` | ✅ | 🔲 | — |
+| Integers | `I64_GE_U` | `i64.ge_u` | ✅ | 🔲 | — |
+| Integers | `I64_TO_I32` | `i64.to_i32` | ✅ | 🔲 | — |
+| Integers | `I64_TO_F32_S` | `i64.to_f32_s` | ✅ | 🔲 | — |
+| Integers | `I64_TO_F32_U` | `i64.to_f32_u` | ✅ | 🔲 | — |
+| Integers | `I64_TO_F64_S` | `i64.to_f64_s` | ✅ | 🔲 | — |
+| Integers | `I64_TO_F64_U` | `i64.to_f64_u` | ✅ | 🔲 | — |
+| Integers | `I64_REINTERPRET_F64` | `i64.reinterpret_f64` | ✅ | 🔲 | — |
+| Floating point | `F32_CONST` | `f32.const` | ✅ | 🔲 | — |
+| Floating point | `F32_ADD` | `f32.add` | ✅ | 🔲 | — |
+| Floating point | `F32_SUB` | `f32.sub` | ✅ | 🔲 | — |
+| Floating point | `F32_MUL` | `f32.mul` | ✅ | 🔲 | — |
+| Floating point | `F32_DIV` | `f32.div` | ✅ | 🔲 | — |
+| Floating point | `F32_REM` | `f32.rem` | ◐ | 🔲 | terminal fallback |
+| Floating point | `F32_MOD` | `f32.mod` | ◐ | 🔲 | terminal fallback |
+| Floating point | `F32_ABS` | `f32.abs` | ✅ | 🔲 | — |
+| Floating point | `F32_NEG` | `f32.neg` | ✅ | 🔲 | — |
+| Floating point | `F32_SQRT` | `f32.sqrt` | ✅ | 🔲 | — |
+| Floating point | `F32_CEIL` | `f32.ceil` | ✅ | 🔲 | — |
+| Floating point | `F32_FLOOR` | `f32.floor` | ✅ | 🔲 | — |
+| Floating point | `F32_TRUNC` | `f32.trunc` | ✅ | 🔲 | — |
+| Floating point | `F32_NEAREST` | `f32.nearest` | ✅ | 🔲 | — |
+| Floating point | `F32_MIN` | `f32.min` | ✅ | 🔲 | — |
+| Floating point | `F32_MAX` | `f32.max` | ✅ | 🔲 | — |
+| Floating point | `F32_COPYSIGN` | `f32.copysign` | ✅ | 🔲 | — |
+| Floating point | `F32_EQ` | `f32.eq` | ✅ | 🔲 | — |
+| Floating point | `F32_NE` | `f32.ne` | ✅ | 🔲 | — |
+| Floating point | `F32_LT` | `f32.lt` | ✅ | 🔲 | — |
+| Floating point | `F32_GT` | `f32.gt` | ✅ | 🔲 | — |
+| Floating point | `F32_LE` | `f32.le` | ✅ | 🔲 | — |
+| Floating point | `F32_GE` | `f32.ge` | ✅ | 🔲 | — |
+| Floating point | `F32_TO_I32_S` | `f32.to_i32_s` | ✅ | 🔲 | — |
+| Floating point | `F32_TO_I32_U` | `f32.to_i32_u` | ✅ | 🔲 | — |
+| Floating point | `F32_TO_I64_S` | `f32.to_i64_s` | ✅ | 🔲 | boxability guard |
+| Floating point | `F32_TO_I64_U` | `f32.to_i64_u` | ✅ | 🔲 | boxability guard |
+| Floating point | `F32_TO_F64` | `f32.to_f64` | ✅ | 🔲 | — |
+| Floating point | `F32_REINTERPRET_I32` | `f32.reinterpret_i32` | ✅ | 🔲 | — |
+| Floating point | `F64_CONST` | `f64.const` | ✅ | 🔲 | — |
+| Floating point | `F64_ADD` | `f64.add` | ✅ | 🔲 | — |
+| Floating point | `F64_SUB` | `f64.sub` | ✅ | 🔲 | — |
+| Floating point | `F64_MUL` | `f64.mul` | ✅ | 🔲 | — |
+| Floating point | `F64_DIV` | `f64.div` | ✅ | 🔲 | — |
+| Floating point | `F64_REM` | `f64.rem` | ◐ | 🔲 | terminal fallback |
+| Floating point | `F64_MOD` | `f64.mod` | ◐ | 🔲 | terminal fallback |
+| Floating point | `F64_ABS` | `f64.abs` | ✅ | 🔲 | — |
+| Floating point | `F64_NEG` | `f64.neg` | ✅ | 🔲 | — |
+| Floating point | `F64_SQRT` | `f64.sqrt` | ✅ | 🔲 | — |
+| Floating point | `F64_CEIL` | `f64.ceil` | ✅ | 🔲 | — |
+| Floating point | `F64_FLOOR` | `f64.floor` | ✅ | 🔲 | — |
+| Floating point | `F64_TRUNC` | `f64.trunc` | ✅ | 🔲 | — |
+| Floating point | `F64_NEAREST` | `f64.nearest` | ✅ | 🔲 | — |
+| Floating point | `F64_MIN` | `f64.min` | ✅ | 🔲 | — |
+| Floating point | `F64_MAX` | `f64.max` | ✅ | 🔲 | — |
+| Floating point | `F64_COPYSIGN` | `f64.copysign` | ✅ | 🔲 | — |
+| Floating point | `F64_EQ` | `f64.eq` | ✅ | 🔲 | — |
+| Floating point | `F64_NE` | `f64.ne` | ✅ | 🔲 | — |
+| Floating point | `F64_LT` | `f64.lt` | ✅ | 🔲 | — |
+| Floating point | `F64_GT` | `f64.gt` | ✅ | 🔲 | — |
+| Floating point | `F64_LE` | `f64.le` | ✅ | 🔲 | — |
+| Floating point | `F64_GE` | `f64.ge` | ✅ | 🔲 | — |
+| Floating point | `F64_TO_I32_S` | `f64.to_i32_s` | ✅ | 🔲 | — |
+| Floating point | `F64_TO_I32_U` | `f64.to_i32_u` | ✅ | 🔲 | — |
+| Floating point | `F64_TO_I64_S` | `f64.to_i64_s` | ✅ | 🔲 | boxability guard |
+| Floating point | `F64_TO_I64_U` | `f64.to_i64_u` | ✅ | 🔲 | boxability guard |
+| Floating point | `F64_TO_F32` | `f64.to_f32` | ✅ | 🔲 | — |
+| Floating point | `F64_REINTERPRET_I64` | `f64.reinterpret_i64` | ✅ | 🔲 | — |
+| Strings | `STRING_NEW_UTF32` | `string.new_utf32` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Strings | `STRING_LEN` | `string.len` | ◐ | 🔲 | terminal fallback |
+| Strings | `STRING_CONCAT` | `string.concat` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Strings | `STRING_EQ` | `string.eq` | ⬜ | 🔲 | string comparisons stay threaded |
+| Strings | `STRING_NE` | `string.ne` | ⬜ | 🔲 | string comparisons stay threaded |
+| Strings | `STRING_LT` | `string.lt` | ⬜ | 🔲 | string comparisons stay threaded |
+| Strings | `STRING_GT` | `string.gt` | ⬜ | 🔲 | string comparisons stay threaded |
+| Strings | `STRING_LE` | `string.le` | ⬜ | 🔲 | string comparisons stay threaded |
+| Strings | `STRING_GE` | `string.ge` | ⬜ | 🔲 | string comparisons stay threaded |
+| Strings | `STRING_ENCODE_UTF32` | `string.encode_utf32` | ◐ | 🔲 | terminal fallback |
+| Arrays | `ARRAY_NEW` | `array.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Arrays | `ARRAY_NEW_DEFAULT` | `array.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Arrays | `ARRAY_LEN` | `array.len` | ✅ | 🔲 | native typed-array length fast path |
+| Arrays | `ARRAY_GET` | `array.get` | ✅ | 🔲 | native typed-array get fast path |
+| Arrays | `ARRAY_SET` | `array.set` | ◐ | 🔲 | terminal native mutation |
+| Arrays | `ARRAY_FILL` | `array.fill` | ⬜ | 🔲 | bulk mutation stays threaded |
+| Arrays | `ARRAY_COPY` | `array.copy` | ⬜ | 🔲 | bulk mutation stays threaded |
+| Arrays | `ARRAY_APPEND` | `array.append` | ⬜ | 🔲 | grow/mutation stays threaded |
+| Arrays | `ARRAY_DELETE` | `array.delete` | ⬜ | 🔲 | mutation and removed-value ownership stay threaded |
+| Arrays | `ARRAY_SLICE` | `array.slice` | ⬜ | 🔲 | allocation and ownership stay threaded |
+| Structs | `STRUCT_NEW` | `struct.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Structs | `STRUCT_NEW_DEFAULT` | `struct.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Structs | `STRUCT_GET` | `struct.get` | ✅ | 🔲 | native field get fast path |
+| Structs | `STRUCT_SET` | `struct.set` | ◐ | 🔲 | terminal native mutation |
+| Maps | `MAP_NEW` | `map.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Maps | `MAP_NEW_DEFAULT` | `map.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Maps | `MAP_LEN` | `map.len` | ◐ | 🔲 | terminal fallback |
+| Maps | `MAP_GET` | `map.get` | ◐ | 🔲 | terminal fallback |
+| Maps | `MAP_LOOKUP` | `map.lookup` | ◐ | 🔲 | terminal fallback |
+| Maps | `MAP_SET` | `map.set` | ⬜ | 🔲 | mutation stays threaded |
+| Maps | `MAP_DELETE` | `map.delete` | ⬜ | 🔲 | mutation stays threaded |
+| Maps | `MAP_CLEAR` | `map.clear` | ⬜ | 🔲 | mutation stays threaded |
+| Maps | `MAP_KEYS` | `map.keys` | ◐ | 🔲 | terminal fallback |
+| Closures | `CLOSURE_NEW` | `closure.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
+| Maps | `MAP_ITER` | `map.iter` | ◐ | 🔲 | terminal fallback |
+| Structured errors | `THROW` | `throw` | ◐ | 🔲 | terminal fallback to handler logic |
+| Structured errors | `ERROR_NEW` | `error.new` | ◐ | 🔲 | terminal fallback allocation |
+| Structured errors | `ERROR_GET` | `error.get` | ✅ | 🔲 | native error field read |
+| Structured errors | `ERROR_CODE` | `error.code` | ◐ | 🔲 | terminal fallback |
+| Strings | `STRING_ITER` | `string.iter` | ◐ | 🔲 | terminal fallback |
 
 ## Family Rules
 
@@ -122,10 +328,11 @@ When changing the instruction set:
 - keep names short, standard, and consistent
 - prefer one general opcode over several narrow variants
 - do not add an opcode when existing opcodes compose cleanly
-- update widths, verifier, threaded runtime, JIT status, tests, and this document together
+- update widths, verifier, threaded runtime, per-backend JIT status, tests, and this document together
 - keep stack effects explicit
 - keep ref ownership rules visible
 - preserve interpreter/JIT semantic symmetry
+- keep opcode status split by ARM64 and AMD64 instead of grouping several opcodes in one row
 
 ## Related Docs
 
@@ -133,3 +340,4 @@ When changing the instruction set:
 - `docs/verification.md` — static validation and stack rules
 - `docs/value-representation.md` — kinds, boxed layout, and boolean representation
 - `docs/jit-internals.md` — native lowering and fallback behavior
+- `docs/compatibility.md` — platform and backend availability


### PR DESCRIPTION
## Summary

- Split the instruction-set JIT status into per-opcode rows with separate ARM64 and AMD64 columns.
- Document the AMD64 backend state explicitly as unavailable while `asm/amd64` remains a placeholder and non-ARM64 uses the JIT stub.
- Add README cross-links from summary sections to the owning detailed docs in English, Korean, and the docs index.

## Notes

- This is documentation-only.
- The opcode table is kept in `instr/opcode.go` order so future opcode additions can be checked directly against the source of truth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded README cross-links to help readers find architecture, host integration, memory model, JIT internals, and roadmap details more easily.
  * Clarified usage and performance guidance with more direct references for building, optimization, debugging, and profiling.
  * Improved the instruction set documentation with a clearer opcode reference, backend/JIT availability status, and compatibility notes.
  * Updated the docs guide to better explain ownership and where detailed information lives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->