### PR TITLE
fix(jit): harden branch-heavy ARM64 traces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,6 +166,7 @@ Violations cause silent corruption or invalid execution.
 - On JIT type mismatch or unsupported lowering, return `false` without mutating IR, stack, params, facts, or labels.
 - Executable buffers must follow `Unseal -> Append -> Seal -> Call`; `Seal()` must sync the instruction cache on Darwin/ARM64.
 - Offset-preserving passes must preserve byte offsets; `GlobalValueNumberingPass` and `DeadCodeEliminationPass` are the known exceptions and must repair branches/handlers.
+- `asm.Relaxer.Relax` implementations must return a replacement sequence that is already in range; `asm.Assembler.encode`'s fixpoint loop relies on this to relax each branch at most once and terminate.
 
 ## Tests
 

--- a/analysis/blocks.go
+++ b/analysis/blocks.go
@@ -29,6 +29,15 @@ func NewBasicBlocksAnalysis() *BasicBlocksAnalysis {
 
 func (p *BasicBlocksAnalysis) Run(m *pass.Manager, fn *types.Function) ([]*BasicBlock, error) {
 	offsets := []int{0}
+	mark := func(ip, target int) error {
+		if target < 0 || target > len(fn.Code) {
+			return invalidJumpError(ip, target)
+		}
+		if target < len(fn.Code) {
+			offsets = append(offsets, target)
+		}
+		return nil
+	}
 	for ip := 0; ip < len(fn.Code); {
 		inst := instr.Instruction(fn.Code[ip:])
 		next := ip + inst.Width()
@@ -39,10 +48,9 @@ func (p *BasicBlocksAnalysis) Run(m *pass.Manager, fn *types.Function) ([]*Basic
 			}
 		case instr.BR, instr.BR_IF:
 			offset := ip + inst.Width() + instr.ReadI16(inst.Operand(0))
-			if offset < 0 || offset >= len(fn.Code) {
-				return nil, invalidJumpError(ip, offset)
+			if err := mark(ip, offset); err != nil {
+				return nil, err
 			}
-			offsets = append(offsets, offset)
 			if next < len(fn.Code) {
 				offsets = append(offsets, next)
 			}
@@ -51,16 +59,14 @@ func (p *BasicBlocksAnalysis) Run(m *pass.Manager, fn *types.Function) ([]*Basic
 			count := int(operands[0])
 			for j := range count {
 				offset := ip + inst.Width() + instr.ReadI16(operands[j+1])
-				if offset < 0 || offset >= len(fn.Code) {
-					return nil, invalidJumpError(ip, offset)
+				if err := mark(ip, offset); err != nil {
+					return nil, err
 				}
-				offsets = append(offsets, offset)
 			}
 			offset := ip + inst.Width() + instr.ReadI16(operands[len(operands)-1])
-			if offset < 0 || offset >= len(fn.Code) {
-				return nil, invalidJumpError(ip, offset)
+			if err := mark(ip, offset); err != nil {
+				return nil, err
 			}
-			offsets = append(offsets, offset)
 		default:
 		}
 		ip = next
@@ -153,6 +159,10 @@ func (p *BasicBlocksAnalysis) Run(m *pass.Manager, fn *types.Function) ([]*Basic
 }
 
 func (p *BasicBlocksAnalysis) link(blocks []*BasicBlock, indexByStart map[int]int, src, dst int) bool {
+	// The past-the-end offset is a virtual exit, not an empty basic block.
+	if dst == blocks[len(blocks)-1].End {
+		return true
+	}
 	if i, ok := indexByStart[dst]; ok {
 		blocks[src].Succs = append(blocks[src].Succs, i)
 		blocks[i].Preds = append(blocks[i].Preds, src)

--- a/analysis/blocks_test.go
+++ b/analysis/blocks_test.go
@@ -238,6 +238,18 @@ func TestBasicBlocksAnalysis_Run(t *testing.T) {
 			},
 		},
 		{
+			name: "branch to virtual exit",
+			fn: types.NewFunctionBuilder(nil).Emit(
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.BR_IF, 5),
+				instr.New(instr.I32_CONST, 2),
+			).MustBuild(),
+			blocks: []*BasicBlock{
+				{Start: 0, End: 8, Succs: []int{1}, Preds: nil},
+				{Start: 8, End: 13, Succs: nil, Preds: []int{0}},
+			},
+		},
+		{
 			name: "invalid br target after map lookup",
 			fn: types.NewFunctionBuilder(nil).Emit(
 				instr.New(instr.BR, 100),

--- a/asm/arch.go
+++ b/asm/arch.go
@@ -80,7 +80,9 @@ type Frame interface {
 // buffer. Implementations are produced by ABI.NewCallable and returned from
 // Link.
 type Callable interface {
-	Call(ctx uintptr) error
+	// Call invokes the native entry with ctx as its architecture-specific
+	// context. ctx must remain valid until Call returns.
+	Call(ctx unsafe.Pointer) error
 }
 
 var (

--- a/asm/arch.go
+++ b/asm/arch.go
@@ -29,6 +29,20 @@ type ABI interface {
 	NewCallable(addr unsafe.Pointer) (Callable, error)
 }
 
+// Relaxer is an optional Arch capability implemented by architectures that
+// can rewrite a branch instruction with an out-of-range immediate
+// displacement into an equivalent multi-instruction sequence that fits.
+// Assembler.encode type-asserts Arch for Relaxer and, when present, runs a
+// fixpoint pass over intra-Code label branches before final encoding.
+type Relaxer interface {
+	// Relax inspects a PC-relative label-branch instruction and its
+	// resolved byte displacement (target - instruction address). It
+	// returns a replacement instruction sequence when disp does not fit
+	// the immediate field encoded by inst, and false when inst is not a
+	// label branch or the displacement already fits.
+	Relax(inst Instruction, disp int64) ([]Instruction, bool)
+}
+
 // Frame is an optional Arch capability that supplies the instructions a
 // spilling register allocator injects when the physical register bank is
 // exhausted. The allocator reserves a stack spill area at entry, moves
@@ -48,6 +62,9 @@ type Frame interface {
 	// Leave releases the spill area. Emitted immediately before every
 	// instruction Returns reports true for. Returns nil when slots == 0.
 	Leave(slots int) []Instruction
+	// Resume reserves the spill area again after an intra-Code call returns
+	// through the shared epilogue. It must preserve the current spill base.
+	Resume(slots int) []Instruction
 	// Store writes reg into spill slot.
 	Store(slot int, reg PReg) Instruction
 	// Reload reads spill slot into reg.
@@ -55,6 +72,8 @@ type Frame interface {
 	// Returns reports whether op transfers control out of the callable, so
 	// the allocator must restore the stack with Leave before it.
 	Returns(op uint16) bool
+	// Calls reports whether op calls another label in the same Code.
+	Calls(op uint16) bool
 }
 
 // Callable is a fully linked, directly invokable entry into the executable
@@ -65,7 +84,8 @@ type Callable interface {
 }
 
 var (
-	ErrNotImplemented = errors.New("not implemented")
-	ErrInvalidOperand = errors.New("invalid operand")
-	ErrInvalidArgs    = errors.New("invalid arguments")
+	ErrNotImplemented   = errors.New("not implemented")
+	ErrInvalidOperand   = errors.New("invalid operand")
+	ErrInvalidArgs      = errors.New("invalid arguments")
+	ErrBranchOutOfRange = errors.New("branch offset out of range")
 )

--- a/asm/arm64/abi.go
+++ b/asm/arm64/abi.go
@@ -24,7 +24,7 @@ func (abi) NewCallable(addr unsafe.Pointer) (asm.Callable, error) {
 	return &caller{addr: addr}, nil
 }
 
-func (c *caller) Call(ctx uintptr) error {
+func (c *caller) Call(ctx unsafe.Pointer) error {
 	invoke(uintptr(c.addr), ctx)
 	return nil
 }

--- a/asm/arm64/abi_arm64.go
+++ b/asm/arm64/abi_arm64.go
@@ -2,5 +2,9 @@
 
 package arm64
 
+import "unsafe"
+
 // invoke calls the compiled native block at addr with ctx passed in X0.
-func invoke(addr uintptr, ctx uintptr)
+//
+//go:noescape
+func invoke(addr uintptr, ctx unsafe.Pointer)

--- a/asm/arm64/abi_arm64.s
+++ b/asm/arm64/abi_arm64.s
@@ -1,19 +1,26 @@
 #include "textflag.h"
 
-// func invoke(addr uintptr, ctx uintptr)
+// func invoke(addr uintptr, ctx unsafe.Pointer)
 //
 // ctx is passed to native code in R0. R19-R26 are callee-saved under AAPCS64
 // and used by the JIT allocator, so the Go trampoline preserves them.
+// The frame also reserves 4096 spill bytes plus 4096 bytes for generated calls.
+// Native code starts at the top of that reserve and may move SP downward
+// without crossing the Go stack frame or bypassing Go's stack-growth check.
 // Note: R18 is reserved by the Go toolchain; never use it.
 
-TEXT ·invoke(SB), NOSPLIT, $80-16
+TEXT ·invoke(SB), $8272-16
     STP  (R19, R20),  8(RSP)
     STP  (R21, R22), 24(RSP)
     STP  (R23, R24), 40(RSP)
     STP  (R25, R26), 56(RSP)
     MOVD addr+0(FP), R9
     MOVD ctx+8(FP), R0
+    ADD  $8192, RSP
+    ADD  $80, RSP
     BL   (R9)
+    SUB  $80, RSP
+    SUB  $8192, RSP
     LDP   8(RSP), (R19, R20)
     LDP  24(RSP), (R21, R22)
     LDP  40(RSP), (R23, R24)

--- a/asm/arm64/abi_arm64_test.go
+++ b/asm/arm64/abi_arm64_test.go
@@ -1,0 +1,48 @@
+//go:build arm64
+
+package arm64
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/siyul-park/minivm/asm"
+)
+
+func TestNew(t *testing.T) {
+	a := asm.New(New())
+	ctx := a.Reg(asm.RegTypeInt, asm.Width64)
+	left := a.Reg(asm.RegTypeInt, asm.Width64)
+	right := a.Reg(asm.RegTypeInt, asm.Width64)
+	result := a.Reg(asm.RegTypeInt, asm.Width64)
+	require.NoError(t, a.Pin(ctx, X0))
+	a.Emit(LDR(left, ctx, 0))
+	a.Emit(LDR(right, ctx, 8))
+	a.Emit(ADD(result, left, right))
+	a.Emit(STR(result, ctx, 16))
+	a.Emit(RET())
+
+	code, err := a.Build()
+	require.NoError(t, err)
+	buf, err := asm.NewBuffer(4096)
+	require.NoError(t, err)
+	defer buf.Free()
+	linked, err := asm.Link(buf, New(), []*asm.Code{code}, nil)
+	require.NoError(t, err)
+	// Use the concrete caller so escape analysis keeps the fresh goroutine's
+	// context on its stack while invoke grows and relocates that stack.
+	callable, ok := linked[0].Callable.(*caller)
+	require.True(t, ok)
+
+	errs := make(chan error, 1)
+	done := make(chan [3]uint64, 1)
+	go func() {
+		ctx := [3]uint64{20, 22}
+		errs <- callable.Call(unsafe.Pointer(&ctx[0]))
+		done <- ctx
+	}()
+	require.NoError(t, <-errs)
+	require.Equal(t, [3]uint64{20, 22, 42}, <-done)
+}

--- a/asm/arm64/abi_stub.go
+++ b/asm/arm64/abi_stub.go
@@ -2,6 +2,8 @@
 
 package arm64
 
-func invoke(addr uintptr, ctx uintptr) {
+import "unsafe"
+
+func invoke(addr uintptr, ctx unsafe.Pointer) {
 	panic("not implemented")
 }

--- a/asm/arm64/arch.go
+++ b/asm/arm64/arch.go
@@ -10,6 +10,7 @@ type arch struct {
 }
 
 var _ asm.Arch = arch{}
+var _ asm.Relaxer = arch{}
 
 // New returns an asm.Arch targeting ARM64. The arch's encoder, ABI, and
 // frame are stateless singletons; allocate once per process.
@@ -28,9 +29,9 @@ func New() asm.Arch {
 			[]uint8{8, 9, 10, 11, 12, 13, 14, 15},
 			// X10-X14: pinned VM context registers. X0-X1: internal
 			// native return registers. X15: pinned native call-depth
-			// register. Pinning can claim them explicitly; auto-allocation
-			// cannot.
-			[]uint8{0, 1, 10, 11, 12, 13, 14, 15},
+			// register. X26: stable spill-frame base across native calls.
+			// Pinning can claim them explicitly; auto-allocation cannot.
+			[]uint8{0, 1, 10, 11, 12, 13, 14, 15, 26},
 		),
 		encoder: NewEncoder(),
 		abi:     abi{},

--- a/asm/arm64/encoder.go
+++ b/asm/arm64/encoder.go
@@ -760,11 +760,17 @@ func (e *Encoder) Encode(inst asm.Instruction) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := checkBranchOffset(offset, 26); err != nil {
+			return nil, err
+		}
 		return enc(0x14000000 | (uint32(offset/4) & 0x3FFFFFF)), nil
 
 	case OpBL:
 		offset, err := e.decodeBranch(inst)
 		if err != nil {
+			return nil, err
+		}
+		if err := checkBranchOffset(offset, 26); err != nil {
 			return nil, err
 		}
 		return enc(0x94000000 | (uint32(offset/4) & 0x3FFFFFF)), nil
@@ -806,6 +812,9 @@ func (e *Encoder) Encode(inst asm.Instruction) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err := checkBranchOffset(offset, 19); err != nil {
+			return nil, err
+		}
 		imm19 := (uint32(offset/4) & 0x7FFFF) << 5
 		return enc(base | imm19 | reg(r)), nil
 
@@ -816,6 +825,9 @@ func (e *Encoder) Encode(inst asm.Instruction) ([]byte, error) {
 		}
 		base, err := intBase(0xB5000000, r)
 		if err != nil {
+			return nil, err
+		}
+		if err := checkBranchOffset(offset, 19); err != nil {
 			return nil, err
 		}
 		imm19 := (uint32(offset/4) & 0x7FFFF) << 5
@@ -833,6 +845,9 @@ func (e *Encoder) Encode(inst asm.Instruction) ([]byte, error) {
 		if err := validTestBit(r, bit); err != nil {
 			return nil, err
 		}
+		if err := checkBranchOffset(offset, 14); err != nil {
+			return nil, err
+		}
 		b5 := (uint32(bit) >> 5) & 1 // b5 lives in bit 31
 		b40 := uint32(bit) & 0x1F    // b40 lives in bits[23:19]
 		imm14 := (uint32(offset/4) & 0x3FFF) << 5
@@ -844,6 +859,9 @@ func (e *Encoder) Encode(inst asm.Instruction) ([]byte, error) {
 			return nil, err
 		}
 		if err := validTestBit(r, bit); err != nil {
+			return nil, err
+		}
+		if err := checkBranchOffset(offset, 14); err != nil {
 			return nil, err
 		}
 		b5 := (uint32(bit) >> 5) & 1
@@ -859,6 +877,9 @@ func (e *Encoder) Encode(inst asm.Instruction) ([]byte, error) {
 		OpBVS, OpBVC, OpBHI, OpBLS, OpBGE, OpBLT, OpBGT, OpBLE:
 		offset, err := e.decodeBranch(inst)
 		if err != nil {
+			return nil, err
+		}
+		if err := checkBranchOffset(offset, 19); err != nil {
 			return nil, err
 		}
 		cond := condCode[op]
@@ -1396,6 +1417,24 @@ func (e *Encoder) decodeTestBranch(inst asm.Instruction) (r asm.PReg, bit uint8,
 	}
 	packed := immOp.Value
 	return rOp.Reg, uint8(packed & 0xFF), packed >> 8, nil
+}
+
+// checkBranchOffset validates that offset is 4-byte aligned and its
+// instruction-count (offset/4) fits the signed bits-wide immediate field
+// used by a PC-relative branch encoding. Every branch/compare-branch/
+// test-branch case masks its offset into a fixed-width field; without this
+// check an out-of-range offset silently truncates instead of failing,
+// producing a branch to the wrong target.
+func checkBranchOffset(offset int64, bits uint) error {
+	if offset%4 != 0 {
+		return asm.ErrBranchOutOfRange
+	}
+	units := offset / 4
+	half := int64(1) << (bits - 1)
+	if units < -half || units >= half {
+		return asm.ErrBranchOutOfRange
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/asm/arm64/encoder_test.go
+++ b/asm/arm64/encoder_test.go
@@ -144,6 +144,11 @@ func TestEncoder_Encode(t *testing.T) {
 			{"unencodable logical immediate", ANDI(X1, X2, 0), ErrMissingImmediate},
 			{"int destination for SCVTF", SCVTF(X1, X2), asm.ErrInvalidOperand},
 			{"float source for CLZ", CLZ(X1, D2), asm.ErrInvalidOperand},
+			{"B offset unaligned", B(2), asm.ErrBranchOutOfRange},
+			{"B offset exceeds imm26", B(1 << 27), asm.ErrBranchOutOfRange},
+			{"BEQ offset exceeds imm19", BEQ(1 << 21), asm.ErrBranchOutOfRange},
+			{"CBZ offset exceeds imm19", CBZ(X1, 1<<21), asm.ErrBranchOutOfRange},
+			{"TBZ offset exceeds imm14", TBZ(X1, 3, 1<<17), asm.ErrBranchOutOfRange},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {

--- a/asm/arm64/frame.go
+++ b/asm/arm64/frame.go
@@ -3,9 +3,9 @@ package arm64
 import "github.com/siyul-park/minivm/asm"
 
 // frame implements asm.Frame so the shared register allocator can spill to a
-// stack-pointer-relative frame. Native code may make framed self-calls, but
-// those calls save and restore SP around the branch. The VM garbage collector
-// never runs while native code holds the stack.
+// native stack frame. X26 holds its stable base because native self-calls move
+// SP while saving their LR and VM frame state. The invoke trampoline preserves
+// X26, and arch excludes it from automatic allocation.
 //
 // The load/store and add/subtract-immediate forms used here read register
 // field 31 as SP, so they emit against the SP alias rather than SP (same
@@ -24,6 +24,17 @@ const (
 // Enter reserves the spill area. SP updates stay within ARM64's unshifted
 // add/sub immediate range while preserving 16-byte alignment after every step.
 func (frame) Enter(slots int) []asm.Instruction {
+	out := frame{}.Resume(slots)
+	if len(out) == 0 {
+		return nil
+	}
+	return append(out, ADDI(X26, SP, 0))
+}
+
+// Resume reserves the spill area after an intra-code call returned through
+// the shared epilogue. It leaves spillBase unchanged so stores and reloads
+// around the call keep addressing the outer activation's slots.
+func (frame) Resume(slots int) []asm.Instruction {
 	if slots <= 0 {
 		return nil
 	}
@@ -58,19 +69,24 @@ func (frame) Leave(slots int) []asm.Instruction {
 	return out
 }
 
-// Store spills reg to slot: STR reg, [SP, #slot*8].
+// Store spills reg to slot relative to the stable spill base.
 func (frame) Store(slot int, reg asm.PReg) asm.Instruction {
-	return STR(spillReg(reg), SP, int16(slot*spillSlotBytes))
+	return STR(spillReg(reg), X26, int16(slot*spillSlotBytes))
 }
 
-// Reload fills reg from slot: LDR reg, [SP, #slot*8].
+// Reload fills reg from a slot relative to the stable spill base.
 func (frame) Reload(reg asm.PReg, slot int) asm.Instruction {
-	return LDR(spillReg(reg), SP, int16(slot*spillSlotBytes))
+	return LDR(spillReg(reg), X26, int16(slot*spillSlotBytes))
 }
 
 // Returns reports whether op is the native return.
 func (frame) Returns(op uint16) bool {
 	return Op(op) == OpRET
+}
+
+// Calls reports whether op is an ARM64 branch with link.
+func (frame) Calls(op uint16) bool {
+	return Op(op) == OpBL
 }
 
 // spillReg widens reg to its 64-bit view so a full slot is stored and

--- a/asm/arm64/frame_test.go
+++ b/asm/arm64/frame_test.go
@@ -12,7 +12,12 @@ func TestFrame(t *testing.T) {
 		require.Equal(t, []asm.Instruction{
 			SUBI(SP, SP, maxFrameAdjust),
 			SUBI(SP, SP, 16),
+			ADDI(X26, SP, 0),
 		}, frame{}.Enter(512))
+		require.Equal(t, []asm.Instruction{
+			SUBI(SP, SP, maxFrameAdjust),
+			SUBI(SP, SP, 16),
+		}, frame{}.Resume(512))
 		require.Equal(t, []asm.Instruction{
 			ADDI(SP, SP, maxFrameAdjust),
 			ADDI(SP, SP, 16),

--- a/asm/arm64/relax.go
+++ b/asm/arm64/relax.go
@@ -8,31 +8,6 @@ import "github.com/siyul-park/minivm/asm"
 // itself, so clearing one 4-byte instruction needs +8.
 const skipDisp = 8
 
-// invCond maps each AArch64 conditional-branch opcode to its logical
-// inverse: EQ<->NE, CS<->CC, MI<->PL, VS<->VC, HI<->LS, GE<->LT, GT<->LE.
-var invCond = map[Op]Op{
-	OpBEQ: OpBNE, OpBNE: OpBEQ,
-	OpBCS: OpBCC, OpBCC: OpBCS,
-	OpBMI: OpBPL, OpBPL: OpBMI,
-	OpBVS: OpBVC, OpBVC: OpBVS,
-	OpBHI: OpBLS, OpBLS: OpBHI,
-	OpBGE: OpBLT, OpBLT: OpBGE,
-	OpBGT: OpBLE, OpBLE: OpBGT,
-}
-
-// relaxRangeBits maps each label-branch opcode Relax handles to the bit
-// width of its PC-relative immediate field, matching the widths
-// encoder.go's checkBranchOffset validates for the same opcodes. TBZ/TBNZ
-// are absent: instr.go never exposes a label-carrying constructor for
-// them (TBZ/TBNZ always take a caller-computed immediate offset), so they
-// never reach Relax with a LabelOperand and need no entry here.
-var relaxRangeBits = map[Op]uint{
-	OpBEQ: 19, OpBNE: 19, OpBCS: 19, OpBCC: 19, OpBMI: 19, OpBPL: 19,
-	OpBVS: 19, OpBVC: 19, OpBHI: 19, OpBLS: 19, OpBGE: 19, OpBLT: 19,
-	OpBGT: 19, OpBLE: 19,
-	OpCBZ: 19, OpCBNZ: 19,
-}
-
 // Relax implements asm.Relaxer for arm64. For B.cond and CBZ/CBNZ label
 // branches whose imm19 field (+-1MB) does not fit disp, it rewrites the
 // branch into an inverted-condition branch that skips over an
@@ -45,11 +20,11 @@ var relaxRangeBits = map[Op]uint{
 // (the skip branch's displacement is a fixed 8 bytes; the B's range is
 // checked before committing), so a branch relaxes at most once.
 func (a arch) Relax(inst asm.Instruction, disp int64) ([]asm.Instruction, bool) {
-	bits, ok := relaxRangeBits[Op(inst.Op)]
+	skip, ok := invertBranch(inst)
 	if !ok {
 		return nil, false
 	}
-	if checkBranchOffset(disp, bits) == nil {
+	if checkBranchOffset(disp, 19) == nil {
 		return nil, false
 	}
 
@@ -69,10 +44,6 @@ func (a arch) Relax(inst asm.Instruction, disp int64) ([]asm.Instruction, bool) 
 		return nil, false
 	}
 
-	skip, ok := invertBranch(inst)
-	if !ok {
-		return nil, false
-	}
 	return []asm.Instruction{skip, BLabel(lbl.ID)}, true
 }
 
@@ -87,11 +58,35 @@ func invertBranch(inst asm.Instruction) (asm.Instruction, bool) {
 		return asm.Instruction{Op: uint16(OpCBNZ), Src1: inst.Src1, Src2: asm.Imm(skipDisp)}, true
 	case OpCBNZ:
 		return asm.Instruction{Op: uint16(OpCBZ), Src1: inst.Src1, Src2: asm.Imm(skipDisp)}, true
+	case OpBEQ:
+		return BNE(skipDisp), true
+	case OpBNE:
+		return BEQ(skipDisp), true
+	case OpBCS:
+		return BCC(skipDisp), true
+	case OpBCC:
+		return BCS(skipDisp), true
+	case OpBMI:
+		return BPL(skipDisp), true
+	case OpBPL:
+		return BMI(skipDisp), true
+	case OpBVS:
+		return BVC(skipDisp), true
+	case OpBVC:
+		return BVS(skipDisp), true
+	case OpBHI:
+		return BLS(skipDisp), true
+	case OpBLS:
+		return BHI(skipDisp), true
+	case OpBGE:
+		return BLT(skipDisp), true
+	case OpBLT:
+		return BGE(skipDisp), true
+	case OpBGT:
+		return BLE(skipDisp), true
+	case OpBLE:
+		return BGT(skipDisp), true
 	default:
-		inv, ok := invCond[Op(inst.Op)]
-		if !ok {
-			return asm.Instruction{}, false
-		}
-		return asm.Instruction{Op: uint16(inv), Src2: asm.Imm(skipDisp)}, true
+		return asm.Instruction{}, false
 	}
 }

--- a/asm/arm64/relax.go
+++ b/asm/arm64/relax.go
@@ -1,0 +1,97 @@
+package arm64
+
+import "github.com/siyul-park/minivm/asm"
+
+// skipDisp is the fixed forward byte displacement the inverted skip
+// branch Relax emits uses to jump over the single unconditional B that
+// follows it. Branch offsets are relative to the branch instruction
+// itself, so clearing one 4-byte instruction needs +8.
+const skipDisp = 8
+
+// invCond maps each AArch64 conditional-branch opcode to its logical
+// inverse: EQ<->NE, CS<->CC, MI<->PL, VS<->VC, HI<->LS, GE<->LT, GT<->LE.
+var invCond = map[Op]Op{
+	OpBEQ: OpBNE, OpBNE: OpBEQ,
+	OpBCS: OpBCC, OpBCC: OpBCS,
+	OpBMI: OpBPL, OpBPL: OpBMI,
+	OpBVS: OpBVC, OpBVC: OpBVS,
+	OpBHI: OpBLS, OpBLS: OpBHI,
+	OpBGE: OpBLT, OpBLT: OpBGE,
+	OpBGT: OpBLE, OpBLE: OpBGT,
+}
+
+// relaxRangeBits maps each label-branch opcode Relax handles to the bit
+// width of its PC-relative immediate field, matching the widths
+// encoder.go's checkBranchOffset validates for the same opcodes. TBZ/TBNZ
+// are absent: instr.go never exposes a label-carrying constructor for
+// them (TBZ/TBNZ always take a caller-computed immediate offset), so they
+// never reach Relax with a LabelOperand and need no entry here.
+var relaxRangeBits = map[Op]uint{
+	OpBEQ: 19, OpBNE: 19, OpBCS: 19, OpBCC: 19, OpBMI: 19, OpBPL: 19,
+	OpBVS: 19, OpBVC: 19, OpBHI: 19, OpBLS: 19, OpBGE: 19, OpBLT: 19,
+	OpBGT: 19, OpBLE: 19,
+	OpCBZ: 19, OpCBNZ: 19,
+}
+
+// Relax implements asm.Relaxer for arm64. For B.cond and CBZ/CBNZ label
+// branches whose imm19 field (+-1MB) does not fit disp, it rewrites the
+// branch into an inverted-condition branch that skips over an
+// unconditional B to the original target:
+//
+//	B.<inv-cond> +8   ; skip the B below when the original condition is false
+//	B   <target>      ; imm26, +-128MB
+//
+// Both replacement instructions are constructed to already be in range
+// (the skip branch's displacement is a fixed 8 bytes; the B's range is
+// checked before committing), so a branch relaxes at most once.
+func (a arch) Relax(inst asm.Instruction, disp int64) ([]asm.Instruction, bool) {
+	bits, ok := relaxRangeBits[Op(inst.Op)]
+	if !ok {
+		return nil, false
+	}
+	if checkBranchOffset(disp, bits) == nil {
+		return nil, false
+	}
+
+	lbl, ok := inst.Src2.(asm.LabelOperand)
+	if !ok {
+		return nil, false
+	}
+
+	// Forward targets move by the same four bytes as the inserted B, so their
+	// displacement is unchanged. Backward targets stay fixed while the B moves
+	// four bytes forward.
+	bDisp := disp
+	if disp < 0 {
+		bDisp -= 4
+	}
+	if checkBranchOffset(bDisp, 26) != nil {
+		return nil, false
+	}
+
+	skip, ok := invertBranch(inst)
+	if !ok {
+		return nil, false
+	}
+	return []asm.Instruction{skip, BLabel(lbl.ID)}, true
+}
+
+// invertBranch builds the inverted-condition skip branch that precedes
+// the unconditional B Relax emits, preserving inst's register operand
+// (for CBZ/CBNZ) and inverting its condition/comparison sense so control
+// falls through to the B only when the original branch would have been
+// taken.
+func invertBranch(inst asm.Instruction) (asm.Instruction, bool) {
+	switch Op(inst.Op) {
+	case OpCBZ:
+		return asm.Instruction{Op: uint16(OpCBNZ), Src1: inst.Src1, Src2: asm.Imm(skipDisp)}, true
+	case OpCBNZ:
+		return asm.Instruction{Op: uint16(OpCBZ), Src1: inst.Src1, Src2: asm.Imm(skipDisp)}, true
+	default:
+		inv, ok := invCond[Op(inst.Op)]
+		if !ok {
+			return asm.Instruction{}, false
+		}
+		return asm.Instruction{Op: uint16(inv), Src2: asm.Imm(skipDisp)}, true
+	}
+}

--- a/asm/arm64/relax_test.go
+++ b/asm/arm64/relax_test.go
@@ -1,0 +1,88 @@
+package arm64
+
+import (
+	"testing"
+
+	"github.com/siyul-park/minivm/asm"
+	"github.com/stretchr/testify/require"
+)
+
+// TestArch_Relax covers the structural contract of Relax: in-range
+// branches are left alone, out-of-range B.cond/CBZ/CBNZ branches are
+// rewritten into an inverted skip branch plus an in-range unconditional B
+// to the original label, TBZ/TBNZ (which never carry a LabelOperand in
+// this codebase) are never relaxed, and a target so far away that even
+// the replacement B would be out of range is rejected so encode falls
+// back to ErrBranchOutOfRange.
+func TestArch_Relax(t *testing.T) {
+	a := arch{}
+	lbl := asm.Label(7)
+
+	t.Run("in-range branch is left alone", func(t *testing.T) {
+		_, relaxed := a.Relax(BCondLabel(OpBEQ, lbl), 1<<10)
+		require.False(t, relaxed)
+
+		_, relaxed = a.Relax(CBZLabel(X1, lbl), 1<<10)
+		require.False(t, relaxed)
+	})
+
+	t.Run("out-of-range B.cond inverts condition and preserves target", func(t *testing.T) {
+		for op, inv := range invCond {
+			repl, relaxed := a.Relax(BCondLabel(op, lbl), 1<<20)
+			require.True(t, relaxed, op)
+			require.Len(t, repl, 2, op)
+			require.Equal(t, uint16(inv), repl[0].Op, op)
+			require.Equal(t, asm.Imm(skipDisp), repl[0].Src2, op)
+			require.Equal(t, uint16(OpB), repl[1].Op, op)
+			require.Equal(t, asm.LabelOp(lbl), repl[1].Src2, op)
+		}
+	})
+
+	t.Run("out-of-range CBZ/CBNZ inverts comparison and preserves register", func(t *testing.T) {
+		repl, relaxed := a.Relax(CBZLabel(X3, lbl), 1<<20)
+		require.True(t, relaxed)
+		require.Len(t, repl, 2)
+		require.Equal(t, uint16(OpCBNZ), repl[0].Op)
+		require.Equal(t, asm.P(X3), repl[0].Src1)
+		require.Equal(t, asm.Imm(skipDisp), repl[0].Src2)
+		require.Equal(t, uint16(OpB), repl[1].Op)
+		require.Equal(t, asm.LabelOp(lbl), repl[1].Src2)
+
+		repl, relaxed = a.Relax(CBNZLabel(X3, lbl), -(1 << 21))
+		require.True(t, relaxed)
+		require.Equal(t, uint16(OpCBZ), repl[0].Op)
+		require.Equal(t, asm.P(X3), repl[0].Src1)
+	})
+
+	t.Run("TBZ/TBNZ never carry a label operand and are never relaxed", func(t *testing.T) {
+		_, relaxed := a.Relax(TBZ(X1, 3, 1<<17), 1<<17)
+		require.False(t, relaxed)
+
+		_, relaxed = a.Relax(TBNZ(X1, 3, 1<<17), 1<<17)
+		require.False(t, relaxed)
+	})
+
+	t.Run("target beyond the B's own imm26 range is rejected", func(t *testing.T) {
+		_, relaxed := a.Relax(BCondLabel(OpBEQ, lbl), 1<<28)
+		require.False(t, relaxed)
+	})
+
+	t.Run("replacement B observes exact directional imm26 boundaries", func(t *testing.T) {
+		_, relaxed := a.Relax(BCondLabel(OpBEQ, lbl), (1<<27)-4)
+		require.True(t, relaxed)
+
+		_, relaxed = a.Relax(BCondLabel(OpBEQ, lbl), 1<<27)
+		require.False(t, relaxed)
+
+		_, relaxed = a.Relax(BCondLabel(OpBEQ, lbl), -(1<<27)+4)
+		require.True(t, relaxed)
+
+		_, relaxed = a.Relax(BCondLabel(OpBEQ, lbl), -(1 << 27))
+		require.False(t, relaxed)
+	})
+
+	t.Run("non-branch instruction is never relaxed", func(t *testing.T) {
+		_, relaxed := a.Relax(ADD(X1, X2, X3), 1<<20)
+		require.False(t, relaxed)
+	})
+}

--- a/asm/arm64/relax_test.go
+++ b/asm/arm64/relax_test.go
@@ -27,14 +27,23 @@ func TestArch_Relax(t *testing.T) {
 	})
 
 	t.Run("out-of-range B.cond inverts condition and preserves target", func(t *testing.T) {
-		for op, inv := range invCond {
-			repl, relaxed := a.Relax(BCondLabel(op, lbl), 1<<20)
-			require.True(t, relaxed, op)
-			require.Len(t, repl, 2, op)
-			require.Equal(t, uint16(inv), repl[0].Op, op)
-			require.Equal(t, asm.Imm(skipDisp), repl[0].Src2, op)
-			require.Equal(t, uint16(OpB), repl[1].Op, op)
-			require.Equal(t, asm.LabelOp(lbl), repl[1].Src2, op)
+		pairs := [][2]Op{
+			{OpBEQ, OpBNE}, {OpBNE, OpBEQ},
+			{OpBCS, OpBCC}, {OpBCC, OpBCS},
+			{OpBMI, OpBPL}, {OpBPL, OpBMI},
+			{OpBVS, OpBVC}, {OpBVC, OpBVS},
+			{OpBHI, OpBLS}, {OpBLS, OpBHI},
+			{OpBGE, OpBLT}, {OpBLT, OpBGE},
+			{OpBGT, OpBLE}, {OpBLE, OpBGT},
+		}
+		for _, pair := range pairs {
+			repl, relaxed := a.Relax(BCondLabel(pair[0], lbl), 1<<20)
+			require.True(t, relaxed, pair[0])
+			require.Len(t, repl, 2, pair[0])
+			require.Equal(t, uint16(pair[1]), repl[0].Op, pair[0])
+			require.Equal(t, asm.Imm(skipDisp), repl[0].Src2, pair[0])
+			require.Equal(t, uint16(OpB), repl[1].Op, pair[0])
+			require.Equal(t, asm.LabelOp(lbl), repl[1].Src2, pair[0])
 		}
 	})
 

--- a/asm/assembler.go
+++ b/asm/assembler.go
@@ -26,6 +26,7 @@ type Assembler struct {
 	entries  []Label
 	nextVReg int32
 	nextLbl  Label
+	noSpill  bool
 	err      error
 }
 
@@ -67,6 +68,12 @@ func (a *Assembler) Entry(id Label) {
 	a.entries = append(a.entries, id)
 }
 
+// DisableSpilling makes Build return ErrNoRegistersAvailable instead of
+// inserting a spill frame when register pressure exhausts the physical bank.
+func (a *Assembler) DisableSpilling() {
+	a.noSpill = true
+}
+
 // Pin forces v to occupy preg. A vreg can be pinned to only one preg; a
 // conflicting Pin records an error returned from Build.
 func (a *Assembler) Pin(v VReg, preg PReg) error {
@@ -97,7 +104,10 @@ func (a *Assembler) Build() (*Code, error) {
 	}
 
 	rw := newRewriter(a.arch, a.insts, a.pins)
-	rewritten, labels, err := rw.run(a.insts, a.labels)
+	if a.noSpill {
+		rw.frame = nil
+	}
+	rewritten, labels, err := rw.run(a.insts, a.labels, a.entries)
 	if err != nil {
 		return nil, err
 	}
@@ -123,6 +133,11 @@ func (a *Assembler) Build() (*Code, error) {
 // operands and records byte offsets; final patches intra-Code labels and
 // records external labels as relocations.
 func (a *Assembler) encode(insts []Instruction, labels map[Label]int) ([]byte, map[Label]int, []Relocation, error) {
+	insts, labels, err := a.relax(insts, labels)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
 	encoded, offsets, err := a.draft(insts)
 	if err != nil {
 		return nil, nil, nil, err
@@ -138,6 +153,75 @@ func (a *Assembler) encode(insts []Instruction, labels map[Label]int) ([]byte, m
 		return nil, nil, nil, err
 	}
 	return out, pos, relocs, nil
+}
+
+// relax rewrites out-of-range intra-Code label branches into equivalent
+// in-range multi-instruction sequences when the target Arch implements
+// Relaxer. It runs a fixpoint loop: draft the current instruction list to
+// measure offsets, find the first label branch whose Relaxer-reported
+// replacement differs, splice it in, and repeat. Every replacement is
+// constructed by Relax to already be in range (a short in-range skip
+// branch plus, at most, one in-range unconditional branch), so each
+// branch relaxes at most once and the loop terminates after the first
+// full pass that finds nothing left to relax. Architectures without a
+// Relaxer (e.g. amd64) leave insts and labels untouched.
+func (a *Assembler) relax(insts []Instruction, labels map[Label]int) ([]Instruction, map[Label]int, error) {
+	relaxer, ok := a.arch.(Relaxer)
+	if !ok {
+		return insts, labels, nil
+	}
+
+	for {
+		_, offsets, err := a.draft(insts)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		idx, replacement := -1, []Instruction(nil)
+		for i, inst := range insts {
+			lbl, isLabel := inst.Src2.(LabelOperand)
+			if !isLabel {
+				continue
+			}
+			target, intra := labels[lbl.ID]
+			if !intra {
+				continue
+			}
+			disp := int64(offsets[target] - offsets[i])
+			repl, relaxed := relaxer.Relax(inst, disp)
+			if !relaxed {
+				continue
+			}
+			idx, replacement = i, repl
+			break
+		}
+		if idx < 0 {
+			return insts, labels, nil
+		}
+
+		insts, labels = spliceInstruction(insts, labels, idx, replacement)
+	}
+}
+
+// spliceInstruction replaces insts[idx] with replacement and shifts every
+// label bound at or after idx by the resulting length delta, preserving
+// every label's logical position in the rewritten stream.
+func spliceInstruction(insts []Instruction, labels map[Label]int, idx int, replacement []Instruction) ([]Instruction, map[Label]int) {
+	delta := len(replacement) - 1
+
+	out := make([]Instruction, 0, len(insts)+delta)
+	out = append(out, insts[:idx]...)
+	out = append(out, replacement...)
+	out = append(out, insts[idx+1:]...)
+
+	newLabels := make(map[Label]int, len(labels))
+	for id, pos := range labels {
+		if pos > idx {
+			pos += delta
+		}
+		newLabels[id] = pos
+	}
+	return out, newLabels
 }
 
 // draft encodes each instruction with #0 substituted for label operands so

--- a/asm/assembler.go
+++ b/asm/assembler.go
@@ -204,8 +204,8 @@ func (a *Assembler) relax(insts []Instruction, labels map[Label]int) ([]Instruct
 }
 
 // spliceInstruction replaces insts[idx] with replacement and shifts every
-// label bound at or after idx by the resulting length delta, preserving
-// every label's logical position in the rewritten stream.
+// label bound after idx by the resulting length delta, preserving every
+// label's logical position in the rewritten stream.
 func spliceInstruction(insts []Instruction, labels map[Label]int, idx int, replacement []Instruction) ([]Instruction, map[Label]int) {
 	delta := len(replacement) - 1
 

--- a/asm/assembler_test.go
+++ b/asm/assembler_test.go
@@ -49,9 +49,9 @@ func TestAssembler_Build(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, linked, 1)
 
-		ctxBuf := []uint64{3, 4, 0}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&ctxBuf[0]))))
-		require.Equal(t, []uint64{3, 4, 7}, ctxBuf)
+		ctxBuf := [3]uint64{3, 4, 0}
+		require.NoError(t, linked[0].Callable.Call(unsafe.Pointer(&ctxBuf[0])))
+		require.Equal(t, [3]uint64{3, 4, 7}, ctxBuf)
 	})
 
 	t.Run("relaxes an out-of-range CBZ branch", func(t *testing.T) {
@@ -99,11 +99,11 @@ func TestAssembler_Build(t *testing.T) {
 		require.NoError(t, err)
 
 		notTaken := []uint64{1, 0xFF}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&notTaken[0]))))
+		require.NoError(t, linked[0].Callable.Call(unsafe.Pointer(&notTaken[0])))
 		require.Equal(t, uint64(1), notTaken[1])
 
 		taken := []uint64{0, 0xFF}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&taken[0]))))
+		require.NoError(t, linked[0].Callable.Call(unsafe.Pointer(&taken[0])))
 		require.Equal(t, uint64(0), taken[1])
 	})
 
@@ -151,11 +151,11 @@ func TestAssembler_Build(t *testing.T) {
 		require.NoError(t, err)
 
 		notTaken := []uint64{1, 0xFF}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&notTaken[0]))))
+		require.NoError(t, linked[0].Callable.Call(unsafe.Pointer(&notTaken[0])))
 		require.Equal(t, uint64(1), notTaken[1])
 
 		taken := []uint64{0, 0xFF}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&taken[0]))))
+		require.NoError(t, linked[0].Callable.Call(unsafe.Pointer(&taken[0])))
 		require.Equal(t, uint64(0), taken[1])
 	})
 
@@ -171,7 +171,7 @@ func TestAssembler_Build(t *testing.T) {
 		// value stays live until the final fold, so the allocator must
 		// keep spilling and reloading; a balanced SP frame is proven by
 		// the call returning cleanly with the correct sum.
-		const n = 64
+		const n = 256
 		var want uint64
 		vals := make([]asm.VReg, n)
 		for i := 0; i < n; i++ {
@@ -203,9 +203,15 @@ func TestAssembler_Build(t *testing.T) {
 		linked, err := asm.Link(buf, arch, []*asm.Code{code}, nil)
 		require.NoError(t, err)
 
-		ctxBuf := []uint64{0}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&ctxBuf[0]))))
-		require.Equal(t, want, ctxBuf[0])
+		for range 64 {
+			ctxBuf := [1]uint64{}
+			done := make(chan error, 1)
+			go func() {
+				done <- linked[0].Callable.Call(unsafe.Pointer(&ctxBuf[0]))
+			}()
+			require.NoError(t, <-done)
+			require.Equal(t, want, ctxBuf[0])
+		}
 	})
 }
 
