### PR TITLE
fix(interp): harden heap ownership and cycle collection

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,7 +124,7 @@ A typical execution follows this path:
 | `tracer` | profile samples and trace recording |
 | `frames` | call stack |
 | `stack` | operand stack |
-| `heap`, `rc`, `free` | heap storage, reference counts, and reusable slots |
+| `heap`, `rc`, `free`, `trial`, `work` | heap storage, exact counts, reusable slots, and cycle-collection scratch |
 | `globals` | global slots |
 | `compiler` | private JIT compiler for standalone interpreters |
 | `cache` | shared native-code cache used by pools |

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -111,13 +111,16 @@ err = vm.Release(addr)
 Ownership rules:
 
 - `Alloc` creates an owned heap reference
+- `Alloc` of an existing `types.Ref` or `KindRef` creates another ownership of the same address
 - `Load` reads without changing ownership
-- `Store` replaces the value at an address
+- `Store` replaces the value at an address, releases refs owned by the old value, and finalizes its external resources
+- `Store(addr, types.BoxRef(addr))` leaves the current value unchanged
 - `Retain` creates another host-owned reference
 - `Release` drops a host-owned reference
-- every successful `Retain` must be matched by `Release`
+- every owned reference from `Alloc` or `Retain` must eventually be transferred or released
 
-Leaked host references keep heap objects alive.
+Leaked host references keep heap objects alive. Releasing an address does not
+invalidate another ownership created by `Alloc` or `Retain`.
 
 ### Globals and Locals
 
@@ -128,11 +131,11 @@ If `val` is `KindRef`, ownership transfers into the slot. The caller must not re
 To keep another reference, retain first.
 
 ```go
-ref, err := vm.Retain(addr)
+_, err := vm.Retain(addr)
 if err != nil {
     return err
 }
-err = vm.SetGlobal(0, types.BoxRef(ref))
+err = vm.SetGlobal(0, types.BoxRef(addr))
 ```
 
 This mirrors `GLOBAL_SET` and `LOCAL_SET`, which consume stack references into slots.
@@ -305,9 +308,9 @@ Unsigned integers use the same VM types as signed integers. Values above the sig
 
 Marshaled references live on the VM heap. This includes strings, arrays, maps, structs, host objects, and host functions.
 
-They remain alive while reachable from the stack, constants, globals, closures, heap objects, or retained host references. They do not survive `vm.Close()` or `vm.Reset()`.
+They remain alive while reachable from the stack, constants, globals, closures, heap objects, or retained host references. Dynamic values do not survive `vm.Close()` or `vm.Reset()`; reset finalizes their external resources and invalidates every dynamic heap address.
 
-Use marshaled refs before the next reset, or register them as constants or globals.
+Use marshaled refs before the next reset, or register immutable inputs as program constants.
 
 ```go
 v, err := vm.Marshal(myStruct)

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -126,9 +126,9 @@ invalidate another ownership created by `Alloc` or `Retain`.
 
 `SetGlobal(idx, val)` and `SetLocal(idx, val)` overwrite VM slots.
 
-If `val` is `KindRef`, ownership transfers into the slot. The caller must not release that same reference afterward.
+If `val` is a different `KindRef`, ownership transfers into the slot. The caller must not release that same ownership afterward. Assigning the slot's current boxed value is a no-op; in that case no ownership transfers, and the caller remains responsible for any ownership it already holds.
 
-To keep another reference, retain first.
+To keep another reference after a different-value assignment, retain first.
 
 ```go
 _, err := vm.Retain(addr)

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -114,7 +114,13 @@ Ownership rules:
 - `Alloc` of an existing `types.Ref` or `KindRef` creates another ownership of the same address
 - `Load` reads without changing ownership
 - `Store` replaces the value at an address, releases refs owned by the old value, and finalizes its external resources
-- `Store(addr, types.BoxRef(addr))` leaves the current value unchanged
+- storing the same concrete pointer or the destination's own `types.Ref` /
+  `KindRef` is a no-op
+- storing a different heap address returns `ErrTypeMismatch`; use
+  `Alloc(existingRef)` to create another ownership of one object
+- concrete pointer values passed to `Alloc`, `Store`, or `Push` transfer unique
+  ownership and must not already be owned by the interpreter; use an existing
+  ref when sharing one object
 - `Retain` creates another host-owned reference
 - `Release` drops a host-owned reference
 - every owned reference from `Alloc` or `Retain` must eventually be transferred or released
@@ -126,7 +132,11 @@ invalidate another ownership created by `Alloc` or `Retain`.
 
 `SetGlobal(idx, val)` and `SetLocal(idx, val)` overwrite VM slots.
 
-If `val` is a different `KindRef`, ownership transfers into the slot. The caller must not release that same ownership afterward. Assigning the slot's current boxed value is a no-op; in that case no ownership transfers, and the caller remains responsible for any ownership it already holds.
+If `val` is a different valid `KindRef`, ownership transfers into the slot. The
+caller must not release that same ownership afterward. Invalid heap addresses
+return `ErrSegmentationFault` without changing the slot. Assigning the slot's
+current boxed value is a no-op; in that case no ownership transfers, and the
+caller remains responsible for any ownership it already holds.
 
 To keep another reference after a different-value assignment, retain first.
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -220,13 +220,17 @@ Rules:
 - `Alloc` of an existing ref creates another ownership of the same address
 - `Load` reads an object without changing ownership
 - `Store` overwrites an existing heap slot and finalizes the old value
+- `Store` accepts the destination's own ref as a no-op but rejects a different
+  heap address; share objects through `Alloc(existingRef)` instead
+- concrete pointer values transferred into heap or stack slots must have unique
+  ownership; use refs to share one object
 - `Retain` creates an additional host-owned ref
 - `Release` drops a host-owned ref
 - every ownership created by `Alloc` or `Retain` must be transferred or released
 
-Leaked host refs keep objects alive. `SetGlobal` and `SetLocal` transfer a
-different ref into the destination, but assigning the destination's current
-boxed value is a no-op and leaves the caller's ownership unchanged.
+Leaked host refs keep objects alive. `SetGlobal` and `SetLocal` validate and
+transfer a different ref into the destination, but assigning the destination's
+current boxed value is a no-op and leaves the caller's ownership unchanged.
 
 `Marshal` may allocate nested heap refs while converting Go values. Those refs belong to the interpreter heap. Consume them through VM APIs such as `Push` or `Alloc`, or let `Close` / `Reset` discard temporary allocations.
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -195,13 +195,16 @@ err = vm.Release(addr)
 Rules:
 
 - `Alloc` creates an owned heap ref
+- `Alloc` of an existing ref creates another ownership of the same address
 - `Load` reads an object without changing ownership
-- `Store` overwrites an existing heap slot
+- `Store` overwrites an existing heap slot and finalizes the old value
 - `Retain` creates an additional host-owned ref
 - `Release` drops a host-owned ref
-- every successful `Retain` must be matched by `Release`
+- every ownership created by `Alloc` or `Retain` must be transferred or released
 
-Leaked host refs keep objects alive.
+Leaked host refs keep objects alive. `SetGlobal` and `SetLocal` transfer a
+different ref into the destination, but assigning the destination's current
+boxed value is a no-op and leaves the caller's ownership unchanged.
 
 `Marshal` may allocate nested heap refs while converting Go values. Those refs belong to the interpreter heap. Consume them through VM APIs such as `Push` or `Alloc`, or let `Close` / `Reset` discard temporary allocations.
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -94,17 +94,24 @@ This contract lets `release` and GC reuse caller-owned scratch storage.
 
 Allocation order:
 
-1. reuse an index from `free`
-2. run GC when needed or when the max heap limit is reached
-3. reuse a slot freed by GC if available
-4. return `ErrHeapExhausted` if the hard limit still applies
-5. otherwise append or grow heap storage
+1. run GC when occupied slots reach the adaptive goal
+2. reuse an index from `free`
+3. run GC if backing storage or the hard limit is reached and this
+   allocation has not collected yet
+4. reuse a slot freed by GC if available
+5. return `ErrHeapExhausted` if the hard limit still applies
+6. otherwise append or grow heap storage
 
-`WithHeap(n)` sets initial heap capacity only.
+An allocation attempt runs GC at most once.
 
-`WithMaxHeap(n)` sets a hard heap entry limit. Values `n <= 0` mean unlimited.
+`WithHeap(n)` sets initial heap capacity. Subject to the hard limit, the initial
+GC goal is at least that capacity and at least 64 slots beyond the baseline heap.
 
-The max limit is checked after free-list reuse and GC, so collectable objects do not block future allocations.
+`WithMaxHeap(n)` sets a hard heap entry limit. Values `n <= 0` mean
+unlimited. It also clamps the adaptive goal.
+
+The max limit is checked after GC and free-list reuse, so collectable objects
+do not block future allocations.
 
 Public host APIs that allocate, such as `Alloc`, `Push`, and `Marshal`, return `ErrHeapExhausted` as ordinary errors.
 
@@ -113,7 +120,22 @@ Public host APIs that allocate, such as `Alloc`, `Push`, and `Marshal`, return `
 GC uses trial deletion to derive roots from exact reference counts instead of
 maintaining a second root registry.
 
-GC runs when the heap is full and `free` is empty.
+GC runs when occupied slots reach an adaptive goal. Backing-storage
+exhaustion and the hard heap limit remain forced collection points even when
+the goal is higher.
+
+After collection, the next goal is derived from the live set:
+
+```text
+live = len(heap) - len(free)
+dynamic = max(live - base, 0)
+goal = live + max(dynamic, 64)
+```
+
+The hard heap limit clamps `goal`, and `goal` never falls below `live`. The
+64-slot minimum avoids repeated collection for small heaps; larger dynamic live
+sets receive roughly their current size as allocation runway. `Reset` recomputes
+the goal from the baseline heap instead of inheriting the previous run's target.
 
 High-level flow:
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -20,7 +20,7 @@ For boxed value layout and kind rules, see `docs/value-representation.md`.
 
 ## Summary
 
-minivm uses stable heap indices, manual reference counting, and a cycle-collecting mark-and-sweep GC.
+minivm uses stable heap indices, exact reference counting, and a trial-deletion mark-and-sweep collector for cycles.
 
 Only `KindRef` values participate in reference counting. Primitive boxed values are copied by value and ignored by RC.
 
@@ -37,9 +37,11 @@ Design rules:
 `Interpreter` stores heap state in parallel slices.
 
 ```go
