### PR TITLE
perf: reduce warm jit coordination overhead

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -171,6 +171,17 @@ The default threshold is `4096` executed instructions, which is about 32 samples
 
 Loop-anchored trace compilation lets hot loop bodies run in native code between safepoints instead of deoptimizing on every iteration. Recursive function references through locals can also remain native when guards succeed.
 
+### JIT Coordination Workloads
+
+`BenchmarkJITIssue101` tracks a LightGBM-style branchy batch path with many tiny tree-score functions called over one mutable `f64` feature row. It is sensitive to per-tick coordination overhead after a trace is already installed.
+
+| Workload | Mode | Before ns/op | Current ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|---:|
+| `branchy_batch_tree_evaluation` | threaded | 1,760 | 1,807 | 0 | 0 |
+| `branchy_batch_tree_evaluation` | JIT | 2,874 | 1,203 | 0 | 0 |
+
+The JIT row improved by keeping warm-entry fallback checks dense and skipping no-op safepoints when no context cancellation, fuel, hook, profiler, or shared cache coordination is active.
+
 On x86-64, JIT is not implemented yet. The runtime falls back to threaded execution.
 
 ## Methodology

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -175,12 +175,12 @@ Loop-anchored trace compilation lets hot loop bodies run in native code between 
 
 `BenchmarkJITIssue101` tracks a LightGBM-style branchy batch path with many tiny tree-score functions called over one mutable `f64` feature row. It is sensitive to per-tick coordination overhead after a trace is already installed.
 
-| Workload | Mode | Before ns/op | Current ns/op | B/op | allocs/op |
-|---|---|---:|---:|---:|---:|
-| `branchy_batch_tree_evaluation` | threaded | 1,760 | 1,807 | 0 | 0 |
-| `branchy_batch_tree_evaluation` | JIT | 2,874 | 1,203 | 0 | 0 |
+| Workload | Mode | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `branchy_batch_tree_evaluation` | threaded | 1,807 | 0 | 0 |
+| `branchy_batch_tree_evaluation` | JIT | 1,203 | 0 | 0 |
 