@@ -286,11 +292,11 @@ func TestLink(t *testing.T) {
 		require.Contains(t, linked[0].Entries, entry)
 
 		ctxBuf := []uint64{0}
-		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&ctxBuf[0]))))
+		require.NoError(t, linked[0].Callable.Call(unsafe.Pointer(&ctxBuf[0])))
 		require.Equal(t, uint64(3), ctxBuf[0])
 
 		ctxBuf[0] = 41
-		require.NoError(t, linked[0].Entries[entry].Call(uintptr(unsafe.Pointer(&ctxBuf[0]))))
+		require.NoError(t, linked[0].Entries[entry].Call(unsafe.Pointer(&ctxBuf[0])))
 		require.Equal(t, uint64(42), ctxBuf[0])
 	})
 }

--- a/asm/assembler_test.go
+++ b/asm/assembler_test.go
@@ -54,6 +54,111 @@ func TestAssembler_Build(t *testing.T) {
 		require.Equal(t, []uint64{3, 4, 7}, ctxBuf)
 	})
 
+	t.Run("relaxes an out-of-range CBZ branch", func(t *testing.T) {
+		arch := arm64.New()
+
+		a := asm.New(arch)
+		ctx := a.Reg(asm.RegTypeInt, asm.Width64)
+		flag := a.Reg(asm.RegTypeInt, asm.Width64)
+		filler := a.Reg(asm.RegTypeInt, asm.Width64)
+		result := a.Reg(asm.RegTypeInt, asm.Width64)
+
+		require.NoError(t, a.Pin(ctx, arm64.X0))
+
+		zero := a.Label()
+
+		a.Emit(arm64.LDR(flag, ctx, 0))
+		a.Emit(arm64.CBZLabel(flag, zero))
+
+		// Over 1MB of filler instructions pushes the CBZ's target past
+		// its +-1MB imm19 range, forcing Assembler.encode to relax it.
+		const fillerCount = 280_000
+		a.Emit(arm64.LDI(filler, 1)...)
+		for i := 0; i < fillerCount; i++ {
+			a.Emit(arm64.ADDI(filler, filler, 1))
+		}
+
+		a.Emit(arm64.LDI(result, 1)...)
+		a.Emit(arm64.STR(result, ctx, 8))
+		a.Emit(arm64.RET())
+
+		a.Bind(zero)
+		a.Emit(arm64.LDI(result, 0)...)
+		a.Emit(arm64.STR(result, ctx, 8))
+		a.Emit(arm64.RET())
+
+		code, err := a.Build()
+		require.NoError(t, err)
+		require.Greater(t, len(code.Bytes), 1<<20)
+
+		buf, err := asm.NewBuffer(len(code.Bytes) + 4096)
+		require.NoError(t, err)
+		defer buf.Free()
+
+		linked, err := asm.Link(buf, arch, []*asm.Code{code}, nil)
+		require.NoError(t, err)
+
+		notTaken := []uint64{1, 0xFF}
+		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&notTaken[0]))))
+		require.Equal(t, uint64(1), notTaken[1])
+
+		taken := []uint64{0, 0xFF}
+		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&taken[0]))))
+		require.Equal(t, uint64(0), taken[1])
+	})
+
+	t.Run("relaxes an out-of-range B.cond branch", func(t *testing.T) {
+		arch := arm64.New()
+
+		a := asm.New(arch)
+		ctx := a.Reg(asm.RegTypeInt, asm.Width64)
+		flag := a.Reg(asm.RegTypeInt, asm.Width64)
+		filler := a.Reg(asm.RegTypeInt, asm.Width64)
+		result := a.Reg(asm.RegTypeInt, asm.Width64)
+
+		require.NoError(t, a.Pin(ctx, arm64.X0))
+
+		zero := a.Label()
+
+		a.Emit(arm64.LDR(flag, ctx, 0))
+		a.Emit(arm64.CMPI(flag, 0))
+		a.Emit(arm64.BCondLabel(arm64.OpBEQ, zero))
+
+		const fillerCount = 280_000
+		a.Emit(arm64.LDI(filler, 1)...)
+		for i := 0; i < fillerCount; i++ {
+			a.Emit(arm64.ADDI(filler, filler, 1))
+		}
+
+		a.Emit(arm64.LDI(result, 1)...)
+		a.Emit(arm64.STR(result, ctx, 8))
+		a.Emit(arm64.RET())
+
+		a.Bind(zero)
+		a.Emit(arm64.LDI(result, 0)...)
+		a.Emit(arm64.STR(result, ctx, 8))
+		a.Emit(arm64.RET())
+
+		code, err := a.Build()
+		require.NoError(t, err)
+		require.Greater(t, len(code.Bytes), 1<<20)
+
+		buf, err := asm.NewBuffer(len(code.Bytes) + 4096)
+		require.NoError(t, err)
+		defer buf.Free()
+
+		linked, err := asm.Link(buf, arch, []*asm.Code{code}, nil)
+		require.NoError(t, err)
+
+		notTaken := []uint64{1, 0xFF}
+		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&notTaken[0]))))
+		require.Equal(t, uint64(1), notTaken[1])
+
+		taken := []uint64{0, 0xFF}
+		require.NoError(t, linked[0].Callable.Call(uintptr(unsafe.Pointer(&taken[0]))))
+		require.Equal(t, uint64(0), taken[1])
+	})
+
 	t.Run("spills under register pressure", func(t *testing.T) {
 		arch := arm64.New()
 
@@ -116,6 +221,28 @@ func TestAssembler_Pin(t *testing.T) {
 
 	_, err := a.Build()
 	require.ErrorIs(t, err, asm.ErrConflictingPin)
+}
+
+func TestAssembler_DisableSpilling(t *testing.T) {
+	a := asm.New(arm64.New())
+	a.DisableSpilling()
+
+	const n = 64
+	vals := make([]asm.VReg, n)
+	for i := range vals {
+		vals[i] = a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.LDI(vals[i], uint64(i+1))...)
+	}
+	acc := vals[0]
+	for i := 1; i < len(vals); i++ {
+		next := a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.ADD(next, acc, vals[i]))
+		acc = next
+	}
+	a.Emit(arm64.RET())
+
+	_, err := a.Build()
+	require.ErrorIs(t, err, asm.ErrNoRegistersAvailable)
 }
 
 func TestLink(t *testing.T) {

--- a/asm/rewriter.go
+++ b/asm/rewriter.go
@@ -62,9 +62,21 @@ func newRewriter(arch Arch, insts []Instruction, pins map[int32]PReg) *rewriter 
 // substituting every operand's vreg with its current physical register,
 // then injects the spill frame and returns labels rebased onto the
 // rewritten stream.
-func (r *rewriter) run(insts []Instruction, labels map[Label]int) ([]Instruction, map[Label]int, error) {
+func (r *rewriter) run(insts []Instruction, labels map[Label]int, entries []Label) ([]Instruction, map[Label]int, error) {
+	for i, inst := range insts {
+		lbl, ok := inst.Src2.(LabelOperand)
+		if !ok {
+			continue
+		}
+		if pos, intra := labels[lbl.ID]; intra && pos <= i {
+			r.frame = nil
+			break
+		}
+	}
+
 	newIdx := make([]int, len(insts)+1)
 	for i, inst := range insts {
+		newIdx[i] = len(r.out)
 		protected := make(map[int32]bool)
 		for _, v := range inst.Uses() {
 			if err := r.use(v, protected); err != nil {
@@ -76,7 +88,6 @@ func (r *rewriter) run(insts []Instruction, labels map[Label]int) ([]Instruction
 				return nil, nil, err
 			}
 		}
-		newIdx[i] = len(r.out)
 		r.out = append(r.out, r.substitute(inst))
 		for _, v := range inst.Uses() {
 			if r.last[v.ID()] == i {
@@ -85,7 +96,7 @@ func (r *rewriter) run(insts []Instruction, labels map[Label]int) ([]Instruction
 		}
 	}
 	newIdx[len(insts)] = len(r.out)
-	return r.inject(labels, newIdx)
+	return r.inject(labels, entries, newIdx)
 }
 
 // use ensures v occupies a physical register before the instruction that
@@ -269,7 +280,7 @@ func (r *rewriter) note(v VReg) {
 // frame prologue is prepended, a frame epilogue precedes every return, and
 // labels are rebased across both the per-instruction shifts and the
 // inserted frame instructions.
-func (r *rewriter) inject(labels map[Label]int, newIdx []int) ([]Instruction, map[Label]int, error) {
+func (r *rewriter) inject(labels map[Label]int, entries []Label, newIdx []int) ([]Instruction, map[Label]int, error) {
 	if r.slots == 0 || r.frame == nil {
 		out := make(map[Label]int, len(labels))
 		for id, idx := range labels {
@@ -280,27 +291,38 @@ func (r *rewriter) inject(labels map[Label]int, newIdx []int) ([]Instruction, ma
 
 	enter := r.frame.Enter(r.slots)
 	leave := r.frame.Leave(r.slots)
+	entry := make(map[Label]bool, len(entries))
+	for _, id := range entries {
+		if labels[id] != 0 {
+			return nil, nil, ErrNoRegistersAvailable
+		}
+		entry[id] = true
+	}
 	final := make([]Instruction, 0, len(enter)+len(r.out)+len(leave))
 	final = append(final, enter...)
 
 	bodyToFinal := make([]int, len(r.out)+1)
 	for bi, inst := range r.out {
+		bodyToFinal[bi] = len(final)
 		if r.frame.Returns(inst.Op) {
 			final = append(final, leave...)
 		}
-		bodyToFinal[bi] = len(final)
 		final = append(final, inst)
+		if _, internal := inst.Src2.(LabelOperand); internal && r.frame.Calls(inst.Op) {
+			final = append(final, r.frame.Resume(r.slots)...)
+		}
 	}
 	bodyToFinal[len(r.out)] = len(final)
 
-	// No label targets the frame prologue. The primary callable enters at
-	// byte 0 and falls through the prologue, so reaching it never depends on
-	// a label; conversely an intra-code branch — including a back-edge that
-	// lands on body index 0 — must skip the prologue or it would re-reserve
-	// the frame on every pass and walk SP off the stack. Rebase every label
-	// past the prologue.
+	// Internal branches skip the prologue so a back-edge cannot reserve the
+	// frame again. An external entry bound at instruction zero is different:
+	// its callable must start at byte zero and execute Enter before the body.
 	out := make(map[Label]int, len(labels))
 	for id, idx := range labels {
+		if entry[id] {
+			out[id] = 0
+			continue
+		}
 		out[id] = bodyToFinal[newIdx[idx]]
 	}
 	return final, out, nil

--- a/benchmarks/alloc_test.go
+++ b/benchmarks/alloc_test.go
@@ -1,0 +1,80 @@
+package bench
+
+import (
+	"context"
+	"testing"
+
+	"github.com/siyul-park/minivm/interp"
+	"github.com/stretchr/testify/require"
+)
+
+// fibAllocN is a smaller fib input for allocation-focused benchmarks: large
+// enough to cross the default JIT sample threshold, small enough that each
+// Run call is cheap to repeat once per iteration.
+const fibAllocN int32 = 20
+
+// BenchmarkFib35AllocInterpSteady isolates per-iteration allocations for the
+// threaded interpreter (JIT disabled) once the interpreter is warm. A single
+// untimed Run/Reset cycle runs before ResetTimer so the timed loop measures
+// steady-state cost only, not the one-time entry-trace capture that a small
+// -benchtime run would otherwise fold into allocs/op.
+func BenchmarkFib35AllocInterpSteady(b *testing.B) {
+	ctx := context.Background()
+	vm := interp.New(Fib(fibN), interp.WithThreshold(-1))
+	defer vm.Close()
+
+	require.NoError(b, vm.Run(ctx))
+	vm.Reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = vm.Run(ctx)
+		vm.Reset()
+	}
+	b.StopTimer()
+	require.NoError(b, err)
+}
+
+// BenchmarkFib20AllocJITWarmup isolates the one-time cost of compiling and
+// installing a native trace: each iteration builds a fresh interpreter and
+// runs it exactly once, so the reported allocs/op is the warmup cost rather
+// than a steady-state average diluted by many cheap iterations. It uses
+// fib(20) instead of fib(35) to keep the per-iteration setup (interp.New,
+// tracer capture, ARM64 compile) affordable at typical -benchtime values.
+func BenchmarkFib20AllocJITWarmup(b *testing.B) {
+	ctx := context.Background()
+	prog := Fib(fibAllocN)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		vm := interp.New(prog)
+		require.NoError(b, vm.Run(ctx))
+		vm.Close()
+	}
+}
+
+// BenchmarkFib35AllocJITSteady isolates per-iteration allocations once a
+// native trace is already installed: an untimed Run/Reset cycle before
+// ResetTimer forces the one-shot entry compile, so the timed loop measures
+// steady-state JIT cost only.
+func BenchmarkFib35AllocJITSteady(b *testing.B) {
+	ctx := context.Background()
+	vm := interp.New(Fib(fibN))
+	defer vm.Close()
+
+	require.NoError(b, vm.Run(ctx))
+	vm.Reset()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = vm.Run(ctx)
+		vm.Reset()
+	}
+	b.StopTimer()
+	require.NoError(b, err)
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,8 @@ For plain functions, `addr == ref`. For closures, `addr` points to the function 
 - Unsupported paths must fall back to threaded execution.
 - JIT handlers must not duplicate complex interpreter behavior unless they can own all semantics.
 - Guard failure materializes VM state and resumes threaded dispatch.
+- ARM64 label branches are range-checked and relaxed only to replacements that are already in range; an unreachable target falls back to threaded execution.
+- Spill frames use a stable base register, and every internal call resume point must restore the active spill-frame depth. Loop traces and terminal mutation traces disable spilling when control flow cannot preserve that contract.
 
 See `jit-internals.md` for trace recording, journal layout, calls, branches, loops, and fallback rules.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -79,6 +79,22 @@ Compared with other script VMs, minivm JIT is about **22-40x faster** on this be
 
 minivm JIT is still slower than wazero by about **1.2x**. This is expected: minivm keeps NaN-boxed values and deoptimization state, while wazero compiles WASM to unboxed native code without the same fallback requirements.
 
+### Warmup vs. Steady-State Allocations
+
+The `minivm interp` and `minivm JIT` rows above run `-benchtime=2s`, which repeats `Run`/`Reset` enough times to amortize one-time setup: the interpreter's entry-trace capture, and (for JIT) native trace compilation and installation. At a small `-benchtime`/`-benchtime=Nx` (few `b.N` iterations), that one-time cost dominates and inflates the reported `allocs/op`, making the runtime look far less allocation-light than it is in steady state.
+
+`benchmarks/alloc_test.go` isolates the two phases explicitly by running one untimed `Run`/`Reset` cycle before `b.ResetTimer()`:
+
+| Benchmark | Isolates | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `BenchmarkFib35AllocInterpSteady` | threaded interpreter, warm | 516,040,250 | 0 | 0 |
+| `BenchmarkFib20AllocJITWarmup` | one fresh compile + `fib(20)` run | 171,915 | 290,147 | 2,264 |
+| `BenchmarkFib35AllocJITSteady` | JIT, trace already installed | 48,199,078 | 0 | 0 |
+
+Both the threaded interpreter and the JIT are zero-allocation per `Run` once warm. The JIT's ~2,264 allocations and ~290 KB are a one-shot cost from `interp.New`, tracer capture, and native compilation/installation on the first hot entry; they do not recur on subsequent `Run` calls against the same interpreter.
+
+Large bytecode programs also used to make profiler warmup quadratic because each newly observed instruction offset reallocated the collector's sample slice to its exact length. Geometric growth reduced a 10,000-row tl2g batch benchmark (`-benchtime=20x`) from about 50.9 MB/op to 551 KB/op; the remaining figure includes the workload's output and other setup allocations.
+
 ## Threaded Interpreter Throughput
 
 The following results measure the pure threaded interpreter with JIT disabled.

--- a/docs/instruction-set.md
+++ b/docs/instruction-set.md
@@ -42,6 +42,8 @@ JIT status is per opcode and per backend. It describes whether a recorded trace 
 
 AMD64 currently has no active JIT backend. `asm/amd64` is a placeholder and `interp/jit_stub.go` disables compiler construction on non-ARM64 platforms, so every AMD64 entry is `🔲`.
 
+ARM64 native branches are range-checked before encoding. Conditional label branches outside their signed imm19 range are relaxed to an inverted conditional skip plus an unconditional imm26 branch when that replacement can reach the target; otherwise JIT compilation cleanly falls back to threaded execution.
+
 ## Operand Widths
 
 Operand widths are declared in `instr/type.go`.

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -104,7 +104,7 @@ General behavior belongs to the threaded interpreter. Native guard failures mate
 
 Trace recording lives in `interp/trace.go`.
 
-Recording clones the interpreter, starts the clone at the requested `(addr, ip)`, and executes threaded closures until it reaches return, loop back-edge, branch exit, unsupported operation, trace limit, or abort condition.
+Recording clones the interpreter, starts the clone at the requested `(addr, ip)`, and executes threaded closures until it reaches return, loop back-edge, branch exit, unsupported operation, trace limit, or abort condition. A backward edge to a different header cuts the linear prefix so that header can become a standalone loop trace with a native safepoint budget. Reaching the trace limit records a partial trace with a resumable cut instead of aborting. Native execution deoptimizes at that cut; when the exit becomes hot, the existing side-exit machinery records and compiles the next bounded continuation.
 
 The live interpreter is not mutated while recording.
 
@@ -118,6 +118,7 @@ Each recorded step stores the data needed for speculative lowering:
 - observed guard values
 - observed heap shape
 - branch target and taken state
+- partial-trace resume boundary
 - selected heap values for read-only fast paths
 
 The tracer aborts before host calls, allocation, and mutating heap operations. These remain interpreter-owned.
@@ -152,7 +153,7 @@ Keep the lowerer interface small. Add architecture hooks only when the architect
 
 Native callables use an AAPCS64-shaped entry.
 
-`Callable.Call(ctx)` passes:
+`Callable.Call(ctx unsafe.Pointer)` passes:
 
 ```text
 &i.journal[0] in X0
@@ -168,7 +169,20 @@ Native code loads VM state from the journal into pinned scratch registers.
 | `scratchSP` | X13 | current stack pointer |
 | `scratchCtrl` | X14 | journal pointer |
 
-The Go trampoline preserves X19-X26. X26 is reserved as the stable spill-frame base, so a native self-call may move SP without changing spill addresses.
+The context stays an `unsafe.Pointer` through the Go call boundary so Go can
+relocate a stack-backed context when the trampoline grows the goroutine stack.
+Converting it to `uintptr` before that stack split would leave native code with
+a stale address.
+
+The Go trampoline preserves X19-X26 and declares an 8,192-byte native reserve:
+`asm.maxSpillSlots` (512) × 8 bytes plus `interp.nativeFrameLimit` (128) × 32
+bytes. Its complete Go frame is 8,272 bytes including the 80-byte trampoline
+area.
+Native code starts at the top of the reserve, so generated SP adjustments stay
+inside memory covered by Go's stack-growth check. X26 is the stable spill-frame
+base, so a native self-call may move SP without changing spill addresses. Keep
+the allocator limit, native frame limit, and `asm/arm64/abi_arm64.s` reserve in
+sync.
 
 Register allocation (`asm/rewriter.go`) is a single linear-scan pass: it spills the vreg with the farthest-away next use to a stack slot at the stream position where pressure was observed. Rewritten labels target the start of any inserted reload/store prefix, and labels on a return target its inserted frame epilogue. Intra-Code calls that return through the shared epilogue reserve the caller's spill area again before continuing.
 
@@ -189,7 +203,7 @@ Header cells come before fixed-stride frame records.
 | `journalBP` | current frame base |
 | `journalSP` | stack pointer |
 | `journalDepth` | number of written frame records |
-| `journalCap` | available frame record capacity |
+| `journalCap` | available frame record capacity, capped at 128 |
 | `journalTrap` | trap state |
 | `journalNextIP` | fallback or resume IP |
 | `journalBudget` | native loop back-edge budget |
@@ -239,7 +253,7 @@ Recorded forward branches become guarded exits or learned branch continuations.
 
 `BR_IF` and `BR_TABLE` emit the recorded path. Unrecorded targets deoptimize.
 
-When a side exit becomes hot, the tracer records that target. A later compile may fold it into the same native callable as a pending block.
+When a side exit becomes hot, the tracer records that target. A later compile may fold it into the same native callable as a pending block. Loop roots are never folded as ordinary continuations: they deoptimize at the header and use their standalone loop entry, which preserves back-edge and safepoint semantics.
 
 Pending blocks reload from VM stack homes, compile hotter exits first, and stop at a bounded pending cap.
 
@@ -340,7 +354,12 @@ Heap-promoted `i64` values fall back before boxing.
 
 Primitive `ARRAY_SET` and `STRUCT_SET` are terminal mutations. The hot path may perform the store, flush state, and resume threaded execution at the next instruction. Shape, bounds, field-kind, or release failure deoptimizes at the original opcode so the interpreter owns full semantics.
 
-A loop body that inlines two or more branchy calls before a terminal `ARRAY_SET`/`STRUCT_SET` can push register pressure past the physical bank; before the register allocator rejected unsafe spilling (see "Trace ABI" above), that shape corrupted the native stack pointer on return from `asm/arm64.invoke` (regression test: `interp.TestInterpreter_JITArraySetAfterBranchyCallsInLoop`). The allocator now falls back to threaded dispatch for any trace that would need to spill across a branch, so the lowerer no longer special-cases pending-branch counts.
+A loop body that inlines two or more branchy calls before a terminal
+`ARRAY_SET`/`STRUCT_SET` can push register pressure past the physical bank.
+The allocator rejects spilling across backward edges, and the compiler disables
+spilling for loop and terminal-mutation roots; register exhaustion then keeps
+threaded dispatch installed (regression test:
+`interp.TestInterpreter_JITArraySetAfterBranchyCallsInLoop`).
 
 Allocation and complex ref-bearing mutations stay threaded.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -168,7 +168,11 @@ Native code loads VM state from the journal into pinned scratch registers.
 | `scratchSP` | X13 | current stack pointer |
 | `scratchCtrl` | X14 | journal pointer |
 
-The Go trampoline preserves X19-X26 for native register allocation.
+The Go trampoline preserves X19-X26. X26 is reserved as the stable spill-frame base, so a native self-call may move SP without changing spill addresses.
+
+Register allocation (`asm/rewriter.go`) is a single linear-scan pass: it spills the vreg with the farthest-away next use to a stack slot at the stream position where pressure was observed. Rewritten labels target the start of any inserted reload/store prefix, and labels on a return target its inserted frame epilogue. Intra-Code calls that return through the shared epilogue reserve the caller's spill area again before continuing.
+
+Linear spill state is still unsafe across a loop back-edge, and terminal `ARRAY_SET`/`STRUCT_SET` traces can combine multiple branch paths before their exit. The compiler disables spilling for loop roots and terminal mutation roots. A root that exhausts physical registers then returns `asm.ErrNoRegistersAvailable` and keeps threaded dispatch installed; acyclic entry traces can still spill and emit native code.
 
 Native code does not marshal parameters or returns. It writes results and trap state into the journal, and the Go wrapper restores interpreter state from there.
 
@@ -248,6 +252,12 @@ Solo interpreters recompile a side exit when its hit count first reaches the hot
 Targets still deoptimize when they are unknown or unsupported.
 
 Branch lowering may skip hot-path flushes only when the branch state is clean. If locals or operands are dirty, flush first. Learned continuations and side exits must see the same stack image as threaded dispatch.
+
+### Branch range validation
+
+ARM64 conditional/compare/test branches (`B.cond`, `CBZ`/`CBNZ`, `TBZ`/`TBNZ`) encode a fixed-width signed PC-relative immediate — imm19 (±1MB) for `B.cond`/`CBZ`/`CBNZ`, imm14 (±32KB) for `TBZ`/`TBNZ`, imm26 (±128MB) for `B`/`BL`. `asm/arm64.Encoder.Encode` validates every such offset is 4-byte aligned and fits its field, returning `asm.ErrBranchOutOfRange` instead of silently masking an out-of-range offset into a wrong target. `interp/jit.go` `emitRoot` treats `ErrBranchOutOfRange` the same as `asm.ErrNoRegistersAvailable`: it aborts native lowering for that trace and falls back to threaded dispatch rather than emit a corrupt callable.
+
+Before that fallback triggers, `asm.Assembler.encode` runs a branch relaxation fixpoint (`asm.Relaxer`, implemented by `asm/arm64.arch.Relax`) between the draft and final encoding passes. For each intra-Code `B.cond`/`CBZ`/`CBNZ` label branch whose imm19 displacement does not fit, `Relax` rewrites it into an inverted-condition branch that skips a following unconditional `B` (imm26, ±128MB) to the original target, then re-drafts and repeats until nothing is left to relax. Both replacement instructions are constructed to already be in range, so a branch relaxes at most once and the loop always terminates; if the unconditional `B` itself would not reach the target (>±128MB), `Relax` returns `false` and `ErrBranchOutOfRange`/the JIT fallback still applies. `TBZ`/`TBNZ` never carry a `LabelOperand` in this codebase (their offset is always a caller-computed immediate — see `asm/arm64/instr.go`), so they never reach `Relax` and the imm14 (±32KB) window has no relaxation path; architectures without a `Relaxer` (amd64) are unaffected — `encode` no-ops the pass.
 
 ## Loops
 
@@ -329,6 +339,8 @@ Ref reads retain loaded refs. `CORO_VALUE` retains the value and releases the ha
 Heap-promoted `i64` values fall back before boxing.
 
 Primitive `ARRAY_SET` and `STRUCT_SET` are terminal mutations. The hot path may perform the store, flush state, and resume threaded execution at the next instruction. Shape, bounds, field-kind, or release failure deoptimizes at the original opcode so the interpreter owns full semantics.
+
+A loop body that inlines two or more branchy calls before a terminal `ARRAY_SET`/`STRUCT_SET` can push register pressure past the physical bank; before the register allocator rejected unsafe spilling (see "Trace ABI" above), that shape corrupted the native stack pointer on return from `asm/arm64.invoke` (regression test: `interp.TestInterpreter_JITArraySetAfterBranchyCallsInLoop`). The allocator now falls back to threaded dispatch for any trace that would need to spill across a branch, so the lowerer no longer special-cases pending-branch counts.
 
 Allocation and complex ref-bearing mutations stay threaded.
 

--- a/docs/pass-system.md
+++ b/docs/pass-system.md
@@ -172,6 +172,9 @@ Block boundaries are:
 - every branch target
 - the byte after `BR`, `BR_IF`, `BR_TABLE`, `UNREACHABLE`, `RETURN`, or `RETURN_CALL`
 
+A branch to the past-the-end offset has no successor block: the analysis models
+it as a virtual exit, while `program.Verify` limits that exit to top-level code.
+
 Keep these boundary rules consistent with the JIT and verifier.
 
 ## Global Value Numbering

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -121,7 +121,10 @@ Branch targets include:
 - `BR_IF`
 - `BR_TABLE`
 
-Each target must land on an instruction boundary.
+Each target must land on an instruction boundary. Top-level code may also
+target the past-the-end offset, which exits the program just like ordinary
+top-level fall-through. Function bodies must target an instruction and still
+terminate explicitly.
 
 ### 3. Termination
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -1196,7 +1196,7 @@ func (i *Interpreter) restore(f *frame, addr int) {
 // context resets and fills the journal handed to native code: stack/global base
 // pointers, current frame BP/SP, pointer cells for native fast paths, and the
 // per-call frame budget. It returns &journal[0], passed to native code in X0.
-func (i *Interpreter) context() uintptr {
+func (i *Interpreter) context() unsafe.Pointer {
 	i.journal[journalStack] = 0
 	if len(i.stack) > 0 {
 		i.journal[journalStack] = uint64(uintptr(unsafe.Pointer(&i.stack[0])))
@@ -1222,11 +1222,11 @@ func (i *Interpreter) context() uintptr {
 	}
 
 	i.journal[journalDepth] = 0
-	i.journal[journalCap] = uint64(len(i.frames) - i.fp)
+	i.journal[journalCap] = uint64(min(len(i.frames)-i.fp, nativeFrameLimit))
 	i.journal[journalTrap] = trapNone
 	i.journal[journalBudget] = uint64(i.tick)
 	i.journal[journalActive] = 0
-	return uintptr(unsafe.Pointer(&i.journal[0]))
+	return unsafe.Pointer(&i.journal[0])
 }
 
 func (i *Interpreter) runtimeError(r any) error {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -29,6 +29,9 @@ type Interpreter struct {
 	exits    map[anchor]func(*Interpreter)
 	stubs    []func(*Interpreter)
 	tried    map[int]bool
+	headers  map[int][]int
+	entered  map[int]bool
+	looped   map[anchor]bool
 	journal  []uint64
 
 	types     []types.Type
@@ -243,6 +246,9 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		exits:     map[anchor]func(*Interpreter){},
 		stubs:     make([]func(*Interpreter), len(prog.Constants)+1),
 		tried:     map[int]bool{},
+		headers:   map[int][]int{},
+		entered:   map[int]bool{},
+		looped:    map[anchor]bool{},
 		dynamic:   map[int]bool{},
 		journal:   make([]uint64, journalHead+journalStride*opt.frame),
 		frames:    make([]frame, opt.frame),
@@ -895,9 +901,20 @@ func (i *Interpreter) safepoint() error {
 // threaded safepoint used to repeat on that lookup are already satisfied.
 func (i *Interpreter) observe(f *frame) error {
 	i.sample(f)
-	if f.ip == 0 && !i.tracer.hasEntry(f.addr) {
-		if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: 0}); err != nil {
-			return err
+	// entered memoizes a true hasEntry(addr) locally: once an anchor's entry
+	// trace is recorded non-aborted it never reverts (i.remove clears the memo
+	// on rebind/invalidation), so a solo interpreter skips the tracer's shared
+	// mutex on every following tick instead of re-checking hasEntry.
+	if f.ip == 0 && !i.entered[f.addr] {
+		if i.tracer.hasEntry(f.addr) {
+			i.entered[f.addr] = true
+		} else {
+			if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: 0}); err != nil {
+				return err
+			}
+			if i.tracer.hasEntry(f.addr) {
+				i.entered[f.addr] = true
+			}
 		}
 	}
 	// A hot loop header sampled mid-function: f.ip is genuinely at the back-edge
@@ -911,18 +928,29 @@ func (i *Interpreter) observe(f *frame) error {
 	if i.threshold >= 0 && f.ip > 0 &&
 		samples >= uint64(i.threshold) &&
 		i.exits[anchor{addr: f.addr, ip: f.ip}] == nil {
-		for _, h := range i.tracer.headers(i, f.addr) {
+		hs, ok := i.headers[f.addr]
+		if !ok {
+			hs = i.tracer.headers(i, f.addr)
+			i.headers[f.addr] = hs
+		}
+		for _, h := range hs {
 			if h != f.ip {
 				continue
 			}
-			if !i.tracer.hasLoop(f.addr, f.ip) {
-				if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: f.ip}); err != nil {
-					return err
-				}
-				if i.tracer.hasLoop(f.addr, f.ip) {
-					if err := i.compile(f.addr); err != nil {
+			a := anchor{addr: f.addr, ip: f.ip}
+			if !i.looped[a] {
+				if !i.tracer.hasLoop(f.addr, f.ip) {
+					if _, err := i.tracer.capture(i, a); err != nil {
 						return err
 					}
+					if i.tracer.hasLoop(f.addr, f.ip) {
+						i.looped[a] = true
+						if err := i.compile(f.addr); err != nil {
+							return err
+						}
+					}
+				} else {
+					i.looped[a] = true
 				}
 			}
 			break
@@ -1560,7 +1588,14 @@ func (i *Interpreter) remove(addr int) {
 			delete(i.exits, a)
 		}
 	}
+	for a := range i.looped {
+		if a.addr == addr {
+			delete(i.looped, a)
+		}
+	}
 	delete(i.tried, addr)
+	delete(i.headers, addr)
+	delete(i.entered, addr)
 	if i.tracer != nil {
 		i.tracer.remove(addr)
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2942,6 +2942,55 @@ func TestWithFrame(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, types.I32(1), v)
 	})
+
+	t.Run("native recursion respects reserved frame limit", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+
+		b := types.NewFunctionBuilder(nil).WithParams(types.TypeI32).WithReturns(types.TypeI32)
+		base := b.Label()
+		b.Emit(instr.New(instr.LOCAL_GET, 0)).
+			Emit(instr.New(instr.I32_EQZ)).
+			BrIf(base).
+			Emit(instr.New(instr.LOCAL_GET, 0)).
+			Emit(instr.New(instr.I32_CONST, 1)).
+			Emit(instr.New(instr.I32_SUB)).
+			Emit(instr.New(instr.CONST_GET, 0)).
+			Emit(instr.New(instr.CALL)).
+			Emit(instr.New(instr.I32_CONST, 1)).
+			Emit(instr.New(instr.I32_ADD)).
+			Emit(instr.New(instr.RETURN)).
+			Bind(base).
+			Emit(instr.New(instr.I32_CONST, 0)).
+			Emit(instr.New(instr.RETURN))
+		recurse, err := b.Build()
+		require.NoError(t, err)
+		prog := program.New([]instr.Instruction{
+			instr.New(instr.I32_CONST, nativeFrameLimit),
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+		}, program.WithConstants(recurse))
+		i := New(prog, WithFrame(nativeFrameLimit+2), WithTick(1), WithThreshold(0))
+		defer i.Close()
+
+		require.NoError(t, i.Run(context.Background()))
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(nativeFrameLimit), v)
+		require.Equal(t, float64(1), i.samples.Value("vm_jit_emits_total"))
+
+		prog = program.New([]instr.Instruction{
+			instr.New(instr.I32_CONST, nativeFrameLimit+1),
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+		}, program.WithConstants(recurse))
+		i = New(prog, WithFrame(nativeFrameLimit+2), WithTick(1), WithThreshold(0))
+		defer i.Close()
+
+		require.ErrorIs(t, i.Run(context.Background()), ErrFrameOverflow)
+		require.Equal(t, float64(1), i.samples.Value("vm_jit_emits_total"))
+	})
 }
 
 func TestWithStack(t *testing.T) {
@@ -3048,6 +3097,88 @@ func TestWithThreshold(t *testing.T) {
 		}
 		require.NotNil(t, i.exits[anchor{addr: 0, ip: 0}])
 		require.Equal(t, float64(1), i.samples.Value("vm_jit_emits_total"))
+	})
+
+	t.Run("jits select with comparison condition", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+		prog := program.New([]instr.Instruction{
+			instr.New(instr.I32_CONST, 10),
+			instr.New(instr.I32_CONST, 20),
+			instr.New(instr.I32_CONST, 1),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.I32_LT_S),
+			instr.New(instr.SELECT),
+		})
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+
+		require.NoError(t, i.Run(context.Background()))
+		v, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.I32(10), v)
+		require.Equal(t, float64(1), i.samples.Value("vm_jit_emits_total"))
+	})
+
+	t.Run("jits oversized top-level code in bounded segments", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+		code := make([]instr.Instruction, 0, opLimit+3)
+		for range opLimit/2 + 1 {
+			code = append(code, instr.New(instr.I32_CONST, 1), instr.New(instr.DROP))
+		}
+		code = append(code, instr.New(instr.I32_CONST, 7))
+		i := New(program.New(code), WithTick(1), WithThreshold(0))
+		defer i.Close()
+
+		for range exitThreshold + 3 {
+			i.Reset()
+			require.NoError(t, i.Run(context.Background()))
+			v, err := i.Pop()
+			require.NoError(t, err)
+			require.Equal(t, types.I32(7), v)
+		}
+		require.GreaterOrEqual(t, i.samples.Value("vm_jit_emits_total"), float64(2))
+	})
+
+	t.Run("keeps a learned nested loop resumable", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+		b := program.NewBuilder()
+		loop := b.Label()
+		b.Locals(types.TypeI32, types.TypeF64).
+			Emit(instr.I32_CONST, 0).
+			Emit(instr.LOCAL_SET, 0).
+			Emit(instr.F64_CONST, 0).
+			Emit(instr.LOCAL_SET, 1).
+			Bind(loop).
+			Emit(instr.LOCAL_GET, 1).
+			Emit(instr.F64_CONST, math.Float64bits(1)).
+			Emit(instr.F64_ADD).
+			Emit(instr.LOCAL_SET, 1).
+			Emit(instr.LOCAL_GET, 0).
+			Emit(instr.I32_CONST, 1).
+			Emit(instr.I32_ADD).
+			Emit(instr.LOCAL_TEE, 0).
+			Emit(instr.I32_CONST, 4).
+			Emit(instr.I32_LT_S).
+			BrIf(loop).
+			Emit(instr.LOCAL_GET, 1)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+
+		for round := range exitThreshold + 8 {
+			i.Reset()
+			require.NoError(t, i.Run(context.Background()))
+			value, err := i.Pop()
+			require.NoError(t, err)
+			require.Equal(t, types.F64(4), value, "round %d", round)
+		}
 	})
 
 	t.Run("warm entry skips sampling", func(t *testing.T) {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -144,7 +144,7 @@ const (
 	journalBP             // current frame bp; external entry in
 	journalSP             // interpreter sp; external entry in/out
 	journalDepth          // trap-time frame records written; native read/write
-	journalCap            // frame budget len(i.frames)-i.fp; read-only
+	journalCap            // frame budget capped by nativeFrameLimit; read-only
 	journalTrap           // exit kind out: trapNone | trapFallback | trapOverflow | trapYield
 	journalNextIP         // resume/fallback IP out for the single-frame path
 	journalBudget         // back-edges remaining before the next safepoint; native read/write
@@ -170,6 +170,10 @@ const (
 	trapOverflow
 	trapYield
 )
+
+// nativeFrameLimit caps generated call depth to the stack space reserved by
+// the ARM64 invoke trampoline. Deeper calls trap before moving SP.
+const nativeFrameLimit = 128
 
 // loopBudget is how many native loop back-edges run between safepoints. It is
 // independent of tick so a hot loop amortizes the deopt/re-enter cost of a

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/siyul-park/minivm/asm"
+	"github.com/siyul-park/minivm/instr"
 	"github.com/siyul-park/minivm/types"
 )
 
@@ -299,9 +300,13 @@ func (c *compiler) emitRoot(i *Interpreter, addr int, fn *types.Function, mod *m
 	if !c.lowerer.lower(ctx) {
 		return false, nil
 	}
+	last := ctx.tree.root.ops[len(ctx.tree.root.ops)-1].op
+	if ctx.loop || last == instr.ARRAY_SET || last == instr.STRUCT_SET {
+		asmb.DisableSpilling()
+	}
 	code, err := asmb.Build()
 	if err != nil {
-		if errors.Is(err, asm.ErrNoRegistersAvailable) {
+		if errors.Is(err, asm.ErrNoRegistersAvailable) || errors.Is(err, asm.ErrBranchOutOfRange) {
 			return false, nil
 		}
 		return false, err

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -141,15 +141,27 @@ func (l arm64Lowerer) enter(ctx *lowering) {
 
 // walk emits the recorded opcode sequence. An entry trace is fully unrolled —
 // forward BR vanishes, forward BR_IF becomes a guard, and the walk succeeds
-// only when the recorded path ends in the entry frame's RETURN. A loop trace
-// additionally closes one back-edge: a BR or BR_IF whose target is the loop
-// header becomes the native back-edge (see backedge).
+// only when the recorded path ends in the entry frame's RETURN. A bounded
+// partial trace exits at its cut so the next segment can be learned as a hot
+// continuation. A loop trace additionally closes one back-edge: a BR or BR_IF
+// whose target is the loop header becomes the native back-edge (see backedge).
 func (l arm64Lowerer) walk(ctx *lowering, ops, tail []step) bool {
 	for idx := 0; idx < len(ops); idx++ {
 		op := ops[idx]
 		f := ctx.frame()
 		if op.fn != f.addr {
 			return false
+		}
+		if op.cut {
+			if idx != len(ops)-1 {
+				return false
+			}
+			label, ok := l.branchOrExit(ctx, op.target, tail)
+			if !ok {
+				return false
+			}
+			ctx.assembler.Emit(arm64.BLabel(label))
+			return true
 		}
 		if ctx.loop && (op.op == instr.BR || op.op == instr.BR_IF) && op.target == ctx.tree.root.anchor.ip {
 			if !l.backedge(ctx, op) {
@@ -589,7 +601,8 @@ func (l arm64Lowerer) walk(ctx *lowering, ops, tail []step) bool {
 		ctx.assembler.Emit(arm64.BLabel(label))
 		return true
 	}
-	if ctx.tree.root.kind == completed {
+	// A learned continuation may finish a partial top-level root.
+	if ctx.tree.root.kind == completed || (ctx.tree.root.kind == partial && ctx.frame().addr == 0) {
 		return l.complete(ctx)
 	}
 	return false
@@ -894,7 +907,7 @@ func (l arm64Lowerer) selectOp(ctx *lowering) bool {
 	cond := ctx.pop()
 	v2 := ctx.pop()
 	v1 := ctx.pop()
-	if cond.kind != types.KindI32 || v1.kind != v2.kind || v1.kind == types.KindRef {
+	if cond.kind.Repr() != types.KindI32 || v1.kind != v2.kind || v1.kind == types.KindRef {
 		return false
 	}
 	ctx.assembler.Emit(arm64.CMPI(l.narrow32(cond.reg), 0))
@@ -1767,7 +1780,12 @@ func (l arm64Lowerer) branchClean(ctx *lowering, ip int, tail []step) (asm.Label
 func (l arm64Lowerer) continuation(ctx *lowering, ip int, tail []step, flush bool) (asm.Label, bool) {
 	target := branch{fn: ctx.frame().addr, ip: ip}
 	leg := ctx.branches[target]
-	if leg.trace == nil || l.marked(ctx) || ctx.pendingBranches >= pendingLimit {
+	// Loop roots require the loop lowering mode: it turns their recorded
+	// back-edge into a real native back-edge with a safepoint budget. Inlining
+	// one as an ordinary continuation would instead treat the recorded path as
+	// top-level completion and return after a single iteration. Exit to the
+	// threaded loop header so its independently compiled loop entry runs.
+	if leg.trace == nil || leg.trace.kind == loop || l.marked(ctx) || ctx.pendingBranches >= pendingLimit {
 		return 0, false
 	}
 	if flush && !l.flush(ctx, false) {
@@ -2681,12 +2699,12 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	}
 	pre := ctx.pre()
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-1].reg)
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-2])
+	a := ctx.assembler
+	fail, ok := l.sideExit(ctx, pre, op.ip)
 	if !ok {
 		return false
 	}
-	a := ctx.assembler
-	fail, ok := l.sideExit(ctx, pre, op.ip)
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-2])
 	if !ok {
 		return false
 	}

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1,0 +1,95 @@
+package interp
+
+import (
+	"context"
+	"math"
+	"runtime"
+	"testing"
+
+	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/program"
+	"github.com/siyul-park/minivm/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInterpreter_JITArraySetAfterBranchyCallsInLoop is a regression test for
+// a SIGSEGV in generated ARM64 code: an outer row loop whose body inlines
+// branchy F64 tree calls and ends each iteration with ARRAY_SET. Register
+// pressure used to spill inside the terminal mutation trace, letting a branch
+// skip spill-frame work and corrupt the Go stack.
+func TestInterpreter_JITArraySetAfterBranchyCallsInLoop(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+
+	const trees = 2
+	const rows = 8
+	row := make([]float64, rows)
+	out := make([]float64, rows)
+	rowArr := types.TypedArray[float64](row)
+	outArr := types.TypedArray[float64](out)
+
+	fn := types.NewFunctionBuilder(nil).
+		WithParams(types.TypeF64Array).
+		WithReturns(types.TypeF64)
+	left := fn.Label()
+	fn.Emit(instr.New(instr.LOCAL_GET, 0)).
+		Emit(instr.New(instr.I32_CONST, 0)).
+		Emit(instr.New(instr.ARRAY_GET)).
+		Emit(instr.New(instr.F64_CONST, math.Float64bits(0.5))).
+		Emit(instr.New(instr.F64_LE)).
+		BrIf(left).
+		Emit(instr.New(instr.F64_CONST, math.Float64bits(-0.01))).
+		Emit(instr.New(instr.RETURN)).
+		Bind(left).
+		Emit(instr.New(instr.F64_CONST, math.Float64bits(0.01))).
+		Emit(instr.New(instr.RETURN))
+	tree, err := fn.Build()
+	require.NoError(t, err)
+
+	b := program.NewBuilder()
+	b.Locals(types.TypeI32, types.TypeF64)
+	b.Const(rowArr)
+	b.Const(outArr)
+	b.Const(tree)
+
+	loop := b.Label()
+	b.Emit(instr.I32_CONST, 0).
+		Emit(instr.LOCAL_SET, 0).
+		Bind(loop).
+		Emit(instr.F64_CONST, 0).
+		Emit(instr.LOCAL_SET, 1)
+	for range trees {
+		b.Emit(instr.LOCAL_GET, 1).
+			ConstGet(rowArr).
+			ConstGet(tree).
+			Emit(instr.CALL).
+			Emit(instr.F64_ADD).
+			Emit(instr.LOCAL_SET, 1)
+	}
+	b.ConstGet(outArr).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.LOCAL_GET, 1).
+		Emit(instr.ARRAY_SET).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, 1).
+		Emit(instr.I32_ADD).
+		Emit(instr.LOCAL_TEE, 0).
+		Emit(instr.I32_CONST, uint64(uint32(rows))).
+		Emit(instr.I32_LT_S).
+		BrIf(loop)
+
+	prog, err := b.Build()
+	require.NoError(t, err)
+
+	i := New(prog, WithTick(1), WithThreshold(1))
+	defer i.Close()
+
+	for n := 0; n < 256; n++ {
+		for idx := range row {
+			row[idx] = float64((n*13+idx*7)%19) / 19
+		}
+		require.NoError(t, i.Run(context.Background()))
+		i.Reset()
+	}
+}

--- a/interp/pool_test.go
+++ b/interp/pool_test.go
@@ -3,11 +3,13 @@ package interp
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/prof"
 	"github.com/siyul-park/minivm/program"
 	"github.com/siyul-park/minivm/types"
 	"github.com/stretchr/testify/require"
@@ -83,6 +85,10 @@ func TestPool_Get(t *testing.T) {
 	})
 
 	t.Run("compiles a shared branch tree concurrently without racing", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+
 		// A called function with a branch tree: members share one Tracer, so one
 		// interpreter warming a side exit (Tracer.exit mutating tree.branches/hits)
 		// runs concurrently with another lowering the same root (rootAt reading it).
@@ -121,22 +127,24 @@ func TestPool_Get(t *testing.T) {
 			instr.New(instr.CALL),
 		}, program.WithConstants(eval))
 
-		p := NewPool(prog, 4, WithTick(1), WithThreshold(0))
+		metrics := prof.New()
+		p := NewPool(prog, 12, WithTick(1), WithThreshold(0), WithProfiler(metrics))
 		defer p.Close()
 
 		var wg sync.WaitGroup
-		errs := make(chan error, 8)
-		for range 8 {
+		errs := make(chan error, 12)
+		for worker := range 12 {
 			wg.Add(1)
-			go func() {
+			go func(worker int) {
 				defer wg.Done()
-				for range exitThreshold * 4 {
+				for n := range exitThreshold * 32 {
 					i, err := p.Get(context.Background())
 					if err != nil {
 						errs <- err
 						return
 					}
-					if err := i.Push(types.I32(3)); err != nil {
+					value := int32((worker+n)%24 - 8)
+					if err := i.Push(types.I32(value)); err != nil {
 						p.Put(i)
 						errs <- err
 						return
@@ -148,13 +156,77 @@ func TestPool_Get(t *testing.T) {
 					}
 					p.Put(i)
 				}
-			}()
+			}(worker)
 		}
 		wg.Wait()
 		close(errs)
 		for err := range errs {
 			require.NoError(t, err)
 		}
+		emits, ok := metrics.Metric("vm_jit_emits_total")
+		require.True(t, ok)
+		require.Greater(t, emits, float64(0))
+	})
+
+	t.Run("runs a spilled shared native entry from fresh goroutines", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+
+		const workers = 8
+		const values = 256
+		const rounds = 8
+		want := types.I32(values * (values + 1) / 2)
+
+		b := program.NewBuilder()
+		for value := range values {
+			b.Emit(instr.I32_CONST, uint64(value+1))
+		}
+		for range values - 1 {
+			b.Emit(instr.I32_ADD)
+		}
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		metrics := prof.New()
+		p := NewPool(prog, workers, WithTick(1), WithThreshold(0), WithProfiler(metrics))
+		defer p.Close()
+		for range rounds {
+			ready := make(chan struct{}, workers)
+			start := make(chan struct{})
+			results := make(chan error, workers)
+			for range workers {
+				go func() {
+					i, err := p.Get(context.Background())
+					ready <- struct{}{}
+					<-start
+					if err != nil {
+						results <- err
+						return
+					}
+					err = i.Run(context.Background())
+					if err == nil {
+						var value types.Value
+						value, err = i.Pop()
+						if err == nil && value != want {
+							err = fmt.Errorf("got %v, want %v", value, want)
+						}
+					}
+					p.Put(i)
+					results <- err
+				}()
+			}
+			for range workers {
+				<-ready
+			}
+			close(start)
+			for range workers {
+				require.NoError(t, <-results)
+			}
+		}
+		emits, ok := metrics.Metric("vm_jit_emits_total")
+		require.True(t, ok)
+		require.Greater(t, emits, float64(0))
 	})
 
 	t.Run("rearms shared cache after missed side-exit threshold", func(t *testing.T) {
@@ -177,6 +249,44 @@ func TestPool_Get(t *testing.T) {
 
 		require.Equal(t, cacheCold, p.cache.state[0].Load())
 		require.True(t, p.cache.due(0, 1))
+	})
+
+	t.Run("does not recompile a known loop exit", func(t *testing.T) {
+		if runtime.GOARCH != "arm64" {
+			t.Skip("native JIT is only available on arm64")
+		}
+		b := program.NewBuilder()
+		loop := b.Label()
+		b.Locals(types.TypeI32).
+			Emit(instr.I32_CONST, 0).
+			Emit(instr.LOCAL_SET, 0).
+			Bind(loop).
+			Emit(instr.LOCAL_GET, 0).
+			Emit(instr.I32_CONST, 1).
+			Emit(instr.I32_ADD).
+			Emit(instr.LOCAL_TEE, 0).
+			Emit(instr.I32_CONST, 4).
+			Emit(instr.I32_LT_S).
+			BrIf(loop).
+			Emit(instr.LOCAL_GET, 0)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		metrics := prof.New()
+		p := NewPool(prog, 1, WithTick(1), WithThreshold(0), WithProfiler(metrics))
+
+		for range exitThreshold * 8 {
+			i, err := p.Get(context.Background())
+			require.NoError(t, err)
+			require.NoError(t, i.Run(context.Background()))
+			value, err := i.Pop()
+			require.NoError(t, err)
+			require.Equal(t, types.I32(4), value)
+			p.Put(i)
+		}
+		require.NoError(t, p.Close())
+		attempts, ok := metrics.Metric("vm_jit_attempts_total")
+		require.True(t, ok)
+		require.Equal(t, float64(2), attempts)
 	})
 }
 

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -52,6 +52,7 @@ type step struct {
 	seen  types.Boxed
 	arg   types.Boxed
 	shape shape
+	cut   bool
 
 	fn     int
 	ip     int
@@ -80,6 +81,7 @@ const (
 	loop outcome = iota + 1
 	returned
 	completed
+	partial
 	aborted
 )
 
@@ -103,8 +105,14 @@ func (r *Tracer) exit(i *Interpreter, root anchor, target branch) (int64, error)
 	id := r.exitIndex(tree, target)
 	tree.hits[id]++
 	hits := tree.hits[id]
-	if tree.branches[id] != nil {
+	if branch := tree.branches[id]; branch != nil {
 		r.mu.Unlock()
+		// The first hot exit publishes the standalone loop entry. Later exits
+		// cannot be folded into the parent trace, so recompiling that parent
+		// would only publish the same pair again.
+		if branch.kind == loop && hits != exitThreshold {
+			return 0, nil
+		}
 		return hits, nil
 	}
 	r.mu.Unlock()
@@ -210,6 +218,23 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (*trace, error) {
 
 		r.finish(&clone, &st, op)
 		t.ops = append(t.ops, st)
+		// A backward edge to a different header starts a distinct loop trace.
+		// Stop this linear prefix at the header instead of unrolling the loop up
+		// to opLimit; threaded execution will make that header hot and compile it
+		// with the native back-edge and safepoint budget intact.
+		if (op == instr.BR || op == instr.BR_IF) &&
+			clone.fr.addr == st.fn && clone.fr.ip <= st.ip &&
+			(clone.fr.addr != a.addr || clone.fr.ip != a.ip) {
+			t.ops = append(t.ops, step{
+				fn:     clone.fr.addr,
+				target: clone.fr.ip,
+				depth:  clone.fp - startFP,
+				cut:    true,
+			})
+			t.kind = partial
+			r.store(a, t)
+			return t, nil
+		}
 		// Heap mutations still lower as terminal native fast paths: the hot
 		// path performs the store and resumes at the next threaded instruction;
 		// guard failures resume at the opcode so the interpreter owns the full
@@ -245,7 +270,11 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (*trace, error) {
 		}
 	}
 	if len(t.ops) >= opLimit {
-		t.kind = aborted
+		// Preserve the bounded prefix. Its synthetic cut lowers through the same
+		// side-exit path as a guard, so a hot remainder becomes a continuation.
+		f := clone.fr
+		t.ops = append(t.ops, step{fn: f.addr, target: f.ip, depth: clone.fp - startFP, cut: true})
+		t.kind = partial
 	}
 	r.store(a, t)
 	return t, nil

--- a/interp/trace_test.go
+++ b/interp/trace_test.go
@@ -53,6 +53,46 @@ func TestTracer_Capture(t *testing.T) {
 		require.Equal(t, instr.YIELD, tr.ops[len(tr.ops)-1].op)
 	})
 
+	t.Run("cuts an oversized trace at a resumable boundary", func(t *testing.T) {
+		code := make([]instr.Instruction, opLimit+1)
+		for j := range code {
+			code[j] = instr.New(instr.NOP)
+		}
+		tracer := NewTracer()
+		i := New(program.New(code), WithTracer(tracer), WithThreshold(-1))
+		defer i.Close()
+
+		tr, err := tracer.capture(i, anchor{addr: 0, ip: 0})
+		require.NoError(t, err)
+		require.Equal(t, partial, tr.kind)
+		require.Len(t, tr.ops, opLimit+1)
+		require.True(t, tr.ops[len(tr.ops)-1].cut)
+		require.Equal(t, opLimit, tr.ops[len(tr.ops)-1].target)
+	})
+
+	t.Run("cuts a non-anchor back edge at its loop header", func(t *testing.T) {
+		b := program.NewBuilder()
+		loop := b.Label()
+		b.Emit(instr.NOP).
+			Bind(loop).
+			Emit(instr.I32_CONST, 1).
+			Emit(instr.DROP).
+			Br(loop)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		tracer := NewTracer()
+		i := New(prog, WithTracer(tracer), WithThreshold(-1))
+		defer i.Close()
+
+		tr, err := tracer.capture(i, anchor{addr: 0, ip: 0})
+		require.NoError(t, err)
+		require.Equal(t, partial, tr.kind)
+		require.Len(t, tr.ops, 5)
+		require.Equal(t, instr.BR, tr.ops[len(tr.ops)-2].op)
+		require.True(t, tr.ops[len(tr.ops)-1].cut)
+		require.Equal(t, 1, tr.ops[len(tr.ops)-1].target)
+	})
+
 	t.Run("records terminal set fast paths and rejects remaining array mutators", func(t *testing.T) {
 		tracer := NewTracer()
 		require.False(t, tracer.unrecordable(nil, instr.ARRAY_SET))

--- a/optimize/optimizer_test.go
+++ b/optimize/optimizer_test.go
@@ -118,6 +118,26 @@ func TestOptimizer_Optimize(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("O3 preserves a top-level branch to the program end", func(t *testing.T) {
+		b := program.NewBuilder()
+		end := b.Label()
+		b.Emit(instr.I32_CONST, 1)
+		b.BrIf(end)
+		b.Emit(instr.UNREACHABLE)
+		b.Bind(end)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		require.NoError(t, program.Verify(prog))
+
+		got, err := NewOptimizer(O3).Optimize(prog)
+		require.NoError(t, err)
+		require.NoError(t, program.Verify(got))
+
+		vm := interp.New(got)
+		defer vm.Close()
+		require.NoError(t, vm.Run(context.Background()))
+	})
+
 	t.Run("O3 eliminates a common subexpression and preserves semantics", func(t *testing.T) {
 		build := func() *program.Program {
 			return program.New(

--- a/prof/collector.go
+++ b/prof/collector.go
@@ -80,18 +80,7 @@ func (c *Collector) Add(fn, ip int, op byte) {
 	if fn < 0 || ip < 0 {
 		return
 	}
-	for len(c.funcs) <= fn {
-		c.funcs = append(c.funcs, function{})
-	}
-	if len(c.funcs[fn].ips) <= ip {
-		n := len(c.funcs[fn].ips) * 2
-		if n < ip+1 {
-			n = ip + 1
-		}
-		ips := make([]uint64, n)
-		copy(ips, c.funcs[fn].ips)
-		c.funcs[fn].ips = ips
-	}
+	c.grow(fn, ip)
 	c.total++
 	c.funcs[fn].count++
 	c.funcs[fn].ips[ip]++
@@ -153,19 +142,12 @@ func (c *Collector) merge(o *Collector) {
 		if fd.count == 0 {
 			continue
 		}
-		for len(c.funcs) <= fn {
-			c.funcs = append(c.funcs, function{})
-		}
+		c.grow(fn, len(fd.ips)-1)
 		c.total += fd.count
 		c.funcs[fn].count += fd.count
 		for offset, n := range fd.ips {
 			if n == 0 {
 				continue
-			}
-			if len(c.funcs[fn].ips) <= offset {
-				ips := make([]uint64, offset+1)
-				copy(ips, c.funcs[fn].ips)
-				c.funcs[fn].ips = ips
 			}
 			c.funcs[fn].ips[offset] += n
 		}
@@ -175,6 +157,27 @@ func (c *Collector) merge(o *Collector) {
 	}
 	for _, m := range o.metrics {
 		c.AddMetric(m.Name, m.Value, m.Labels...)
+	}
+}
+
+func (c *Collector) grow(fn, ip int) {
+	if len(c.funcs) <= fn {
+		n := len(c.funcs) * 2
+		if n < fn+1 {
+			n = fn + 1
+		}
+		funcs := make([]function, n)
+		copy(funcs, c.funcs)
+		c.funcs = funcs
+	}
+	if len(c.funcs[fn].ips) <= ip {
+		n := len(c.funcs[fn].ips) * 2
+		if n < ip+1 {
+			n = ip + 1
+		}
+		ips := make([]uint64, n)
+		copy(ips, c.funcs[fn].ips)
+		c.funcs[fn].ips = ips
 	}
 }
 

--- a/prof/collector.go
+++ b/prof/collector.go
@@ -84,7 +84,11 @@ func (c *Collector) Add(fn, ip int, op byte) {
 		c.funcs = append(c.funcs, function{})
 	}
 	if len(c.funcs[fn].ips) <= ip {
-		ips := make([]uint64, ip+1)
+		n := len(c.funcs[fn].ips) * 2
+		if n < ip+1 {
+			n = ip + 1
+		}
+		ips := make([]uint64, n)
 		copy(ips, c.funcs[fn].ips)
 		c.funcs[fn].ips = ips
 	}

--- a/prof/prof_test.go
+++ b/prof/prof_test.go
@@ -109,6 +109,31 @@ func TestProfiler_Flush(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, float64(2), v)
 	})
+
+	t.Run("merges growing sparse instruction ranges", func(t *testing.T) {
+		local := prof.NewCollector()
+		p := prof.New()
+
+		local.Add(7, 10_000, byte(instr.NOP))
+		p.Flush(local)
+		local.Add(7, 20_000, byte(instr.NOP))
+		p.Flush(local)
+
+		v, ok := p.Metric(
+			"vm_func_ip_samples_total",
+			prof.Label{Key: "func", Value: "7"},
+			prof.Label{Key: "ip", Value: "10000"},
+		)
+		require.True(t, ok)
+		require.Equal(t, float64(1), v)
+		v, ok = p.Metric(
+			"vm_func_ip_samples_total",
+			prof.Label{Key: "func", Value: "7"},
+			prof.Label{Key: "ip", Value: "20000"},
+		)
+		require.True(t, ok)
+		require.Equal(t, float64(1), v)
+	})
 }
 
 func TestProfiler_Metrics(t *testing.T) {

--- a/program/verify.go
+++ b/program/verify.go
@@ -235,16 +235,19 @@ func (c *checker) bounds(ip int, op instr.Opcode) error {
 
 // blocks builds the control-flow graph, splitting the code at branch targets,
 // terminators, and protected-region boundaries, and validates that every branch
-// target lands on an instruction boundary inside the function. Throws and traps
-// transfer out of band, so no edges are added for them; the flow pass seeds
-// catch blocks directly.
+// target lands on an instruction boundary. Top-level branches may target the
+// virtual exit at len(code); function branches must stay inside their body.
+// Throws and traps transfer out of band, so no edges are added for them; the
+// flow pass seeds catch blocks directly.
 func (c *checker) blocks() ([]*block, error) {
 	offsets := []int{0}
 	mark := func(ip, target int) error {
-		if target < 0 || target >= len(c.code) {
+		if target < 0 || target > len(c.code) || (target == len(c.code) && c.slot != 0) {
 			return c.fail(ip, instr.Opcode(c.code[ip]), ErrInvalidJump)
 		}
-		offsets = append(offsets, target)
+		if target < len(c.code) {
+			offsets = append(offsets, target)
+		}
 		return nil
 	}
 	for ip := 0; ip < len(c.code); {
@@ -326,6 +329,9 @@ func (c *checker) blocks() ([]*block, error) {
 // link records an edge from block src to the block containing dst, failing when
 // dst is not the start of any block (a jump into the middle of an instruction).
 func (c *checker) link(blocks []*block, src, dst int) error {
+	if dst == len(c.code) && c.slot == 0 {
+		return nil
+	}
 	for i, b := range blocks {
 		if b.start <= dst && dst < b.end {
 			blocks[src].succs = append(blocks[src].succs, i)

--- a/program/verify_test.go
+++ b/program/verify_test.go
@@ -200,6 +200,18 @@ func TestVerify(t *testing.T) {
 		require.ErrorIs(t, Verify(prog), ErrInvalidJump)
 	})
 
+	t.Run("function branch to end", func(t *testing.T) {
+		fn := &types.Function{
+			Typ: &types.FunctionType{},
+			Code: instr.Marshal([]instr.Instruction{
+				instr.New(instr.I32_CONST, 1),
+				instr.New(instr.BR_IF, 0),
+			}),
+		}
+		prog := New([]instr.Instruction{instr.New(instr.NOP)}, WithConstants(fn))
+		require.ErrorIs(t, Verify(prog), ErrInvalidJump)
+	})
+
 	t.Run("function falls through", func(t *testing.T) {
 		fn := &types.Function{
 			Typ:  &types.FunctionType{},

--- a/transform/cd.go
+++ b/transform/cd.go
@@ -93,7 +93,8 @@ func (p *ConstantDeduplicationPass) Run(m *pass.Manager, prog *program.Program) 
 // slice), which panics under Go's == on the interface; such constants are
 // never deduplicated with each other since they're never equal.
 func valueEqual(a, b types.Value) bool {
-	if !reflect.TypeOf(a).Comparable() {
+	typ := reflect.TypeOf(a)
+	if typ != nil && !typ.Comparable() {
 		return false
 	}
 	return a == b

--- a/transform/cd.go
+++ b/transform/cd.go
@@ -1,6 +1,8 @@
 package transform
 
 import (
+	"reflect"
+
 	"github.com/siyul-park/minivm/instr"
 	"github.com/siyul-park/minivm/pass"
 	"github.com/siyul-park/minivm/program"
@@ -39,7 +41,7 @@ func (p *ConstantDeduplicationPass) Run(m *pass.Manager, prog *program.Program) 
 		}
 	}
 
-	constIndex, constSize := dedup(constants, constUsed, func(a, b types.Value) bool { return a == b })
+	constIndex, constSize := dedup(constants, constUsed, valueEqual)
 	typeIndex, typesSize := dedup(typs, typeUsed, func(a, b types.Type) bool { return a.Equals(b) })
 
 	for i, v := range constIndex {
@@ -84,6 +86,17 @@ func (p *ConstantDeduplicationPass) Run(m *pass.Manager, prog *program.Program) 
 	prog.Types = typs
 
 	return pass.PreserveNone(), nil
+}
+
+// valueEqual reports whether a and b are the same constant. types.Value can
+// be backed by an uncomparable dynamic type (e.g. types.TypedArray, a
+// slice), which panics under Go's == on the interface; such constants are
+// never deduplicated with each other since they're never equal.
+func valueEqual(a, b types.Value) bool {
+	if !reflect.TypeOf(a).Comparable() {
+		return false
+	}
+	return a == b
 }
 
 // dedup builds a compaction index for items: each referenced entry (used[i])

--- a/transform/cd_test.go
+++ b/transform/cd_test.go
@@ -12,10 +12,12 @@ import (
 
 func TestConstantDeduplicationPass_Run(t *testing.T) {
 	tests := []struct {
+		name     string
 		program  *program.Program
 		expected *program.Program
 	}{
 		{
+			name: "comparable constants",
 			program: program.New(
 				[]instr.Instruction{
 					instr.New(instr.CONST_GET, 1),
@@ -34,6 +36,7 @@ func TestConstantDeduplicationPass_Run(t *testing.T) {
 			),
 		},
 		{
+			name: "equivalent types",
 			program: program.New(
 				[]instr.Instruction{
 					instr.New(instr.STRUCT_NEW_DEFAULT, 0),
@@ -55,6 +58,7 @@ func TestConstantDeduplicationPass_Run(t *testing.T) {
 			),
 		},
 		{
+			name: "uncomparable constants",
 			program: program.New(
 				[]instr.Instruction{
 					instr.New(instr.CONST_GET, 0),
@@ -76,12 +80,29 @@ func TestConstantDeduplicationPass_Run(t *testing.T) {
 				),
 			),
 		},
+		{
+			name: "nil constants",
+			program: program.New(
+				[]instr.Instruction{
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.CONST_GET, 1),
+				},
+				program.WithConstants([]types.Value{nil, nil}...),
+			),
+			expected: program.New(
+				[]instr.Instruction{
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.CONST_GET, 0),
+				},
+				program.WithConstants([]types.Value{nil}...),
+			),
+		},
 	}
 
 	for _, tt := range tests {
 		m := pass.NewManager()
 
-		t.Run(tt.program.String(), func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			actual := tt.program
 			_, err := NewConstantDeduplicationPass().Run(m, actual)
 			require.NoError(t, err)

--- a/transform/cd_test.go
+++ b/transform/cd_test.go
@@ -54,6 +54,28 @@ func TestConstantDeduplicationPass_Run(t *testing.T) {
 				program.WithTypes(types.NewStructType(types.NewStructField(types.TypeF64))),
 			),
 		},
+		{
+			program: program.New(
+				[]instr.Instruction{
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.CONST_GET, 1),
+				},
+				program.WithConstants(
+					types.TypedArray[float64]{1},
+					types.TypedArray[float64]{1},
+				),
+			),
+			expected: program.New(
+				[]instr.Instruction{
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.CONST_GET, 1),
+				},
+				program.WithConstants(
+					types.TypedArray[float64]{1},
+					types.TypedArray[float64]{1},
+				),
+			),
+		},
 	}
 
 	for _, tt := range tests {

--- a/transform/dce.go
+++ b/transform/dce.go
@@ -72,26 +72,20 @@ func (p *DeadCodeEliminationPass) Run(m *pass.Manager, prog *program.Program) (p
 			switch inst.Opcode() {
 			case instr.BR, instr.BR_IF:
 				target := read + instr.ReadI16(inst.Operand(0)) + inst.Width()
-				for target >= 0 && target < len(offsets) && offsets[target] == -1 {
-					target++
-				}
-				if target < 0 || target >= len(offsets) {
+				if target < 0 || target > len(offsets) {
 					return pass.PreserveNone(), fmt.Errorf("%w: at=%d", analysis.ErrInvalidJump, read)
 				}
-				inst.SetOperand(0, uint64(offsets[target]-write-inst.Width()))
+				inst.SetOperand(0, uint64(p.relocate(offsets, target, len(code))-write-inst.Width()))
 			case instr.BR_TABLE:
 				width := inst.Width()
 				operands := inst.Operands()
 				count := int(operands[0])
 				for j := 0; j <= count; j++ {
 					target := read + instr.ReadI16(operands[j+1]) + width
-					for target >= 0 && target < len(offsets) && offsets[target] == -1 {
-						target++
-					}
-					if target < 0 || target >= len(offsets) {
+					if target < 0 || target > len(offsets) {
 						return pass.PreserveNone(), fmt.Errorf("%w: at=%d", analysis.ErrInvalidJump, read)
 					}
-					inst.SetOperand(j+1, uint64(offsets[target]-write-width))
+					inst.SetOperand(j+1, uint64(p.relocate(offsets, target, len(code))-write-width))
 				}
 			default:
 			}


### PR DESCRIPTION
## What changed

- harden ARM64 trace spilling around branches, internal calls, entry labels, loops, and terminal mutations
- validate and relax out-of-range ARM64 branches with clean threaded fallback
- remove warm-path tracer/profiler allocation and lock churn
- make constant deduplication safe for uncomparable typed-array constants
- add regression, range-boundary, allocation, and large-branch coverage

## Why

Branch-heavy LightGBM-style batch traces could spill an F64 value over the Go return address when control flow skipped spill-frame setup or restoration. Large generated programs also amplified profiler growth and tracer coordination overhead.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `go test -race -run '^TestInterpreter_JITArraySetAfterBranchyCallsInLoop$' -count=100 ./interp`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ARM64 JIT compilation now supports safer handling of long conditional branches.
  - Added an option to disable register spilling during native code generation.
  - Improved support for resumable and partial execution traces.

- **Bug Fixes**
  - Improved validation of branch targets, including program-end exits.
  - Prevented invalid branch offsets from producing corrupt native code.
  - Fixed constant deduplication for complex and nil values.
  - Improved spill-frame handling across native calls and recursion.

- **Documentation**
  - Expanded guidance on JIT behavior, branch ranges, tracing, verification, and allocation benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->