-heap []types.Value
-rc   []int
-free []int
+heap  []types.Value
+rc    []int
+free  []int
+trial []int
+work  []int
 ```
 
 Allocation returns a stable integer heap index. Heap indices never move, because `KindRef` values store heap indices in stack slots, constants, globals, closures, and heap objects.
@@ -64,6 +66,10 @@ Reference counting is handled by threaded handlers and host APIs.
 `release(addr)` decrements `rc[addr]`. When the count reaches zero, it collects nested refs from `Traceable.Refs`, closes the value when needed, clears the heap slot, appends the address to `free`, and repeats for nested refs with an explicit work stack.
 
 `release` must remain iterative to avoid deep-recursion failures on large object graphs.
+
+Counts include every ownership edge, whether it comes from another heap object,
+the VM stack and frames, a global or constant, temporary construction state, or
+the host. The cycle collector relies on this exactness.
 
 ## Traceable Values
 
@@ -104,23 +110,32 @@ Public host APIs that allocate, such as `Alloc`, `Push`, and `Marshal`, return `
 
 ## GC
 
-GC is mark-and-sweep with the sign bit of `rc` used as the mark state. There is no separate mark array.
+GC uses trial deletion to derive roots from exact reference counts instead of
+maintaining a second root registry.
 
 GC runs when the heap is full and `free` is empty.
 
 High-level flow:
 
-1. mark existing live slots as unreachable
-2. trace roots from stack, constants, globals, active frames, coroutines, and closures
-3. sweep slots that remain marked unreachable
+1. copy each allocated slot's exact `rc` into the reused `trial` table
+2. subtract every heap-to-heap edge reported by `Traceable.Refs`
+3. treat positive residual counts as owners outside the heap graph
+4. mark transitively from those externally owned objects
+5. reclaim every allocated unmarked slot as cyclic garbage
+6. subtract dead-to-live edges from surviving exact counts
+
+A residual external count covers stack, constant, global, frame, coroutine,
+temporary construction, and host ownership uniformly. Host-held addresses
+therefore survive collection without a separate pin table.
 
 Properties:
 
-- handles reference cycles
-- uses O(1) extra mark storage
+- handles self-cycles, multi-object cycles, and duplicate edges
+- preserves objects with any external ownership
+- reuses O(heap slots) trial and work buffers after their first growth
 - does not compact
 - keeps heap indices stable
-- pause cost is proportional to heap size
+- pause cost is proportional to allocated slots plus traced edges
 
 ## Invariants
 
@@ -138,9 +153,11 @@ Rules:
 
 Primitive boxed values do not participate in reference counting. Only `KindRef` values are tracked.
 
-### RC must be symmetric
+### RC must be exact and symmetric
 
-Every retained ref must be released exactly once. Releasing too much can collect a value too early; releasing too little leaks it.
+Every ownership edge contributes exactly one count. Every retained ref must be
+released exactly once. Missing counts can collect a value too early; excess
+counts can turn unreachable garbage into a false external root.
 
 ### Heap indices are stable
 
@@ -219,6 +236,7 @@ When changing memory behavior:
 - update old and new refs in the same local block
 - keep `release` iterative
 - use `Refs(dst)` scratch instead of allocating traversal slices eagerly