-The JIT row improved by keeping warm-entry fallback checks dense and skipping no-op safepoints when no context cancellation, fuel, hook, profiler, or shared cache coordination is active.
+The JIT row stays faster by keeping warm-entry fallback checks dense and skipping no-op safepoints when no context cancellation, fuel, hook, profiler, or shared cache coordination is active.
 
 On x86-64, JIT is not implemented yet. The runtime falls back to threaded execution.
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -17,17 +17,19 @@ import (
 
 type Interpreter struct {
 	ctx       context.Context
+	done      <-chan struct{}
 	tracer    *Tracer
 	hook      func(*Interpreter) error
 	marshaler Marshaler
 
-	compiler  *compiler
-	cache     *Cache
-	profiler  *prof.Profiler
-	samples   *prof.Collector
-	fallbacks map[anchor]func(*Interpreter)
-	tried     map[int]bool
-	journal   []uint64
+	compiler       *compiler
+	cache          *Cache
+	profiler       *prof.Profiler
+	samples        *prof.Collector
+	fallbacks      map[anchor]func(*Interpreter)
+	entryFallbacks []func(*Interpreter)
+	tried          map[int]bool
+	journal        []uint64
 
 	types     []types.Type
 	constants []types.Boxed
@@ -235,32 +237,33 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 	}
 
 	i := &Interpreter{
-		tracer:    tracer,
-		hook:      opt.hook,
-		marshaler: m,
-		cache:     opt.cache,
-		profiler:  opt.profiler,
-		samples:   samples,
-		threshold: threshold,
-		types:     prog.Types,
-		constants: make([]types.Boxed, len(prog.Constants)),
-		globals:   make([]types.Boxed, 0, opt.globals),
-		instrs:    make([][]byte, len(prog.Constants)+1),
-		code:      make([][]func(*Interpreter), len(prog.Constants)+1),
-		fallbacks: map[anchor]func(*Interpreter){},
-		tried:     map[int]bool{},
-		dynamic:   map[int]bool{},
-		journal:   make([]uint64, journalHead+journalStride*opt.frame),
-		frames:    make([]frame, opt.frame),
-		stack:     make([]types.Boxed, opt.stack),
-		heap:      make([]types.Value, 0, opt.heap),
-		interned:  make(map[string]types.Ref),
-		free:      make([]int, 0, opt.heap),
-		rc:        make([]int, 0, opt.heap),
-		tick:      opt.tick,
-		fuel:      fuel,
-		gas:       fuel,
-		limit:     opt.maxHeap,
+		tracer:         tracer,
+		hook:           opt.hook,
+		marshaler:      m,
+		cache:          opt.cache,
+		profiler:       opt.profiler,
+		samples:        samples,
+		threshold:      threshold,
+		types:          prog.Types,
+		constants:      make([]types.Boxed, len(prog.Constants)),
+		globals:        make([]types.Boxed, 0, opt.globals),
+		instrs:         make([][]byte, len(prog.Constants)+1),
+		code:           make([][]func(*Interpreter), len(prog.Constants)+1),
+		fallbacks:      map[anchor]func(*Interpreter){},
+		entryFallbacks: make([]func(*Interpreter), len(prog.Constants)+1),
+		tried:          map[int]bool{},
+		dynamic:        map[int]bool{},
+		journal:        make([]uint64, journalHead+journalStride*opt.frame),
+		frames:         make([]frame, opt.frame),
+		stack:          make([]types.Boxed, opt.stack),
+		heap:           make([]types.Value, 0, opt.heap),
+		interned:       make(map[string]types.Ref),
+		free:           make([]int, 0, opt.heap),
+		rc:             make([]int, 0, opt.heap),
+		tick:           opt.tick,
+		fuel:           fuel,
+		gas:            fuel,
+		limit:          opt.maxHeap,
 	}
 	i.alloc(types.Null)
 
@@ -339,6 +342,10 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 
 func (i *Interpreter) Run(ctx context.Context) error {
 	i.ctx = ctx
+	i.done = nil
+	if ctx != nil {
+		i.done = ctx.Done()
+	}
 	for {
 		// dispatch's recover absorbs every panic, so nothing escapes it and ctx is
 		// always cleared below; a caught throw/trap loops to resume at the handler.
@@ -347,6 +354,7 @@ func (i *Interpreter) Run(ctx context.Context) error {
 			continue
 		}
 		i.ctx = nil
+		i.done = nil
 		return err
 	}
 }
@@ -374,13 +382,16 @@ func (i *Interpreter) dispatch() (caught bool, err error) {
 	f := i.fr
 	code := f.code
 	tick := i.tick
+	quiet := i.done == nil && i.gas < 0 && i.hook == nil && i.profiler == nil && i.cache == nil
 
 	for f.ip < len(code) {
 		tick--
 		if tick == 0 {
 			tick = i.tick
-			if err := i.safepoint(); err != nil {
-				return false, err
+			if !quiet || i.entryFallback(f.addr) == nil {
+				if err := i.safepoint(); err != nil {
+					return false, err
+				}
 			}
 		}
 
@@ -764,6 +775,9 @@ func (i *Interpreter) install(mod *module, account bool) {
 		// on return; a loop root re-enters mid-function and never unwinds it.
 		if i.fallbacks[a] == nil {
 			i.fallbacks[a] = i.code[a.addr][a.ip]
+			if a.ip == 0 {
+				i.entryFallbacks[a.addr] = i.fallbacks[a]
+			}
 		}
 		if entry.loop {
 			i.code[a.addr][a.ip] = i.loop(entry.callable)
@@ -829,10 +843,12 @@ func (i *Interpreter) function(addr int) (*types.Function, bool) {
 // frame i.fr, so a native yield must rebuild frames (deopt) and point i.fr at
 // the resumable frame before calling it.
 func (i *Interpreter) safepoint() error {
-	select {
-	case <-i.ctx.Done():
-		return i.ctx.Err()
-	default:
+	if i.done != nil {
+		select {
+		case <-i.done:
+			return i.ctx.Err()
+		default:
+		}
 	}
 
 	if i.gas >= 0 {
@@ -853,8 +869,8 @@ func (i *Interpreter) safepoint() error {
 	// A warm function already has its entry trace installed. Its sampling and
 	// entry/loop capture are dead (those gates require the entry fallback nil)
 	// and its one-shot compile trigger has already fired, so the warm path pays
-	// only one map lookup here. A user profiler still needs per-tick samples.
-	if i.fallbacks[anchor{addr: f.addr, ip: 0}] == nil {
+	// only one indexed read here. A user profiler still needs per-tick samples.
+	if i.entryFallback(f.addr) == nil {
 		if err := i.observe(f); err != nil {
 			return err
 		}
@@ -1076,10 +1092,18 @@ func (i *Interpreter) exit(root anchor) {
 
 func (i *Interpreter) fallback(root anchor) {
 	i.exit(root)
-	a := anchor{addr: i.fr.addr, ip: 0}
-	if i.fr.ip == 0 && i.fallbacks[a] != nil {
-		i.fallbacks[a](i)
+	if i.fr.ip == 0 {
+		if fn := i.entryFallback(i.fr.addr); fn != nil {
+			fn(i)
+		}
 	}
+}
+
+func (i *Interpreter) entryFallback(addr int) func(*Interpreter) {
+	if addr < 0 || addr >= len(i.entryFallbacks) {
+		return nil
+	}
+	return i.entryFallbacks[addr]
 }
 
 // deopt rebuilds VM frames from the native journal after a trap. Native frames
@@ -1460,6 +1484,9 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	if addr >= len(i.code) {
 		i.code = append(i.code, make([][]func(*Interpreter), n-len(i.code))...)
 	}
+	if addr >= len(i.entryFallbacks) {
+		i.entryFallbacks = append(i.entryFallbacks, make([]func(*Interpreter), n-len(i.entryFallbacks))...)
+	}
 	if addr >= len(i.handlers) {
 		i.handlers = append(i.handlers, make([][]instr.Handler, n-len(i.handlers))...)
 	}
@@ -1488,6 +1515,7 @@ func (i *Interpreter) remove(addr int) {
 	}
 	i.instrs[addr] = nil
 	i.code[addr] = nil
+	i.entryFallbacks[addr] = nil
 	i.handlers[addr] = nil
 	i.coros[addr] = false
 	for a := range i.fallbacks {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -222,9 +222,19 @@ func (c *compiler) emit(i *Interpreter, addr int, fn *types.Function, mod *modul
 	if i.tracer == nil {
 		return false, nil
 	}
+	anchors := i.tracer.anchors(addr)
+	if len(anchors) == 0 {
+		return false, nil
+	}
+	funcs := map[int]*types.Function{}
+	for addr := range i.instrs {
+		if fn, ok := i.function(addr); ok {
+			funcs[addr] = fn
+		}
+	}
 	any := false
-	for _, ip := range i.tracer.anchors(addr) {
-		ok, err := c.emitRoot(i, addr, fn, mod, anchor{addr: addr, ip: ip})
+	for _, ip := range anchors {
+		ok, err := c.emitRoot(i, addr, fn, mod, anchor{addr: addr, ip: ip}, funcs)
 		if err != nil {
 			return false, err
 		}
@@ -237,7 +247,7 @@ func (c *compiler) emit(i *Interpreter, addr int, fn *types.Function, mod *modul
 // callable keyed by a. An entry root (a.ip == 0) compiles the whole function
 // from a clean frame; a loop root compiles one iteration with a native
 // back-edge re-entered mid-function at a.ip.
-func (c *compiler) emitRoot(i *Interpreter, addr int, fn *types.Function, mod *module, a anchor) (bool, error) {
+func (c *compiler) emitRoot(i *Interpreter, addr int, fn *types.Function, mod *module, a anchor, funcs map[int]*types.Function) (bool, error) {
 	tree := i.tracer.rootAt(a)
 	if tree == nil {
 		return false, nil
@@ -253,12 +263,6 @@ func (c *compiler) emitRoot(i *Interpreter, addr int, fn *types.Function, mod *m
 	}
 	if len(c.scratchRegs) < scratchCount {
 		return false, nil
-	}
-	funcs := map[int]*types.Function{}
-	for addr := range i.instrs {
-		if fn, ok := i.function(addr); ok {
-			funcs[addr] = fn
-		}
 	}
 	asmb := asm.New(c.arch)
 	entry := asmb.Label()

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -257,11 +257,12 @@ func (r *Tracer) clone(i *Interpreter) Interpreter {
 	out.hook = nil
 	out.threshold = -1
 
-	out.constants = append([]types.Boxed(nil), i.constants...)
+	out.constants = i.constants
 	out.globals = append([]types.Boxed(nil), i.globals...)
-	out.instrs = append([][]byte(nil), i.instrs...)
+	out.instrs = i.instrs
 	out.code = r.codes(i)
 	out.fallbacks = map[anchor]func(*Interpreter){}
+	out.entryFallbacks = make([]func(*Interpreter), len(out.code))
 	out.journal = append([]uint64(nil), i.journal...)
 	out.frames = append([]frame(nil), i.frames...)
 	out.stack = append([]types.Boxed(nil), i.stack...)


### PR DESCRIPTION
## Summary

- Reduce warm JIT/interpreter coordination overhead without changing public APIs.
- Replace the hot warm-entry `fallbacks[anchor{addr, 0}]` map lookup with a dense per-function entry fallback slice.
- Skip the threaded-loop safepoint call when it would be a no-op: no cancellation channel, fuel, hook, profiler, or shared cache coordination is active and the current function already has a native entry installed.
- Trim compile/trace setup work by aliasing read-only trace clone state and building the JIT function map once per emit instead of once per root.
- Update benchmark docs with current-only `BenchmarkJITIssue101` results.

## Why

`BenchmarkJITIssue101` is a branch-heavy batch workload with many tiny tree-score functions over a mutable `f64` feature row. After traces are installed, the remaining cost was dominated by interpreter coordination rather than useful VM work. The prior profile showed `safepoint` and `runtime.mapaccess1` as the main overhead on the JIT path.

This keeps the existing design intact: the threaded interpreter remains the correctness source, JIT behavior stays speculative with fallback, and ARM64-specific lowering remains unchanged.

## Results

Measured on `darwin/arm64`, Apple M4 Pro:

| Benchmark | Mode | ns/op | B/op | allocs/op |
|---|---|---:|---:|---:|
| `BenchmarkJITIssue101` | threaded | 1,807 | 0 | 0 |
| `BenchmarkJITIssue101` | JIT | 1,203 | 0 | 0 |

Additional checks:

- `BenchmarkJITIssue60` remained within expected noise; focused A/B for `closure_counter_loop/jit` was 1,076 ns/op on this branch vs 1,132 ns/op on `main` under the same command.
- `BenchmarkFib35/minivm_jit` remained around 49 ms/op under the planned regression command.
- Follow-up pprof showed `safepoint` at 0.65% cumulative and removed `runtime.mapaccess1` as the JIT coordination hotspot.

## Validation

- `make lint`
- `go test -count=1 -race ./interp ./asm/...`
- `go test -count=1 ./...`
- `cd benchmarks && go test -run='^$' -bench='BenchmarkJITIssue101/(interp|jit)$' -benchmem -benchtime=3s ./...`
- `cd benchmarks && go test -run='^$' -bench='BenchmarkJITIssue60|BenchmarkFib35/minivm_(interp|jit)$' -benchmem -benchtime=3s ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an ARM64 JIT benchmarks subsection with a new workload example and clearer threaded-vs-JIT comparison.

* **Performance Improvements**
  * Improved interpreter cancellation handling for lower overhead during long-running execution.
  * Reduced JIT/trace startup work by skipping compilation steps when no trace anchors are available.

* **Bug Fixes**
  * Enhanced entry fallback behavior during tracing and JIT warmup to improve entry-path resolution and fallback checks.

* **Refactor**
  * Improved interpreter state setup during trace cloning to reduce unnecessary allocations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->