### PR TITLE
refactor(analysis): order GVN declarations

### DIFF
--- a/analysis/gvn.go
+++ b/analysis/gvn.go
@@ -106,6 +106,27 @@ func NewGlobalValueNumberingAnalysis() *GlobalValueNumberingAnalysis {
 	return &GlobalValueNumberingAnalysis{}
 }
 
+func (a *GlobalValueNumberingAnalysis) Run(m *pass.Manager, fn *types.Function) (*GlobalValueNumbering, error) {
+	blocks, err := pass.GetResult[[]*BasicBlock](m, fn)
+	if err != nil {
+		return nil, err
+	}
+
+	g := newGNumbering(fn, blocks)
+	for block, blk := range blocks {
+		g.reset(block)
+		for ip := blk.Start; ip < blk.End; {
+			inst := instr.Instruction(fn.Code[ip:])
+			if !g.step(ip, inst) {
+				break
+			}
+			ip += inst.Width()
+		}
+	}
+	g.available()
+	return g.out, nil
+}
+
 func newGNumbering(fn *types.Function, blocks []*BasicBlock) *gnumbering {
 	var locals []types.Type
 	if fn.Typ != nil {
@@ -136,27 +157,6 @@ func newGNumbering(fn *types.Function, blocks []*BasicBlock) *gnumbering {
 		keys:   map[string]int{},
 		gen:    make([]map[int]gcompute, len(blocks)),
 	}
-}
-
-func (a *GlobalValueNumberingAnalysis) Run(m *pass.Manager, fn *types.Function) (*GlobalValueNumbering, error) {
-	blocks, err := pass.GetResult[[]*BasicBlock](m, fn)
-	if err != nil {
-		return nil, err
-	}
-
-	g := newGNumbering(fn, blocks)
-	for block, blk := range blocks {
-		g.reset(block)
-		for ip := blk.Start; ip < blk.End; {
-			inst := instr.Instruction(fn.Code[ip:])
-			if !g.step(ip, inst) {
-				break
-			}
-			ip += inst.Width()
-		}
-	}
-	g.available()
-	return g.out, nil
 }
 
 // available converts every block-first computation of an already-available value


### PR DESCRIPTION
## Summary

- move the private `newGNumbering` constructor below the exported `Run` method
- keep exported API declarations before private implementation details in `analysis/gvn.go`
- preserve the existing GVN behavior with a declaration-order-only refactor

Fixes #124

## Testing

Not run locally; repository checkout/test execution was not available in this environment. Verified the GitHub compare only changes `analysis/gvn.go` with a small declaration move.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure without changing behavior.
  * Moved a core analysis routine to a different location for easier maintenance.
  * No user-facing functionality or output was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->