+- keep heap-edge counts exact so trial deletion can derive external roots
 - never cache heap element indexes as slice addresses across allocation
 - keep `heap[0]` special and simple
 - prefer transfer semantics when values are already being consumed

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -1599,36 +1599,27 @@ func (i *Interpreter) unbox(val types.Boxed) types.Value {
 }
 
 func (i *Interpreter) alloc(val types.Value) int {
-	collected := false
-	if i.goal > 0 && len(i.heap)-len(i.free) >= i.goal {
+	collected := i.goal > 0 && len(i.heap)-len(i.free) >= i.goal
+	if collected {
 		i.gc()
-		collected = true
 	}
 	if addr, ok := i.reuse(val); ok {
 		return addr
 	}
 
-	if i.limit > 0 && len(i.heap) >= i.limit {
-		if !collected {
-			i.gc()
-			if addr, ok := i.reuse(val); ok {
-				return addr
-			}
+	full := len(i.heap) == cap(i.heap)
+	limited := i.limit > 0 && len(i.heap) >= i.limit
+	if !collected && (full || limited) {
+		i.gc()
+		if addr, ok := i.reuse(val); ok {
+			return addr
 		}
+	}
+	if limited {
 		panic(ErrHeapExhausted)
 	}
 
-	if len(i.heap) == cap(i.heap) {
-		if !collected {
-			i.gc()
-			if addr, ok := i.reuse(val); ok {
-				return addr
-			}
-		}
-		if i.limit > 0 && len(i.heap) >= i.limit {
-			panic(ErrHeapExhausted)
-		}
-
+	if full {
 		c := 2 * cap(i.heap)
 		if c == 0 {
 			c = 1
@@ -1818,8 +1809,7 @@ func (i *Interpreter) gc() {
 
 func (i *Interpreter) pace() {
 	live := len(i.heap) - len(i.free)
-	dynamic := max(live-i.base, 0)
-	goal := live + max(dynamic, heapRunway)
+	goal := live + max(live-i.base, heapRunway)
 	if i.limit > 0 {
 		goal = min(goal, i.limit)
 	}

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -268,11 +268,20 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 	}
 	i.alloc(types.Null)
 
+	// Retain each constant root and nested edge as it becomes visible because a
+	// later constant may allocate and trigger GC. recount normalizes the final
+	// baseline after the whole constant pool has been boxed.
 	for j, v := range prog.Constants {
 		var val types.Boxed
 		switch v := v.(type) {
 		case types.Boxed:
 			val = v
+			if val.Kind() == types.KindRef {
+				addr := val.Ref()
+				if addr >= 0 && addr < len(i.rc) && i.rc[addr] > 0 {
+					i.retain(addr)
+				}
+			}
 		case types.I1:
 			val = types.BoxI1(bool(v))
 		case types.I8:
@@ -287,13 +296,22 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 			val = types.BoxF64(float64(v))
 		case types.Ref:
 			val = types.BoxRef(int(v))
+			if addr := int(v); addr >= 0 && addr < len(i.rc) && i.rc[addr] > 0 {
+				i.retain(addr)
+			}
 		default:
 			val = types.BoxRef(i.keep(v))
+			for _, ref := range i.refs(v) {
+				if addr := int(ref); addr >= 0 && addr < len(i.rc) && i.rc[addr] > 0 {
+					i.retain(addr)
+				}
+			}
 		}
 		i.constants[j] = val
 	}
 
 	i.base = len(i.heap)
+	i.recount()
 
 	i.module = &types.Function{Typ: &types.FunctionType{}, Locals: prog.Locals, Code: prog.Code, Handlers: prog.Handlers}
 	i.instrs[0] = prog.Code
@@ -551,9 +569,10 @@ func (i *Interpreter) Global(idx int) (types.Boxed, error) {
 }
 
 // SetGlobal writes val into global slot idx, releasing the reference the slot
-// previously held. Ownership of a KindRef val transfers into the slot: the
-// caller must not release it afterward, and should Retain first to keep an
-// independent reference.
+// previously held. Ownership of a different KindRef val transfers into the
+// slot: the caller must not release it afterward, and should Retain first to
+// keep an independent reference. Reassigning the current value is a no-op and
+// leaves the caller's ownership unchanged.
 func (i *Interpreter) SetGlobal(idx int, val types.Boxed) error {
 	if idx < 0 || idx >= len(i.globals) {
 		return ErrSegmentationFault
@@ -579,9 +598,10 @@ func (i *Interpreter) Local(idx int) (types.Boxed, error) {
 }
 
 // SetLocal writes val into local slot idx, releasing the reference the slot
-// previously held. Ownership of a KindRef val transfers into the slot: the
-// caller must not release it afterward, and should Retain first to keep an
-// independent reference.
+// previously held. Ownership of a different KindRef val transfers into the
+// slot: the caller must not release it afterward, and should Retain first to
+// keep an independent reference. Reassigning the current value is a no-op and
+// leaves the caller's ownership unchanged.
 func (i *Interpreter) SetLocal(idx int, val types.Boxed) error {
 	f := i.fr
 	addr := f.bp + idx
@@ -625,15 +645,6 @@ func (i *Interpreter) Store(addr int, val types.Value) (err error) {
 		} else {
 			val = types.Unbox(v)
 		}
-	case types.Ref:
-		ref := int(v)
-		if ref < 0 || ref >= len(i.heap) || i.rc[ref] <= 0 {
-			return ErrSegmentationFault
-		}
-		if ref == addr {
-			return nil
-		}
-		val = i.heap[ref]
 	}
 	old := i.heap[addr]
 	i.heap[addr] = val
@@ -786,9 +797,7 @@ func (i *Interpreter) Reset() {
 	hits := i.rc[:cap(i.rc)]
 	clear(hits[i.base:])
 	i.rc = hits[:i.base]
-	for j := 0; j < i.base; j++ {
-		i.rc[j] = 1
-	}
+	i.recount()
 	i.free = i.free[:0]
 
 	// Restore each global from its declaration rather than its previous runtime
@@ -1669,6 +1678,30 @@ func (i *Interpreter) remove(addr int) {
 	delete(i.dynamic, addr)
 }
 
+// recount rebuilds baseline counts from constant roots and heap edges after
+// construction or reset has removed all dynamic slots.
+func (i *Interpreter) recount() {
+	clear(i.rc)
+	i.rc[0] = 1
+	for _, val := range i.constants {
+		if val.Kind() != types.KindRef {
+			continue
+		}
+		addr := val.Ref()
+		if addr >= 0 && addr < len(i.rc) {
+			i.rc[addr]++
+		}
+	}
+	for addr := 1; addr < len(i.heap); addr++ {
+		for _, ref := range i.refs(i.heap[addr]) {
+			child := int(ref)
+			if child >= 0 && child < len(i.rc) {
+				i.rc[child]++
+			}
+		}
+	}
+}
+
 func (i *Interpreter) retainBox(v types.Boxed) {
 	if v.Kind() == types.KindRef {
 		i.retain(v.Ref())
@@ -1745,6 +1778,11 @@ func (i *Interpreter) scan() {
 				panic(ErrSegmentationFault)
 			}
 			i.trial[child]--
+		}
+	}
+	for addr := 1; addr < n; addr++ {
+		if i.rc[addr] > 0 && i.trial[addr] < 0 {
+			panic(ErrSegmentationFault)
 		}
 	}
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -49,6 +49,7 @@ type Interpreter struct {
 	stack    []types.Boxed
 	heap     []types.Value
 	base     int
+	goal     int
 	interned map[string]types.Ref
 	free     []int
 	rc       []int
@@ -82,6 +83,8 @@ type frame struct {
 	ip int
 	bp int
 }
+
+const heapRunway = 64
 
 type option struct {
 	hook       func(*Interpreter) error
@@ -312,6 +315,10 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 
 	i.base = len(i.heap)
 	i.recount()
+	i.goal = max(cap(i.heap), i.base+heapRunway)
+	if i.limit > 0 {
+		i.goal = max(min(i.goal, i.limit), i.base)
+	}
 
 	i.module = &types.Function{Typ: &types.FunctionType{}, Locals: prog.Locals, Code: prog.Code, Handlers: prog.Handlers}
 	i.instrs[0] = prog.Code
@@ -805,6 +812,7 @@ func (i *Interpreter) Reset() {
 	for idx, kind := range i.globalKinds {
 		i.globals[idx] = i.zero(kind)
 	}
+	i.pace()
 }
 
 // compile lowers traces already recorded for addr and installs the resulting
@@ -1566,22 +1574,31 @@ func (i *Interpreter) unbox(val types.Boxed) types.Value {
 }
 
 func (i *Interpreter) alloc(val types.Value) int {
+	collected := false
+	if i.goal > 0 && len(i.heap)-len(i.free) >= i.goal {
+		i.gc()
+		collected = true
+	}
 	if addr, ok := i.reuse(val); ok {
 		return addr
 	}
 
 	if i.limit > 0 && len(i.heap) >= i.limit {
-		i.gc()
-		if addr, ok := i.reuse(val); ok {
-			return addr
+		if !collected {
+			i.gc()
+			if addr, ok := i.reuse(val); ok {
+				return addr
+			}
 		}
 		panic(ErrHeapExhausted)
 	}
 
 	if len(i.heap) == cap(i.heap) {
-		i.gc()
-		if addr, ok := i.reuse(val); ok {
-			return addr
+		if !collected {
+			i.gc()
+			if addr, ok := i.reuse(val); ok {
+				return addr
+			}
 		}
 		if i.limit > 0 && len(i.heap) >= i.limit {
 			panic(ErrHeapExhausted)
@@ -1750,6 +1767,17 @@ func (i *Interpreter) gc() {
 	i.scan()
 	i.mark()
 	i.sweep()
+	i.pace()
+}
+
+func (i *Interpreter) pace() {
+	live := len(i.heap) - len(i.free)
+	dynamic := max(live-i.base, 0)
+	goal := live + max(dynamic, heapRunway)
+	if i.limit > 0 {
+		goal = min(goal, i.limit)
+	}
+	i.goal = max(goal, live)
 }
 
 // scan derives each object's external incoming count. Exact rc includes both

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -584,6 +584,9 @@ func (i *Interpreter) SetGlobal(idx int, val types.Boxed) error {
 	if idx < 0 || idx >= len(i.globals) {
 		return ErrSegmentationFault
 	}
+	if val.Kind() == types.KindRef && !i.alive(val.Ref()) {
+		return ErrSegmentationFault
+	}
 	old := i.globals[idx]
 	if old == val {
 		return nil
@@ -615,6 +618,9 @@ func (i *Interpreter) SetLocal(idx int, val types.Boxed) error {
 	if addr < 0 || addr >= i.sp {
 		return ErrSegmentationFault
 	}
+	if val.Kind() == types.KindRef && !i.alive(val.Ref()) {
+		return ErrSegmentationFault
+	}
 	old := i.stack[addr]
 	if old == val {
 		return nil
@@ -627,31 +633,44 @@ func (i *Interpreter) SetLocal(idx int, val types.Boxed) error {
 }
 
 func (i *Interpreter) Load(addr int) (types.Value, error) {
-	if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+	if !i.alive(addr) {
 		return nil, ErrSegmentationFault
 	}
 	return i.heap[addr], nil
 }
 
+// Store replaces the value at addr. Concrete values transfer unique slot
+// ownership; an existing heap ref is accepted only when it already names addr.
 func (i *Interpreter) Store(addr int, val types.Value) (err error) {
 	defer i.guard(&err)
-	if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+	if !i.alive(addr) {
 		return ErrSegmentationFault
 	}
+	ref, alias := 0, false
 	switch v := val.(type) {
 	case types.Boxed:
 		if v.Kind() == types.KindRef {
-			ref := v.Ref()
-			if ref < 0 || ref >= len(i.heap) || i.rc[ref] <= 0 {
-				return ErrSegmentationFault
-			}
-			if ref == addr {
-				return nil
-			}
-			val = i.heap[ref]
+			ref, alias = v.Ref(), true
 		} else {
 			val = types.Unbox(v)
 		}
+	case types.Ref:
+		ref, alias = int(v), true
+	}
+	if alias {
+		if !i.alive(ref) {
+			return ErrSegmentationFault
+		}
+		if ref == addr {
+			return nil
+		}
+		return ErrTypeMismatch
+	}
+	if owner := i.owner(val); owner >= 0 {
+		if owner == addr {
+			return nil
+		}
+		return ErrTypeMismatch
 	}
 	old := i.heap[addr]
 	i.heap[addr] = val
@@ -668,7 +687,7 @@ func (i *Interpreter) Alloc(val types.Value) (addr int, err error) {
 	case types.Boxed:
 		if v.Kind() == types.KindRef {
 			addr = v.Ref()
-			if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+			if !i.alive(addr) {
 				return 0, ErrSegmentationFault
 			}
 			i.retain(addr)
@@ -677,11 +696,14 @@ func (i *Interpreter) Alloc(val types.Value) (addr int, err error) {
 		val = types.Unbox(v)
 	case types.Ref:
 		addr = int(v)
-		if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+		if !i.alive(addr) {
 			return 0, ErrSegmentationFault
 		}
 		i.retain(addr)
 		return addr, nil
+	}
+	if i.owner(val) >= 0 {
+		return 0, ErrTypeMismatch
 	}
 	if s, ok := val.(types.String); ok {
 		return int(i.intern(string(s))), nil
@@ -694,7 +716,7 @@ func (i *Interpreter) Alloc(val types.Value) (addr int, err error) {
 }
 
 func (i *Interpreter) Retain(addr int) (types.Value, error) {
-	if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+	if !i.alive(addr) {
 		return nil, ErrSegmentationFault
 	}
 	i.retain(addr)
@@ -702,7 +724,7 @@ func (i *Interpreter) Retain(addr int) (types.Value, error) {
 }
 
 func (i *Interpreter) Release(addr int) error {
-	if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+	if !i.alive(addr) {
 		return ErrSegmentationFault
 	}
 	i.release(addr)
@@ -713,6 +735,9 @@ func (i *Interpreter) Push(val types.Value) (err error) {
 	defer i.guard(&err)
 	if i.sp == len(i.stack) {
 		return ErrStackOverflow
+	}
+	if i.owner(val) >= 0 {
+		return ErrTypeMismatch
 	}
 	i.stack[i.sp] = i.box(val)
 	i.sp++
@@ -1729,6 +1754,27 @@ func (i *Interpreter) releaseBox(v types.Boxed) {
 	if v.Kind() == types.KindRef {
 		i.release(v.Ref())
 	}
+}
+
+func (i *Interpreter) alive(addr int) bool {
+	return addr >= 0 && addr < len(i.heap) && i.rc[addr] > 0
+}
+
+func (i *Interpreter) owner(val types.Value) int {
+	pointer := reflect.ValueOf(val)
+	if !pointer.IsValid() || pointer.Kind() != reflect.Pointer {
+		return -1
+	}
+	for addr, current := range i.heap {
+		if !i.alive(addr) {
+			continue
+		}
+		owner := reflect.ValueOf(current)
+		if owner.IsValid() && owner.Type() == pointer.Type() && owner.Pointer() == pointer.Pointer() {
+			return addr
+		}
+	}
+	return -1
 }
 
 func (i *Interpreter) retain(addr int) {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -47,12 +47,13 @@ type Interpreter struct {
 	frames   []frame
 	fr       *frame
 	stack    []types.Boxed
-	roots    []types.Boxed
 	heap     []types.Value
 	base     int
 	interned map[string]types.Ref
 	free     []int
 	rc       []int
+	trial    []int
+	work     []int
 	refbuf   []types.Ref
 
 	fp  int
@@ -778,7 +779,6 @@ func (i *Interpreter) Reset() {
 	}
 
 	i.gas = i.fuel
-	i.roots = i.roots[:0]
 
 	heap := i.heap[:cap(i.heap)]
 	clear(heap[i.base:])
@@ -1608,8 +1608,6 @@ func (i *Interpreter) reuse(val types.Value) (int, bool) {
 }
 
 func (i *Interpreter) keep(val types.Value) int {
-	roots := i.trace(val)
-	defer i.unroot(roots)
 	return i.alloc(val)
 }
 
@@ -1715,105 +1713,85 @@ func (i *Interpreter) release(addr int) {
 	}
 }
 
-func (i *Interpreter) trace(val types.Value) int {
-	n := 0
-	for _, ref := range i.refs(val) {
-		n += i.root(types.BoxRef(int(ref)))
-	}
-	return n
-}
-
-func (i *Interpreter) root(val types.Boxed) int {
-	if val.Kind() != types.KindRef {
-		return 0
-	}
-	i.roots = append(i.roots, val)
-	return 1
-}
-
-func (i *Interpreter) unroot(n int) {
-	if n == 0 {
-		return
-	}
-	i.roots = i.roots[:len(i.roots)-n]
-}
-
 func (i *Interpreter) gc() {
+	i.scan()
 	i.mark()
 	i.sweep()
 }
 
-// mark negates every live refcount, then walks the object graph from the roots,
-// flipping each reachable slot back to its original positive count. When it
-// returns, survivors hold positive counts, unreachable-but-allocated slots are
-// negative, and free slots remain zero.
+// scan derives each object's external incoming count. Exact rc includes both
+// heap edges and owners outside the heap; subtracting every heap-to-heap edge
+// leaves a positive value only for objects owned by the stack, constants,
+// globals, frames, temporary construction state, or the host.
+func (i *Interpreter) scan() {
+	n := len(i.rc)
+	if cap(i.trial) < n {
+		i.trial = make([]int, n)
+	} else {
+		i.trial = i.trial[:n]
+	}
+	copy(i.trial, i.rc)
+
+	for addr := 1; addr < n; addr++ {
+		if i.rc[addr] <= 0 {
+			continue
+		}
+		for _, ref := range i.refs(i.heap[addr]) {
+			child := int(ref)
+			if child == 0 {
+				continue
+			}
+			if child < 0 || child >= n || i.rc[child] <= 0 {
+				panic(ErrSegmentationFault)
+			}
+			i.trial[child]--
+		}
+	}
+}
+
+// mark traces from every positive external count. A negative trial value marks
+// a survivor; zero remains an unreachable cycle candidate.
 func (i *Interpreter) mark() {
-	for j := 1; j < len(i.heap); j++ {
-		if i.rc[j] < 0 {
-			i.rc[j] = 0
-		}
-		i.rc[j] *= -1
-	}
-
-	var stack []int
+	i.work = i.work[:0]
 	push := func(addr int) {
-		if i.rc[addr] < 0 {
-			i.rc[addr] *= -1
-			stack = append(stack, addr)
+		if addr <= 0 || addr >= len(i.rc) || i.rc[addr] <= 0 || i.trial[addr] < 0 {
+			return
 		}
-	}
-	pushBox := func(val types.Boxed) {
-		if val.Kind() == types.KindRef {
-			push(val.Ref())
-		}
+		i.trial[addr] = -i.trial[addr] - 1
+		i.work = append(i.work, addr)
 	}
 
-	for j := 0; j < i.sp; j++ {
-		pushBox(i.stack[j])
-	}
-	for _, val := range i.constants {
-		pushBox(val)
-	}
-	for _, val := range i.globals {
-		pushBox(val)
-	}
-	for _, val := range i.roots {
-		pushBox(val)
-	}
-	for j := 0; j < i.fp; j++ {
-		push(i.frames[j].ref)
-		if co := i.frames[j].coro; co > 0 {
-			push(co)
+	for addr := 1; addr < len(i.rc); addr++ {
+		if i.rc[addr] > 0 && i.trial[addr] > 0 {
+			push(addr)
 		}
 	}
-
-	for len(stack) > 0 {
-		addr := stack[len(stack)-1]
-		stack = stack[:len(stack)-1]
+	for len(i.work) > 0 {
+		addr := i.work[len(i.work)-1]
+		i.work = i.work[:len(i.work)-1]
 		for _, ref := range i.refs(i.heap[addr]) {
 			push(int(ref))
 		}
 	}
 }
 
-// sweep frees every slot mark left negative. For each dead object it first
-// removes that object's contribution to its live referents' counts, so the
-// surviving graph's refcounts stay exact and survivors are not pinned by edges
-// from collected garbage. Dead->dead edges are skipped: the referent is zeroed
-// by its own sweep.
+// sweep reclaims every allocated unmarked slot. Edges from dead objects to
+// survivors are removed from exact rc; dead-to-dead edges need no adjustment
+// because both slots are discarded by this pass.
 func (i *Interpreter) sweep() {
-	for j := 1; j < len(i.heap); j++ {
-		if i.rc[j] >= 0 {
+	for addr := 1; addr < len(i.heap); addr++ {
+		if i.rc[addr] <= 0 || i.trial[addr] < 0 {
 			continue
 		}
-		v := i.heap[j]
+		v := i.heap[addr]
 		for _, ref := range i.refs(v) {
-			if r := int(ref); i.rc[r] > 0 {
-				i.rc[r]--
+			child := int(ref)
+			if child > 0 && child < len(i.rc) && i.rc[child] > 0 && i.trial[child] < 0 {
+				i.rc[child]--
 			}
 		}
-		i.rc[j] = 0
-		i.reclaim(j, v)
+		i.rc[addr] = 0
+		i.reclaim(addr, v)
 	}
 }
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -558,10 +558,13 @@ func (i *Interpreter) SetGlobal(idx int, val types.Boxed) error {
 		return ErrSegmentationFault
 	}
 	old := i.globals[idx]
+	if old == val {
+		return nil
+	}
+	i.globals[idx] = val
 	if old.Kind() == types.KindRef {
 		i.release(old.Ref())
 	}
-	i.globals[idx] = val
 	return nil
 }
 
@@ -585,10 +588,13 @@ func (i *Interpreter) SetLocal(idx int, val types.Boxed) error {
 		return ErrSegmentationFault
 	}
 	old := i.stack[addr]
+	if old == val {
+		return nil
+	}
+	i.stack[addr] = val
 	if old.Kind() == types.KindRef {
 		i.release(old.Ref())
 	}
-	i.stack[addr] = val
 	return nil
 }
 
@@ -604,21 +610,33 @@ func (i *Interpreter) Store(addr int, val types.Value) (err error) {
 	if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
 		return ErrSegmentationFault
 	}
-	if v, ok := val.(types.Boxed); ok {
+	switch v := val.(type) {
+	case types.Boxed:
 		if v.Kind() == types.KindRef {
 			ref := v.Ref()
 			if ref < 0 || ref >= len(i.heap) || i.rc[ref] <= 0 {
 				return ErrSegmentationFault
 			}
+			if ref == addr {
+				return nil
+			}
 			val = i.heap[ref]
 		} else {
 			val = types.Unbox(v)
 		}
+	case types.Ref:
+		ref := int(v)
+		if ref < 0 || ref >= len(i.heap) || i.rc[ref] <= 0 {
+			return ErrSegmentationFault
+		}
+		if ref == addr {
+			return nil
+		}
+		val = i.heap[ref]
 	}
-	if _, ok := i.heap[addr].(*types.Function); ok {
-		i.remove(addr)
-	}
+	old := i.heap[addr]
 	i.heap[addr] = val
+	i.dispose(addr, old)
 	if fn, ok := val.(*types.Function); ok {
 		i.bind(addr, fn, true)
 	}
@@ -627,11 +645,24 @@ func (i *Interpreter) Store(addr int, val types.Value) (err error) {
 
 func (i *Interpreter) Alloc(val types.Value) (addr int, err error) {
 	defer i.guard(&err)
-	if v, ok := val.(types.Boxed); ok {
+	switch v := val.(type) {
+	case types.Boxed:
 		if v.Kind() == types.KindRef {
-			return v.Ref(), nil
+			addr = v.Ref()
+			if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+				return 0, ErrSegmentationFault
+			}
+			i.retain(addr)
+			return addr, nil
 		}
 		val = types.Unbox(v)
+	case types.Ref:
+		addr = int(v)
+		if addr < 0 || addr >= len(i.heap) || i.rc[addr] <= 0 {
+			return 0, ErrSegmentationFault
+		}
+		i.retain(addr)
+		return addr, nil
 	}
 	if s, ok := val.(types.String); ok {
 		return int(i.intern(string(s))), nil
@@ -721,8 +752,10 @@ func (i *Interpreter) Close() error {
 }
 
 func (i *Interpreter) Reset() {
-	for addr := range i.dynamic {
-		i.remove(addr)
+	for addr := i.base; addr < len(i.heap); addr++ {
+		if i.rc[addr] > 0 {
+			i.finalize(addr, i.heap[addr])
+		}
 	}
 	for i.fp > 1 {
 		i.fp--
@@ -746,22 +779,22 @@ func (i *Interpreter) Reset() {
 
 	i.gas = i.fuel
 	i.roots = i.roots[:0]
-	clear(i.interned)
 
-	i.heap = i.heap[:i.base]
-	i.rc = i.rc[:i.base]
+	heap := i.heap[:cap(i.heap)]
+	clear(heap[i.base:])
+	i.heap = heap[:i.base]
+	hits := i.rc[:cap(i.rc)]
+	clear(hits[i.base:])
+	i.rc = hits[:i.base]
 	for j := 0; j < i.base; j++ {
 		i.rc[j] = 1
 	}
 	i.free = i.free[:0]
 
-	// Restore the declared-kind zero seed (see New). Each slot's runtime kind
-	// still matches its declaration, so the kind is read back from the slot
-	// itself; the heap and refcounts were re-baselined above, so any old ref
-	// value needs no release, and this runs after the rc reset so the seed's
-	// null-ref retain is preserved.
-	for idx := range i.globals {
-		i.globals[idx] = i.zero(i.globals[idx].Kind())
+	// Restore each global from its declaration rather than its previous runtime
+	// kind: a dynamic ref global may have held an inline scalar before reset.
+	for idx, kind := range i.globalKinds {
+		i.globals[idx] = i.zero(kind)
 	}
 }
 
@@ -1795,21 +1828,39 @@ func (i *Interpreter) refs(v types.Value) []types.Ref {
 	return i.refbuf
 }
 
-// reclaim finalizes slot addr holding v: it drops interned-string and
-// OS-resource bookkeeping, clears the slot, and returns it to the free list. The
-// caller has already decided addr is dead and settled its referents' counts.
+// dispose releases the refs owned by v and finalizes its non-heap resources.
+// The containing slot stays allocated, so Store can replace a value without
+// changing the address or its external refcount.
+func (i *Interpreter) dispose(addr int, v types.Value) {
+	var local [8]int
+	children := local[:0]
+	for _, ref := range i.refs(v) {
+		children = append(children, int(ref))
+	}
+	for _, child := range children {
+		i.release(child)
+	}
+	i.finalize(addr, v)
+}
+
+// reclaim finalizes slot addr holding v, clears it, and returns the stable
+// address to the free list. The caller has already settled its referents.
 func (i *Interpreter) reclaim(addr int, v types.Value) {
+	i.finalize(addr, v)
+	i.heap[addr] = nil
+	i.free = append(i.free, addr)
+}
+
+func (i *Interpreter) finalize(addr int, v types.Value) {
 	if _, ok := v.(*types.Function); ok {
 		i.remove(addr)
 	}
-	if s, ok := v.(types.String); ok {
+	if s, ok := v.(types.String); ok && i.interned[string(s)] == types.Ref(addr) {
 		delete(i.interned, string(s))
 	}
 	if c, ok := v.(io.Closer); ok {
 		_ = c.Close()
 	}
-	i.heap[addr] = nil
-	i.free = append(i.free, addr)
 }
 
 func (i *Interpreter) yields(code []byte) bool {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3834,6 +3834,24 @@ func TestWithHeap(t *testing.T) {
 		require.Equal(t, 3, i.Len())
 	})
 
+	t.Run("collects cycle at backing capacity", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(2))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		value.refs = []types.Ref{types.Ref(addr)}
+		_, err = i.Retain(addr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(addr))
+
+		reused, err := i.Alloc(types.I32(1))
+		require.NoError(t, err)
+		require.Equal(t, addr, reused)
+		require.Equal(t, 1, value.closed)
+	})
+
 	t.Run("negative capacity normalizes", func(t *testing.T) {
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.I32_CONST, 1), instr.New(instr.REF_NEW),
@@ -3846,7 +3864,7 @@ func TestWithHeap(t *testing.T) {
 	})
 
 	t.Run("collects cycles at adaptive goal", func(t *testing.T) {
-		const capacity = 128
+		const capacity = 2 * heapRunway
 
 		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(capacity))
 		defer i.Close()
@@ -3874,28 +3892,30 @@ func TestWithHeap(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, i.Release(addr))
 
-		for n := range 62 {
+		// The first collection leaves two live slots, so pace sets goal to
+		// 2+heapRunway. Reuse and the new cycle occupy two of that runway.
+		for n := range heapRunway - 2 {
 			_, err = i.Alloc(types.I32(n + 3))
 			require.NoError(t, err)
 		}
 		require.Equal(t, 0, cycle.closed)
 
-		_, err = i.Alloc(types.I32(65))
+		_, err = i.Alloc(types.I32(heapRunway + 1))
 		require.NoError(t, err)
 		require.Equal(t, 1, cycle.closed)
 	})
 
 	t.Run("paces from live set", func(t *testing.T) {
-		const capacity = 192
+		const capacity = 3 * heapRunway
 
 		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(capacity))
 		defer i.Close()
 
-		for n := range 65 {
+		for n := range heapRunway + 1 {
 			_, err := i.Alloc(types.I32(n))
 			require.NoError(t, err)
 		}
-		for range capacity - 66 {
+		for range capacity - heapRunway - 2 {
 			value := &trackedValue{}
 			addr, err := i.Alloc(value)
 			require.NoError(t, err)
@@ -3905,7 +3925,7 @@ func TestWithHeap(t *testing.T) {
 			require.NoError(t, i.Release(addr))
 		}
 
-		_, err := i.Alloc(types.I32(65))
+		_, err := i.Alloc(types.I32(heapRunway + 1))
 		require.NoError(t, err)
 
 		cycle := &trackedValue{}
@@ -3916,25 +3936,27 @@ func TestWithHeap(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, i.Release(addr))
 
-		for n := range 62 {
-			_, err = i.Alloc(types.I32(n + 66))
+		// After the first collection, heapRunway+2 slots survive and the
+		// dynamic live set adds heapRunway+1 slots of runway.
+		for n := range heapRunway - 2 {
+			_, err = i.Alloc(types.I32(n + heapRunway + 2))
 			require.NoError(t, err)
 		}
 		require.Equal(t, 0, cycle.closed)
 
-		_, err = i.Alloc(types.I32(128))
+		_, err = i.Alloc(types.I32(2 * heapRunway))
 		require.NoError(t, err)
 		require.Equal(t, 0, cycle.closed)
 
-		_, err = i.Alloc(types.I32(129))
+		_, err = i.Alloc(types.I32(2*heapRunway + 1))
 		require.NoError(t, err)
 		require.Equal(t, 1, cycle.closed)
 	})
 
 	t.Run("resets adaptive goal", func(t *testing.T) {
-		const capacity = 192
+		const capacity = 3 * heapRunway
 
-		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(256))
+		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(4*heapRunway))
 		defer i.Close()
 
 		for n := range capacity {
@@ -3951,13 +3973,15 @@ func TestWithHeap(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, i.Release(addr))
 
-		for n := range 63 {
+		// Reset leaves only null, so the next goal is 1+heapRunway. The
+		// cycle consumes the first dynamic slot.
+		for n := range heapRunway - 1 {
 			_, err = i.Alloc(types.I32(n))
 			require.NoError(t, err)
 		}
 		require.Equal(t, 0, cycle.closed)
 
-		_, err = i.Alloc(types.I32(63))
+		_, err = i.Alloc(types.I32(heapRunway - 1))
 		require.NoError(t, err)
 		require.Equal(t, 1, cycle.closed)
 	})

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3221,7 +3221,7 @@ func TestInterpreter_Store(t *testing.T) {
 		require.ErrorIs(t, err, ErrSegmentationFault)
 	})
 
-	t.Run("preserves self reference", func(t *testing.T) {
+	t.Run("ignores same-address reference", func(t *testing.T) {
 		i := New(program.New(nil))
 		defer i.Close()
 
@@ -3715,6 +3715,33 @@ func TestWithMaxHeap(t *testing.T) {
 		require.Equal(t, 0, value.closed)
 		require.NoError(t, i.Release(addr))
 		require.Equal(t, 1, value.closed)
+	})
+
+	t.Run("preserves duplicate nested constant edges", func(t *testing.T) {
+		const leafAddr = 1
+		const midAddr = 2
+
+		leaf := &trackedValue{}
+		mid := types.NewArray(types.NewArrayType(types.TypeRef), types.BoxRef(leafAddr))
+		root := types.NewArray(types.NewArrayType(types.TypeRef), types.BoxRef(midAddr), types.BoxRef(midAddr))
+		prog := program.New(nil, program.WithConstants(leaf, mid, root))
+		i := New(prog, WithHeap(4), WithMaxHeap(4))
+		defer i.Close()
+
+		_, err := i.Alloc(types.String("blocked"))
+		require.ErrorIs(t, err, ErrHeapExhausted)
+		got, err := i.Load(leafAddr)
+		require.NoError(t, err)
+		require.Same(t, leaf, got)
+		require.Equal(t, 0, leaf.closed)
+
+		i.Reset()
+		_, err = i.Alloc(types.String("blocked again"))
+		require.ErrorIs(t, err, ErrHeapExhausted)
+		got, err = i.Load(leafAddr)
+		require.NoError(t, err)
+		require.Same(t, leaf, got)
+		require.Equal(t, 0, leaf.closed)
 	})
 
 	t.Run("collects unreachable cycle", func(t *testing.T) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3123,6 +3123,19 @@ func TestInterpreter_SetGlobal(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, types.String("value"), v)
 	})
+
+	t.Run("rejects invalid reference", func(t *testing.T) {
+		prog := program.New(nil, program.WithGlobals(types.TypeRef))
+		i := New(prog)
+		defer i.Close()
+
+		before, err := i.Global(0)
+		require.NoError(t, err)
+		require.ErrorIs(t, i.SetGlobal(0, types.BoxRef(9999)), ErrSegmentationFault)
+		after, err := i.Global(0)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	})
 }
 
 func TestInterpreter_Local(t *testing.T) {
@@ -3164,6 +3177,19 @@ func TestInterpreter_SetLocal(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, types.String("value"), v)
 	})
+
+	t.Run("rejects invalid reference", func(t *testing.T) {
+		prog := program.New(nil, program.WithLocals(types.TypeRef))
+		i := New(prog)
+		defer i.Close()
+
+		before, err := i.Local(0)
+		require.NoError(t, err)
+		require.ErrorIs(t, i.SetLocal(0, types.BoxRef(9999)), ErrSegmentationFault)
+		after, err := i.Local(0)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	})
 }
 
 func TestInterpreter_Load(t *testing.T) {
@@ -3184,7 +3210,7 @@ func TestInterpreter_Store(t *testing.T) {
 
 		addr, err := i.Alloc(types.I32(5))
 		require.NoError(t, err)
-		require.NoError(t, i.Store(addr, types.I32(9)))
+		require.NoError(t, i.Store(addr, types.BoxI32(9)))
 		v, err := i.Load(addr)
 		require.NoError(t, err)
 		require.Equal(t, types.I32(9), v)
@@ -3234,6 +3260,106 @@ func TestInterpreter_Store(t *testing.T) {
 		require.NoError(t, err)
 		require.Same(t, value, v)
 	})
+
+	t.Run("ignores identical value", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		loaded, err := i.Load(addr)
+		require.NoError(t, err)
+		require.NoError(t, i.Store(addr, loaded))
+		require.Equal(t, 0, value.closed)
+	})
+
+	t.Run("rejects different-address reference", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		source := &trackedValue{}
+		sourceAddr, err := i.Alloc(source)
+		require.NoError(t, err)
+		targetAddr, err := i.Alloc(types.I32(5))
+		require.NoError(t, err)
+
+		require.ErrorIs(t, i.Store(targetAddr, types.BoxRef(sourceAddr)), ErrTypeMismatch)
+		require.Equal(t, 0, source.closed)
+		v, err := i.Load(targetAddr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(5), v)
+	})
+
+	t.Run("rejects owned pointer", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		source := &trackedValue{}
+		_, err := i.Alloc(source)
+		require.NoError(t, err)
+		targetAddr, err := i.Alloc(types.I32(5))
+		require.NoError(t, err)
+
+		require.ErrorIs(t, i.Store(targetAddr, source), ErrTypeMismatch)
+		require.Equal(t, 0, source.closed)
+		v, err := i.Load(targetAddr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(5), v)
+	})
+
+	t.Run("ignores same-address ref", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		require.NoError(t, i.Store(addr, types.Ref(addr)))
+		require.Equal(t, 0, value.closed)
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Same(t, value, v)
+	})
+
+	t.Run("rejects different-address ref", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		sourceAddr, err := i.Alloc(types.I32(7))
+		require.NoError(t, err)
+		targetAddr, err := i.Alloc(types.I32(5))
+		require.NoError(t, err)
+
+		require.ErrorIs(t, i.Store(targetAddr, types.Ref(sourceAddr)), ErrTypeMismatch)
+		v, err := i.Load(targetAddr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(5), v)
+	})
+
+	t.Run("rejects invalid ref", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		addr, err := i.Alloc(types.I32(5))
+		require.NoError(t, err)
+		require.ErrorIs(t, i.Store(addr, types.Ref(9999)), ErrSegmentationFault)
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(5), v)
+	})
+
+	t.Run("rejects invalid boxed ref", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		addr, err := i.Alloc(types.I32(5))
+		require.NoError(t, err)
+		require.ErrorIs(t, i.Store(addr, types.BoxRef(9999)), ErrSegmentationFault)
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(5), v)
+	})
 }
 
 func TestInterpreter_Alloc(t *testing.T) {
@@ -3279,6 +3405,21 @@ func TestInterpreter_Alloc(t *testing.T) {
 		require.Equal(t, types.String("hi"), v)
 		require.NoError(t, i.Release(copyAddr))
 	})
+
+	t.Run("rejects owned pointer", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		_, err = i.Alloc(value)
+		require.ErrorIs(t, err, ErrTypeMismatch)
+		loaded, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Same(t, value, loaded)
+		require.Equal(t, 0, value.closed)
+	})
 }
 
 func TestInterpreter_Retain(t *testing.T) {
@@ -3306,11 +3447,25 @@ func TestInterpreter_Release(t *testing.T) {
 }
 
 func TestInterpreter_Push(t *testing.T) {
-	i := New(program.New(nil))
-	defer i.Close()
+	t.Run("pushes scalar", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	require.NoError(t, i.Push(types.I32(4)))
-	require.Equal(t, 1, i.Len())
+		require.NoError(t, i.Push(types.I32(4)))
+		require.Equal(t, 1, i.Len())
+	})
+
+	t.Run("rejects owned pointer", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		value := &trackedValue{}
+		_, err := i.Alloc(value)
+		require.NoError(t, err)
+		require.ErrorIs(t, i.Push(value), ErrTypeMismatch)
+		require.Equal(t, 0, i.Len())
+		require.Equal(t, 0, value.closed)
+	})
 }
 
 func TestInterpreter_Pop(t *testing.T) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3692,11 +3692,177 @@ func TestWithHeap(t *testing.T) {
 }
 
 func TestWithMaxHeap(t *testing.T) {
-	prog := program.New([]instr.Instruction{instr.New(instr.I32_CONST, 1), instr.New(instr.REF_NEW)})
-	i := New(prog, WithMaxHeap(1))
-	defer i.Close()
+	t.Run("rejects live heap at limit", func(t *testing.T) {
+		prog := program.New([]instr.Instruction{instr.New(instr.I32_CONST, 1), instr.New(instr.REF_NEW)})
+		i := New(prog, WithMaxHeap(1))
+		defer i.Close()
 
-	require.ErrorIs(t, i.Run(context.Background()), ErrHeapExhausted)
+		require.ErrorIs(t, i.Run(context.Background()), ErrHeapExhausted)
+	})
+
+	t.Run("preserves host-owned reference", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(2), WithMaxHeap(2))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		_, err = i.Alloc(types.String("blocked"))
+		require.ErrorIs(t, err, ErrHeapExhausted)
+		got, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Same(t, value, got)
+		require.Equal(t, 0, value.closed)
+		require.NoError(t, i.Release(addr))
+		require.Equal(t, 1, value.closed)
+	})
+
+	t.Run("collects unreachable cycle", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(3), WithMaxHeap(3))
+		defer i.Close()
+
+		left := &trackedValue{}
+		leftAddr, err := i.Alloc(left)
+		require.NoError(t, err)
+		right := &trackedValue{}
+		rightAddr, err := i.Alloc(right)
+		require.NoError(t, err)
+		left.refs = []types.Ref{types.Ref(rightAddr)}
+		right.refs = []types.Ref{types.Ref(leftAddr)}
+		_, err = i.Retain(rightAddr)
+		require.NoError(t, err)
+		_, err = i.Retain(leftAddr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(leftAddr))
+		require.NoError(t, i.Release(rightAddr))
+
+		addr, err := i.Alloc(types.String("reused"))
+		require.NoError(t, err)
+		require.Equal(t, 1, left.closed)
+		require.Equal(t, 1, right.closed)
+		require.NoError(t, i.Release(addr))
+	})
+
+	t.Run("preserves host-rooted cycle", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(3), WithMaxHeap(3))
+		defer i.Close()
+
+		left := &trackedValue{}
+		leftAddr, err := i.Alloc(left)
+		require.NoError(t, err)
+		right := &trackedValue{}
+		rightAddr, err := i.Alloc(right)
+		require.NoError(t, err)
+		left.refs = []types.Ref{types.Ref(rightAddr)}
+		right.refs = []types.Ref{types.Ref(leftAddr)}
+		_, err = i.Retain(rightAddr)
+		require.NoError(t, err)
+		_, err = i.Retain(leftAddr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(rightAddr))
+
+		_, err = i.Alloc(types.String("blocked"))
+		require.ErrorIs(t, err, ErrHeapExhausted)
+		got, err := i.Load(leftAddr)
+		require.NoError(t, err)
+		require.Same(t, left, got)
+		got, err = i.Load(rightAddr)
+		require.NoError(t, err)
+		require.Same(t, right, got)
+		require.Equal(t, 0, left.closed)
+		require.Equal(t, 0, right.closed)
+
+		require.NoError(t, i.Release(leftAddr))
+		addr, err := i.Alloc(types.String("reused"))
+		require.NoError(t, err)
+		require.Equal(t, 1, left.closed)
+		require.Equal(t, 1, right.closed)
+		require.NoError(t, i.Release(addr))
+	})
+
+	t.Run("collects self cycle", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(2), WithMaxHeap(2))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		value.refs = []types.Ref{types.Ref(addr)}
+		_, err = i.Retain(addr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(addr))
+
+		reused, err := i.Alloc(types.String("reused"))
+		require.NoError(t, err)
+		require.Equal(t, 1, value.closed)
+		require.NoError(t, i.Release(reused))
+	})
+
+	t.Run("collects duplicate cycle edges", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(3), WithMaxHeap(3))
+		defer i.Close()
+
+		left := &trackedValue{}
+		leftAddr, err := i.Alloc(left)
+		require.NoError(t, err)
+		right := &trackedValue{}
+		rightAddr, err := i.Alloc(right)
+		require.NoError(t, err)
+		left.refs = []types.Ref{types.Ref(rightAddr), types.Ref(rightAddr)}
+		right.refs = []types.Ref{types.Ref(leftAddr)}
+		_, err = i.Retain(rightAddr)
+		require.NoError(t, err)
+		_, err = i.Retain(rightAddr)
+		require.NoError(t, err)
+		_, err = i.Retain(leftAddr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(leftAddr))
+		require.NoError(t, i.Release(rightAddr))
+
+		reused, err := i.Alloc(types.String("reused"))
+		require.NoError(t, err)
+		require.Equal(t, 1, left.closed)
+		require.Equal(t, 1, right.closed)
+		require.NoError(t, i.Release(reused))
+	})
+
+	t.Run("settles dead edges to live object", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(4), WithMaxHeap(4))
+		defer i.Close()
+
+		left := &trackedValue{}
+		leftAddr, err := i.Alloc(left)
+		require.NoError(t, err)
+		right := &trackedValue{}
+		rightAddr, err := i.Alloc(right)
+		require.NoError(t, err)
+		live := &trackedValue{}
+		liveAddr, err := i.Alloc(live)
+		require.NoError(t, err)
+		left.refs = []types.Ref{types.Ref(rightAddr), types.Ref(liveAddr)}
+		right.refs = []types.Ref{types.Ref(leftAddr)}
+		_, err = i.Retain(rightAddr)
+		require.NoError(t, err)
+		_, err = i.Retain(liveAddr)
+		require.NoError(t, err)
+		_, err = i.Retain(leftAddr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(leftAddr))
+		require.NoError(t, i.Release(rightAddr))
+
+		reused, err := i.Alloc(types.String("reused"))
+		require.NoError(t, err)
+		require.Equal(t, 1, left.closed)
+		require.Equal(t, 1, right.closed)
+		got, err := i.Load(liveAddr)
+		require.NoError(t, err)
+		require.IsType(t, live, got)
+		require.Same(t, live, got)
+		require.Equal(t, 0, live.closed)
+		require.NoError(t, i.Release(liveAddr))
+		require.Equal(t, 1, live.closed)
+		require.NoError(t, i.Release(reused))
+	})
 }
 
 func TestWithTick(t *testing.T) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3689,6 +3689,123 @@ func TestWithHeap(t *testing.T) {
 		require.NoError(t, i.Run(context.Background()))
 		require.Equal(t, 1, i.Len())
 	})
+
+	t.Run("collects cycles at adaptive goal", func(t *testing.T) {
+		const capacity = 128
+
+		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(capacity))
+		defer i.Close()
+
+		_, err := i.Alloc(types.I32(1))
+		require.NoError(t, err)
+		for range capacity - 2 {
+			value := &trackedValue{}
+			addr, err := i.Alloc(value)
+			require.NoError(t, err)
+			value.refs = []types.Ref{types.Ref(addr)}
+			_, err = i.Retain(addr)
+			require.NoError(t, err)
+			require.NoError(t, i.Release(addr))
+		}
+
+		_, err = i.Alloc(types.I32(2))
+		require.NoError(t, err)
+
+		cycle := &trackedValue{}
+		addr, err := i.Alloc(cycle)
+		require.NoError(t, err)
+		cycle.refs = []types.Ref{types.Ref(addr)}
+		_, err = i.Retain(addr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(addr))
+
+		for n := range 62 {
+			_, err = i.Alloc(types.I32(n + 3))
+			require.NoError(t, err)
+		}
+		require.Equal(t, 0, cycle.closed)
+
+		_, err = i.Alloc(types.I32(65))
+		require.NoError(t, err)
+		require.Equal(t, 1, cycle.closed)
+	})
+
+	t.Run("paces from live set", func(t *testing.T) {
+		const capacity = 192
+
+		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(capacity))
+		defer i.Close()
+
+		for n := range 65 {
+			_, err := i.Alloc(types.I32(n))
+			require.NoError(t, err)
+		}
+		for range capacity - 66 {
+			value := &trackedValue{}
+			addr, err := i.Alloc(value)
+			require.NoError(t, err)
+			value.refs = []types.Ref{types.Ref(addr)}
+			_, err = i.Retain(addr)
+			require.NoError(t, err)
+			require.NoError(t, i.Release(addr))
+		}
+
+		_, err := i.Alloc(types.I32(65))
+		require.NoError(t, err)
+
+		cycle := &trackedValue{}
+		addr, err := i.Alloc(cycle)
+		require.NoError(t, err)
+		cycle.refs = []types.Ref{types.Ref(addr)}
+		_, err = i.Retain(addr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(addr))
+
+		for n := range 62 {
+			_, err = i.Alloc(types.I32(n + 66))
+			require.NoError(t, err)
+		}
+		require.Equal(t, 0, cycle.closed)
+
+		_, err = i.Alloc(types.I32(128))
+		require.NoError(t, err)
+		require.Equal(t, 0, cycle.closed)
+
+		_, err = i.Alloc(types.I32(129))
+		require.NoError(t, err)
+		require.Equal(t, 1, cycle.closed)
+	})
+
+	t.Run("resets adaptive goal", func(t *testing.T) {
+		const capacity = 192
+
+		i := New(program.New(nil), WithHeap(capacity), WithMaxHeap(256))
+		defer i.Close()
+
+		for n := range capacity {
+			_, err := i.Alloc(types.I32(n))
+			require.NoError(t, err)
+		}
+		i.Reset()
+
+		cycle := &trackedValue{}
+		addr, err := i.Alloc(cycle)
+		require.NoError(t, err)
+		cycle.refs = []types.Ref{types.Ref(addr)}
+		_, err = i.Retain(addr)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(addr))
+
+		for n := range 63 {
+			_, err = i.Alloc(types.I32(n))
+			require.NoError(t, err)
+		}
+		require.Equal(t, 0, cycle.closed)
+
+		_, err = i.Alloc(types.I32(63))
+		require.NoError(t, err)
+		require.Equal(t, 1, cycle.closed)
+	})
 }
 
 func TestWithMaxHeap(t *testing.T) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -25,6 +25,24 @@ type contextKey struct{}
 
 type contextHost struct{}
 
+type trackedValue struct {
+	refs   []types.Ref
+	closed int
+}
+
+func (v *trackedValue) Kind() types.Kind { return types.KindRef }
+func (v *trackedValue) Type() types.Type { return types.TypeRef }
+func (v *trackedValue) String() string   { return "tracked" }
+
+func (v *trackedValue) Refs(dst []types.Ref) []types.Ref {
+	return append(dst, v.refs...)
+}
+
+func (v *trackedValue) Close() error {
+	v.closed++
+	return nil
+}
+
 func (*contextHost) Value(ctx context.Context) int32 {
 	if ctx.Value(contextKey{}) == "value" {
 		return 7
@@ -3080,15 +3098,31 @@ func TestInterpreter_Global(t *testing.T) {
 }
 
 func TestInterpreter_SetGlobal(t *testing.T) {
-	prog := program.New([]instr.Instruction{instr.New(instr.I32_CONST, 0), instr.New(instr.GLOBAL_SET, 0)}, program.WithGlobals(types.TypeI32))
-	i := New(prog)
-	defer i.Close()
+	t.Run("sets scalar", func(t *testing.T) {
+		prog := program.New([]instr.Instruction{instr.New(instr.I32_CONST, 0), instr.New(instr.GLOBAL_SET, 0)}, program.WithGlobals(types.TypeI32))
+		i := New(prog)
+		defer i.Close()
 
-	require.NoError(t, i.Run(context.Background()))
-	require.NoError(t, i.SetGlobal(0, types.BoxI32(8)))
-	v, err := i.Global(0)
-	require.NoError(t, err)
-	require.Equal(t, types.BoxI32(8), v)
+		require.NoError(t, i.Run(context.Background()))
+		require.NoError(t, i.SetGlobal(0, types.BoxI32(8)))
+		v, err := i.Global(0)
+		require.NoError(t, err)
+		require.Equal(t, types.BoxI32(8), v)
+	})
+
+	t.Run("preserves same reference", func(t *testing.T) {
+		prog := program.New(nil, program.WithGlobals(types.TypeRef))
+		i := New(prog)
+		defer i.Close()
+
+		addr, err := i.Alloc(types.String("value"))
+		require.NoError(t, err)
+		require.NoError(t, i.SetGlobal(0, types.BoxRef(addr)))
+		require.NoError(t, i.SetGlobal(0, types.BoxRef(addr)))
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.String("value"), v)
+	})
 }
 
 func TestInterpreter_Local(t *testing.T) {
@@ -3105,15 +3139,31 @@ func TestInterpreter_Local(t *testing.T) {
 }
 
 func TestInterpreter_SetLocal(t *testing.T) {
-	prog := program.New([]instr.Instruction{instr.New(instr.YIELD)}, program.WithLocals(types.TypeI32))
-	i := New(prog)
-	defer i.Close()
+	t.Run("sets scalar", func(t *testing.T) {
+		prog := program.New([]instr.Instruction{instr.New(instr.YIELD)}, program.WithLocals(types.TypeI32))
+		i := New(prog)
+		defer i.Close()
 
-	require.ErrorIs(t, i.Run(context.Background()), ErrYield)
-	require.NoError(t, i.SetLocal(0, types.BoxI32(3)))
-	v, err := i.Local(0)
-	require.NoError(t, err)
-	require.Equal(t, types.BoxI32(3), v)
+		require.ErrorIs(t, i.Run(context.Background()), ErrYield)
+		require.NoError(t, i.SetLocal(0, types.BoxI32(3)))
+		v, err := i.Local(0)
+		require.NoError(t, err)
+		require.Equal(t, types.BoxI32(3), v)
+	})
+
+	t.Run("preserves same reference", func(t *testing.T) {
+		prog := program.New(nil, program.WithLocals(types.TypeRef))
+		i := New(prog)
+		defer i.Close()
+
+		addr, err := i.Alloc(types.String("value"))
+		require.NoError(t, err)
+		require.NoError(t, i.SetLocal(0, types.BoxRef(addr)))
+		require.NoError(t, i.SetLocal(0, types.BoxRef(addr)))
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.String("value"), v)
+	})
 }
 
 func TestInterpreter_Load(t *testing.T) {
@@ -3128,26 +3178,107 @@ func TestInterpreter_Load(t *testing.T) {
 }
 
 func TestInterpreter_Store(t *testing.T) {
-	i := New(program.New(nil))
-	defer i.Close()
+	t.Run("replaces scalar", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	addr, err := i.Alloc(types.I32(5))
-	require.NoError(t, err)
-	require.NoError(t, i.Store(addr, types.I32(9)))
-	v, err := i.Load(addr)
-	require.NoError(t, err)
-	require.Equal(t, types.I32(9), v)
+		addr, err := i.Alloc(types.I32(5))
+		require.NoError(t, err)
+		require.NoError(t, i.Store(addr, types.I32(9)))
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(9), v)
+	})
+
+	t.Run("finalizes replaced value", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		old := &trackedValue{}
+		addr, err := i.Alloc(old)
+		require.NoError(t, err)
+		require.NoError(t, i.Store(addr, types.I32(9)))
+		require.Equal(t, 1, old.closed)
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.I32(9), v)
+	})
+
+	t.Run("releases replaced child", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		child, err := i.Alloc(types.String("child"))
+		require.NoError(t, err)
+		_, err = i.Retain(child)
+		require.NoError(t, err)
+		parent := &trackedValue{refs: []types.Ref{types.Ref(child)}}
+		addr, err := i.Alloc(parent)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(child))
+		require.NoError(t, i.Store(addr, types.I32(9)))
+		_, err = i.Load(child)
+		require.ErrorIs(t, err, ErrSegmentationFault)
+	})
+
+	t.Run("preserves self reference", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		require.NoError(t, i.Store(addr, types.BoxRef(addr)))
+		require.Equal(t, 0, value.closed)
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Same(t, value, v)
+	})
 }
 
 func TestInterpreter_Alloc(t *testing.T) {
-	i := New(program.New(nil))
-	defer i.Close()
+	t.Run("allocates value", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
 
-	addr, err := i.Alloc(types.String("hi"))
-	require.NoError(t, err)
-	v, err := i.Load(addr)
-	require.NoError(t, err)
-	require.Equal(t, types.String("hi"), v)
+		addr, err := i.Alloc(types.String("hi"))
+		require.NoError(t, err)
+		v, err := i.Load(addr)
+		require.NoError(t, err)
+		require.Equal(t, types.String("hi"), v)
+	})
+
+	t.Run("copies boxed reference ownership", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		addr, err := i.Alloc(types.String("hi"))
+		require.NoError(t, err)
+		copyAddr, err := i.Alloc(types.BoxRef(addr))
+		require.NoError(t, err)
+		require.Equal(t, addr, copyAddr)
+		require.NoError(t, i.Release(addr))
+		v, err := i.Load(copyAddr)
+		require.NoError(t, err)
+		require.Equal(t, types.String("hi"), v)
+		require.NoError(t, i.Release(copyAddr))
+	})
+
+	t.Run("copies reference ownership", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		addr, err := i.Alloc(types.String("hi"))
+		require.NoError(t, err)
+		copyAddr, err := i.Alloc(types.Ref(addr))
+		require.NoError(t, err)
+		require.Equal(t, addr, copyAddr)
+		require.NoError(t, i.Release(addr))
+		v, err := i.Load(copyAddr)
+		require.NoError(t, err)
+		require.Equal(t, types.String("hi"), v)
+		require.NoError(t, i.Release(copyAddr))
+	})
 }
 
 func TestInterpreter_Retain(t *testing.T) {
@@ -3312,6 +3443,24 @@ func TestInterpreter_Reset(t *testing.T) {
 		i.Reset()
 		require.Equal(t, i.base, len(i.heap))
 		require.Equal(t, 0, i.sp)
+	})
+
+	t.Run("finalizes and clears dynamic values", func(t *testing.T) {
+		i := New(program.New(nil), WithHeap(4))
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, addr, i.base)
+
+		i.Reset()
+		require.Equal(t, 1, value.closed)
+		full := i.heap[:cap(i.heap)]
+		for _, slot := range full[i.base:] {
+			require.Nil(t, slot)
+		}
+		require.NoError(t, i.Close())
+		require.Equal(t, 1, value.closed)
 	})
 }
 

--- a/interp/marshal.go
+++ b/interp/marshal.go
@@ -71,7 +71,6 @@ type fieldPlan struct {
 type marshalState struct {
 	m    *codec
 	i    *Interpreter
-	root int
 	seen map[uintptr]bool
 }
 
@@ -196,7 +195,6 @@ func structOf(i *Interpreter, val types.Value) (*types.Struct, bool) {
 
 func (m *codec) Marshal(i *Interpreter, v any) (types.Value, error) {
 	state := &marshalState{m: m, i: i, seen: make(map[uintptr]bool)}
-	defer state.close()
 	return state.value(reflect.ValueOf(v))
 }
 
@@ -640,7 +638,6 @@ func (s *marshalState) wrapFunc(fn reflect.Value, typ *types.FunctionType) *Host
 
 		returns := make([]types.Boxed, len(out))
 		marshal := &marshalState{m: m, i: i, seen: make(map[uintptr]bool)}
-		defer marshal.close()
 		for idx := range out {
 			boxed, err := marshal.boxAs(out[idx], typ.Returns[idx])
 			if err != nil {
@@ -801,9 +798,7 @@ func (s *marshalState) boxRef(val types.Value) types.Boxed {
 	case types.Ref:
 		return types.BoxRef(int(v))
 	case types.String:
-		ref := s.i.intern(string(v))
-		s.root += s.i.root(types.BoxRef(int(ref)))
-		return types.BoxRef(int(ref))
+		return types.BoxRef(int(s.i.intern(string(v))))
 	default:
 		return types.BoxRef(s.alloc(val))
 	}
@@ -814,13 +809,7 @@ func (s *marshalState) alloc(val types.Value) int {
 	if err != nil {
 		panic(err)
 	}
-	s.root += s.i.root(types.BoxRef(addr))
 	return addr
-}
-
-func (s *marshalState) close() {
-	s.i.unroot(s.root)
-	s.root = 0
 }
 
 func (s *unmarshalState) value(val types.Value, dst reflect.Value) error {
@@ -1214,7 +1203,6 @@ func (m *codec) unmarshalFunc(fnType *types.FunctionType) unmarshaler {
 			}
 			boxed := make([]types.Boxed, len(in)-offset)
 			marshal := &marshalState{m: m, i: s.i, seen: make(map[uintptr]bool)}
-			defer marshal.close()
 			for idx := range boxed {
 				v, err := marshal.boxAs(in[idx+offset], fnType.Params[idx])
 				if err != nil {

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -281,10 +281,12 @@ func (r *Tracer) clone(i *Interpreter) Interpreter {
 	out.journal = append([]uint64(nil), i.journal...)
 	out.frames = append([]frame(nil), i.frames...)
 	out.stack = append([]types.Boxed(nil), i.stack...)
-	out.roots = append([]types.Boxed(nil), i.roots...)
 	out.heap = r.heap(i.heap)
 	out.free = append([]int(nil), i.free...)
 	out.rc = append([]int(nil), i.rc...)
+	out.trial = nil
+	out.work = nil
+	out.refbuf = nil
 	out.interned = make(map[string]types.Ref, len(i.interned))
 	for key, val := range i.interned {
 		out.interned[key] = val


### PR DESCRIPTION
### **Changes Made**
- correct heap ownership for `Alloc`, `Push`, `SetGlobal`, `SetLocal`, and `Store`, including validated refs, unique concrete-pointer ownership, same-value no-ops, and deterministic finalization
- replace the explicit root registry with RC-derived trial deletion while preserving stable heap indices and iterative release
- preserve exact constant-root and nested-edge counts during interpreter construction and `Reset`
- add regression coverage for host-owned refs, self/multi-object cycles, duplicate edges, dead-to-live edges, finalizers, constant graphs, adaptive collection, and reset pacing
- add live-set-based GC pacing with a 64-slot minimum runway, hard-limit clamping, and one collection per allocation attempt
- consolidate adaptive, backing-capacity, and hard-limit collection into one allocation flow
- update the memory model, host integration, and architecture documentation

### **Related Issues**
- Follow-up to #86
- Follow-up to #103

### **Additional Information**
- Self-review found that duplicate nested constant edges could produce a negative residual count and allow a live constant child to be reclaimed; `recount` now rebuilds exact baseline counts after construction and reset, and the collector rejects negative residual counts before marking.
- Follow-up review found that `Store` could shallow-alias another heap slot, duplicate finalizers, and undercount nested refs; different-address refs and already-owned concrete pointers are now rejected, while `Alloc(existingRef)` remains the explicit sharing path.
- `SetGlobal` and `SetLocal` now reject invalid heap refs before mutating or releasing the existing slot.
- P3 pool shedding, public pacing controls, and GC statistics are intentionally out of scope.
- Verification:
  - `make lint`
  - `go test -count=1 -race ./...`
- No throughput benchmark claim is made; P2 bounds cycle retention and avoids repeated collection from small live sets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified VM heap ownership, host interaction rules, and value lifetime across `Reset`/`Close`.
  - Updated the memory model to use exact reference counting and a trial-deletion mark-and-sweep cycle collector.

- **Bug Fixes**
  - Improved reference lifecycle correctness for `SetGlobal`, `SetLocal`, `Store`, and `Alloc`, including self-assignment no-ops and proper release/finalization on replacement.
  - Reworked cycle collection and heap/`Reset` behavior for more reliable reclamation.

- **Tests**
  - Expanded coverage for heap limits, `Reset` finalization, ownership transfer, and multiple cycle-collection regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->