### PR TITLE
refactor(analysis): rename GVN state constructor

### DIFF
--- a/analysis/gvn.go
+++ b/analysis/gvn.go
@@ -112,7 +112,7 @@ func (a *GlobalValueNumberingAnalysis) Run(m *pass.Manager, fn *types.Function) 
 		return nil, err
 	}
 
-	g := newGNumbering(fn, blocks)
+	g := newNumbering(fn, blocks)
 	for block, blk := range blocks {
 		g.reset(block)
 		for ip := blk.Start; ip < blk.End; {
@@ -127,7 +127,7 @@ func (a *GlobalValueNumberingAnalysis) Run(m *pass.Manager, fn *types.Function) 
 	return g.out, nil
 }
 
-func newGNumbering(fn *types.Function, blocks []*BasicBlock) *gnumbering {
+func newNumbering(fn *types.Function, blocks []*BasicBlock) *gnumbering {
 	var locals []types.Type
 	if fn.Typ != nil {
 		locals = append(locals, fn.Typ.Params...)


### PR DESCRIPTION
## Summary

- rename the private `newGNumbering` helper to `newNumbering`
- keep the name focused on the helper's role within `analysis/gvn.go` instead of repeating the GVN/file context
- leave behavior unchanged

Stacked on #127 so the diff stays limited to the naming convention follow-up.

## Testing

Not run locally; repository checkout/test execution was not available in this environment. Verified with compare that this branch only changes two call/definition lines in `analysis/gvn.go`.