### PR TITLE
perf: optimize primitive array mutation loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Representative medians measured July 15, 2026, on Apple M4 Pro,
 |---|---:|---:|---:|---:|
 | native Go | 8.337 | 20,957,448 | 247.8 | 77.39 |
 | wazero | 49.84 | 46,785,131 | 645.4 | 156.9 |
-| **minivm/default** | **71.83** | **48,426,669** | **5,269** | **228.0** |
-| minivm/threaded | 730.9 | 512,675,498 | 16,143 | 986.4 |
+| **minivm/default** | **71.83** | **48,426,669** | **5,048** | **228.0** |
+| minivm/threaded | 730.9 | 512,675,498 | 15,542 | 986.4 |
 
 `minivm/default` uses the adaptive ARM64 trace-JIT policy. Results vary by
 workload: unsupported paths remain in the threaded interpreter, and some

--- a/README.md
+++ b/README.md
@@ -93,15 +93,15 @@ lifetime rules.
 minivm is designed to be useful before JIT compilation and faster when repeated
 execution makes native traces worthwhile.
 
-Representative medians from the canonical suite on Apple M4 Pro,
+Representative medians measured July 15, 2026, on Apple M4 Pro,
 `darwin/arm64`, Go 1.26.2 (`ns/op`, lower is better):
 
-| Runtime | Iterative Fib | Recursive Fib | Branch Tree |
-|---|---:|---:|---:|
-| native Go | 8.444 | 19,129,096 | 77.55 |
-| wazero | 47.98 | 44,150,405 | 156.3 |
-| **minivm/default** | **69.9** | **47,048,123** | **222.4** |
-| minivm/threaded | 718.5 | 487,293,996 | 949.4 |
+| Runtime | Iterative Fib (30) | Recursive Fib (35) | Sieve (256) | Branch Tree (96) |
+|---|---:|---:|---:|---:|
+| native Go | 8.337 | 20,957,448 | 247.8 | 77.39 |
+| wazero | 49.84 | 46,785,131 | 645.4 | 156.9 |
+| **minivm/default** | **71.83** | **48,426,669** | **5,269** | **228.0** |
+| minivm/threaded | 730.9 | 512,675,498 | 16,143 | 986.4 |
 
 `minivm/default` uses the adaptive ARM64 trace-JIT policy. Results vary by
 workload: unsupported paths remain in the threaded interpreter, and some

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ Representative medians measured July 15, 2026, on Apple M4 Pro,
 |---|---:|---:|---:|---:|
 | native Go | 8.337 | 20,957,448 | 247.8 | 77.39 |
 | wazero | 49.84 | 46,785,131 | 645.4 | 156.9 |
-| **minivm/default** | **71.83** | **48,426,669** | **5,048** | **228.0** |
-| minivm/threaded | 730.9 | 512,675,498 | 15,542 | 986.4 |
+| **minivm/default** | **71.83** | **48,426,669** | **5,052** | **228.0** |
+| minivm/threaded | 730.9 | 512,675,498 | 15,385 | 986.4 |
 
 `minivm/default` uses the adaptive ARM64 trace-JIT policy. Results vary by
 workload: unsupported paths remain in the threaded interpreter, and some

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -65,6 +65,6 @@ Keep inputs deterministic. Add a kernel only when it exposes a distinct VM signa
 
 ## Related Docs
 
-- `../docs/benchmarks.md` - benchmark ownership, methodology, and historical measurements
+- `../docs/benchmarks.md` - current measurements, ownership, and methodology
 - `../docs/instruction-set.md` - opcode semantics and JIT support
 - `../docs/jit-internals.md` - trace and native execution lifecycle

--- a/benchmarks/control_test.go
+++ b/benchmarks/control_test.go
@@ -26,13 +26,35 @@ func TestControl_IterativeFib(t *testing.T) {
 func TestControl_Sieve(t *testing.T) {
 	prog := sieve(256)
 	require.NoError(t, program.Verify(prog))
-	vm := interp.New(prog, interp.WithThreshold(-1))
-	defer vm.Close()
+	want := types.BoxI32(sieveReference(256))
+	tests := []struct {
+		name string
+		new  func(*program.Program) *interp.Interpreter
+	}{
+		{name: "default", new: func(prog *program.Program) *interp.Interpreter {
+			return interp.New(prog)
+		}},
+		{name: "threaded", new: func(prog *program.Program) *interp.Interpreter {
+			return interp.New(prog, interp.WithThreshold(-1))
+		}},
+		{name: "jit", new: func(prog *program.Program) *interp.Interpreter {
+			return interp.New(prog, interp.WithThreshold(0))
+		}},
+	}
 
-	require.NoError(t, vm.Run(context.Background()))
-	value, err := vm.Pop()
-	require.NoError(t, err)
-	require.Equal(t, types.I32(sieveReference(256)), value)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vm := tt.new(prog)
+			defer vm.Close()
+			for range 16 {
+				require.NoError(t, vm.Run(context.Background()))
+				value, err := vm.PopBoxed()
+				require.NoError(t, err)
+				require.Equal(t, want, value)
+				vm.Reset()
+			}
+		})
+	}
 }
 
 func BenchmarkControl_IterativeFib(b *testing.B) {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ For plain functions, `addr == ref`. For closures, `addr` points to the function 
 ### JIT
 
 
-The interpreter requests native compilation through `compiler.Compile(i, addr)` only. The compiler runs the static and trace frontends internally; both produce the same flat, backend-neutral plan with block-ID edges, and installation depends only on the entry ABI kind.
+The interpreter requests native compilation through `compiler.Compile(i, root)` only. The compiler runs the static and trace frontends internally; both produce the same flat, backend-neutral plan with block-ID edges, and installation depends only on the entry ABI kind.
 
 - Native code is speculative and guarded.
 - Blocks with declared entry state carry no register state across edges; stack and dirty locals are materialized in VM memory.
@@ -173,7 +173,7 @@ The interpreter requests native compilation through `compiler.Compile(i, addr)` 
 - JIT handlers must not duplicate complex interpreter behavior unless they can own all semantics.
 - Guard failure materializes VM state and resumes threaded dispatch.
 - ARM64 label branches are range-checked and relaxed only to replacements that are already in range; an unreachable target falls back to threaded execution.
-- Spill frames use a stable base register, and every internal call resume point must restore the active spill-frame depth. Loop traces and terminal mutation traces disable spilling when control flow cannot preserve that contract.
+- Spill frames use a stable base register, and every internal call resume point must restore the active spill-frame depth. Loop traces and plans containing heap mutation disable spilling when control flow cannot preserve that contract.
 
 See `jit-internals.md` for trace recording, journal layout, calls, branches, loops, and fallback rules.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -59,7 +59,7 @@ go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
 
 - `RecursiveFib(35)` places `minivm/default` at **48.43 ms**, within about **3.5%** of wazero's **46.79 ms**, while remaining allocation-free after warmup.
 - Adaptive native traces reduce `IterativeFib(30)` from **730.9 ns** threaded to **71.83 ns**, `TypedArraySum(256)` from **6.239 us** to **655.2 ns**, and `BranchTree(96)` from **986.4 ns** to **228.0 ns**.
-- Primitive array mutation stays on the native loop path in `Sieve(256)`: `default` is **5.048 us** and eager `jit` is **5.033 us**, versus **15.542 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
+- Primitive array mutation stays on the native loop path in `Sieve(256)`: `default` is **5.052 us** and eager `jit` is **5.017 us**, versus **15.385 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
 - Threshold-zero `jit` is not a warmed-JIT guarantee. It matches `default` on Sieve and BranchTree, but is slower on IterativeFib, TypedArraySum, and recursive Fibonacci because it can compile before representative traces are learned.
 - Allocation-heavy workloads remain interpreter-bound. `AllocationGraph(128)` is fastest in minivm's threaded mode at **7.513 us**; adaptive and eager modes add profiling cost without native coverage.
 - Indirect recursion remains a major gap: `IndirectRecursiveFib(20)` takes about **598 us** in adaptive/eager modes, versus **41.8 us** in wazero.
@@ -94,9 +94,9 @@ Each minivm kernel times `Interpreter.Run` only. Result extraction, reset, fixtu
 | IterativeFib(30) | Goja | 2,166 | 368 | 20 |
 | IterativeFib(30) | gpython | 2,427 | 2,448 | 88 |
 | IterativeFib(30) | Yaegi | 2,709 | 2,036 | 101 |
-| Sieve(256) | minivm/default | 5,048 | 1,048 | 2 |
-| Sieve(256) | minivm/threaded | 15,542 | 1,048 | 2 |
-| Sieve(256) | minivm/jit | 5,033 | 1,048 | 2 |
+| Sieve(256) | minivm/default | 5,052 | 1,048 | 2 |
+| Sieve(256) | minivm/threaded | 15,385 | 1,048 | 2 |
+| Sieve(256) | minivm/jit | 5,017 | 1,048 | 2 |
 | Sieve(256) | native Go | 247.8 | 0 | 0 |
 | Sieve(256) | wazero | 645.4 | 8 | 1 |
 | Sieve(256) | Tengo | 51,918 | 122,504 | 1,611 |
@@ -211,7 +211,7 @@ Scalar stack access, reset, retain/release, and uncontended pool reuse are alloc
 
 | Case | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| pre-hot unconditional backedge | 2,383 | 0 | 0 |
+| pre-hot unconditional backedge | 2,446 | 0 | 0 |
 
 This benchmark guards the cold-path boundary: exact backedge observation is installed only after periodic sampling marks a function hot, rather than adding a callback or header scan to every cold loop iteration.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -46,6 +46,10 @@ go test -run='^$' \
 go test -run='^$' -bench='^BenchmarkInterpreter_Run/.*/Threaded$' \
   -benchmem -benchtime=300ms -count=3 ./interp
 
+# Pre-hot unconditional-backedge overhead
+go test -run='^$' -bench='^BenchmarkInterpreter_PreHotBackedge$' \
+  -benchmem -benchtime=300ms -count=3 ./interp
+
 # Reference traversal
 go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
   -benchmem -benchtime=300ms -count=3 ./types
@@ -55,7 +59,7 @@ go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
 
 - `RecursiveFib(35)` places `minivm/default` at **48.43 ms**, within about **3.5%** of wazero's **46.79 ms**, while remaining allocation-free after warmup.
 - Adaptive native traces reduce `IterativeFib(30)` from **730.9 ns** threaded to **71.83 ns**, `TypedArraySum(256)` from **6.239 us** to **655.2 ns**, and `BranchTree(96)` from **986.4 ns** to **228.0 ns**.
-- Primitive array mutation now stays on the native loop path in `Sieve(256)`: `default` is **5.269 us** and eager `jit` is **5.261 us**, versus **16.143 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
+- Primitive array mutation stays on the native loop path in `Sieve(256)`: `default` is **5.048 us** and eager `jit` is **5.033 us**, versus **15.542 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
 - Threshold-zero `jit` is not a warmed-JIT guarantee. It matches `default` on Sieve and BranchTree, but is slower on IterativeFib, TypedArraySum, and recursive Fibonacci because it can compile before representative traces are learned.
 - Allocation-heavy workloads remain interpreter-bound. `AllocationGraph(128)` is fastest in minivm's threaded mode at **7.513 us**; adaptive and eager modes add profiling cost without native coverage.
 - Indirect recursion remains a major gap: `IndirectRecursiveFib(20)` takes about **598 us** in adaptive/eager modes, versus **41.8 us** in wazero.
@@ -90,9 +94,9 @@ Each minivm kernel times `Interpreter.Run` only. Result extraction, reset, fixtu
 | IterativeFib(30) | Goja | 2,166 | 368 | 20 |
 | IterativeFib(30) | gpython | 2,427 | 2,448 | 88 |
 | IterativeFib(30) | Yaegi | 2,709 | 2,036 | 101 |
-| Sieve(256) | minivm/default | 5,269 | 1,048 | 2 |
-| Sieve(256) | minivm/threaded | 16,143 | 1,048 | 2 |
-| Sieve(256) | minivm/jit | 5,261 | 1,048 | 2 |
+| Sieve(256) | minivm/default | 5,048 | 1,048 | 2 |
+| Sieve(256) | minivm/threaded | 15,542 | 1,048 | 2 |
+| Sieve(256) | minivm/jit | 5,033 | 1,048 | 2 |
 | Sieve(256) | native Go | 247.8 | 0 | 0 |
 | Sieve(256) | wazero | 645.4 | 8 | 1 |
 | Sieve(256) | Tengo | 51,918 | 122,504 | 1,611 |
@@ -200,6 +204,16 @@ These benchmarks measure the named public operation. Setup, validation, cleanup,
 | Pool | `Put, uncontended` | 125.5 | 0 | 0 |
 
 Scalar stack access, reset, retain/release, and uncontended pool reuse are allocation-free. Construction and pool misses are dominated by interpreter state allocation. `SharedJITMiss` includes a new pooled interpreter synchronizing against shared JIT state.
+
+## JIT Activation Overhead
+
+`BenchmarkInterpreter_PreHotBackedge` runs a 256-iteration counting loop with `WithTick(1<<20)` and `WithThreshold(1<<30)`, including `Run`, `PopBoxed`, and `Reset`. The function remains below the sample threshold, so it keeps the ordinary generated `BR` handler.
+
+| Case | ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| pre-hot unconditional backedge | 2,383 | 0 | 0 |
+
+This benchmark guards the cold-path boundary: exact backedge observation is installed only after periodic sampling marks a function hot, rather than adding a callback or header scan to every cold loop iteration.
 
 ## Threaded Execution Samples
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -53,7 +53,7 @@ The canonical cross-runtime suite shows both the strengths and the current limit
 - `RecursiveFib(35)` places `minivm/default` near wazero and ahead of the script runtimes measured here, while remaining zero-allocation after warmup.
 - `IterativeFib(30)` and `BranchTree(96)` show the adaptive default tier in the same order of magnitude as wazero while remaining allocation-free.
 - `TypedArraySum(256)` is allocation-free in all minivm modes, but wazero remains materially faster in this fixture.
-- `Sieve(256)` favors the pure threaded interpreter: **16.33 us** versus about **40 us** for `default` and eager `jit`. The benchmark records the gap but does not isolate whether it comes from profiling, fallback, or unsupported paths.
+- `Sieve(256)` now favors native loop traces: `default` is **5.165 us** and eager `jit` is **5.172 us**, versus **15.831 us** for the threaded interpreter. All three modes allocate only the typed array itself (`1,048 B`, `2 allocs`).
 - `IndirectRecursiveFib(20)` is a clear weak point: `minivm/default` is substantially slower than wazero despite remaining allocation-free.
 - `AllocationGraph(128)` exposes object-management cost. minivm is faster than Tengo, Goja, and Yaegi, but slower than gpython and gopher-lua in this fixture.
 
@@ -69,7 +69,7 @@ These results are workload measurements, not general language rankings. The runt
 | `threaded` | `interp.New(prog, interp.WithThreshold(-1))` | JIT disabled; pure threaded execution |
 | `jit` | `interp.New(prog, interp.WithThreshold(0))` | eager profiling/compilation policy; not a precompiled or guaranteed-native steady state |
 
-The `jit` label therefore means **threshold zero**, not “fully warmed native code.” It can be slower than `default` when early compilation produces incomplete traces or when the workload is dominated by unsupported allocation and mutation paths.
+The `jit` label therefore means **threshold zero**, not “fully warmed native code.” Function and module entries become eligible on the first sample, while loop roots reached through an unconditional backward branch wait for eight exact back-edges so the first iteration does not bias the recorded branch path. It can still be slower than `default` when early entry compilation produces incomplete traces or when the workload is dominated by unsupported allocation paths.
 
 Each runtime measures an already prepared callable through result recovery. Compilation, module construction, fixture injection, warmup, and minivm `Reset` are excluded. Runtime-specific host-call and result-conversion costs remain part of the measured invocation, so small differences should not be interpreted as VM-core instruction throughput alone.
 
@@ -89,9 +89,9 @@ Environment: Apple M4 Pro, `darwin/arm64`, Go 1.26.2. Command: `go test -tags=co
 | IterativeFib(30) | goja | 2,137 | 368 | 20 |
 | IterativeFib(30) | gpython | 2,440 | 2,448 | 88 |
 | IterativeFib(30) | yaegi | 2,695 | 2,036 | 101 |
-| Sieve(256) | minivm/default | 40,195 | 28,968 | 407 |
-| Sieve(256) | minivm/threaded | 16,328 | 1,048 | 2 |
-| Sieve(256) | minivm/jit | 39,960 | 28,968 | 407 |
+| Sieve(256) | minivm/default | 5,165 | 1,048 | 2 |
+| Sieve(256) | minivm/threaded | 15,831 | 1,048 | 2 |
+| Sieve(256) | minivm/jit | 5,172 | 1,048 | 2 |
 | Sieve(256) | native | 229.9 | 0 | 0 |
 | Sieve(256) | wazero | 642.4 | 8 | 1 |
 | Sieve(256) | tengo | 51,497 | 122,504 | 1,611 |
@@ -248,7 +248,7 @@ For the deep-recursion `fib(35)` result with JIT enabled, see the cross-runtime 
 
 On ARM64, minivm compiles hot recorded traces to native code. Supported paths include numeric operations, direct calls, selected indirect function dispatch, ref-counted slots, selected read-only heap operations, and loops with safepoint polling.
 
-Unsupported paths either deoptimize or continue through the threaded interpreter. These include allocation, mutation, host calls, heap-promoted i64 values, and unsupported heap shapes.
+Unsupported paths either deoptimize or continue through the threaded interpreter. These include allocation, ref-bearing or complex mutation, host calls, heap-promoted i64 values, and unsupported heap shapes. Guarded primitive typed-array stores can remain inside native loop traces.
 
 The default threshold is `4096` executed instructions, which is about 32 samples at the default tick interval of 128.
 
@@ -256,9 +256,10 @@ The default threshold is `4096` executed instructions, which is about 32 samples
 
 The current canonical kernels show that native trace coverage is workload-dependent:
 
-- adaptive `default` is effective for direct recursive calls, iterative numeric loops, typed-array reads, and branch-heavy scalar code
-- threshold-zero `jit` is not equivalent to a warmed native cache and may compile too early to outperform the adaptive default
-- allocation and mutation-heavy kernels such as `Sieve` and `AllocationGraph` can remain faster in the threaded interpreter
+- adaptive `default` is effective for direct recursive calls, iterative numeric loops, typed-array reads, guarded primitive typed-array writes, and branch-heavy scalar code
+- threshold-zero `jit` is not equivalent to a warmed native cache, but exact back-edge warmup keeps loop capture from over-specializing the first iteration
+- `Sieve(256)` now runs about 3.1 times faster in `default` and eager `jit` than in the threaded interpreter, while preserving the same allocation count
+- allocation-heavy object kernels such as `AllocationGraph` remain limited by heap management rather than scalar trace throughput
 - indirect recursive calls remain substantially slower than wazero and are a priority for call-target and trace-continuation optimization
 
 Use the complete cross-runtime table above for current numbers. Do not infer JIT entry solely from the `jit` sub-benchmark name; profiler metrics are required when a benchmark specifically claims native entry.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Benchmark results, execution characteristics, and measurement methodology for minivm.
+Current performance results, execution characteristics, and measurement methodology for minivm.
 
 ## When to Read
 
@@ -12,52 +12,55 @@ For implementation details, see `docs/jit-internals.md`. For profiling counters,
 
 | Concern | File or command |
 |---|---|
-| full benchmark suite | `make benchmark` |
-| interpreter benchmarks | `interp` package benchmarks |
-| cross-runtime benchmarks | `benchmarks/` module |
+| package and public API benchmarks | `interp/*_test.go`, `types/*_test.go` |
+| runtime-neutral VM kernels | `benchmarks/` module |
+| full canonical suite | `make benchmark-core` |
+| pull-request smoke suite | `make benchmark-pr` |
+| external runtime comparison | `make benchmark-compare` |
 | profiling counters | `docs/profile.md` |
-| platform support | `docs/compatibility.md` |
 
-## Environment
+## Measurement Environment
 
-Unless stated otherwise, benchmarks were run on:
+All numbers in this document were measured on July 15, 2026:
 
-- `darwin/arm64`
 - Apple M4 Pro, 12 cores
+- `darwin/arm64`
+- macOS 26.4.1
 - Go 1.26.2
 
-minivm currently provides ARM64 JIT support only. On ARM64, the default `interp.New` can compile hot recorded traces, including function entries and loop headers, into native code. Pure interpreter benchmarks disable the JIT with `WithThreshold(-1)`.
+Every table reports the median of three sequential samples. Lower `ns/op`, `B/op`, and `allocs/op` are better. The runs were executed serially so concurrent benchmark processes did not compete for CPU time.
 
-## Running Benchmarks
+## Reproduction
 
 ```bash
-# Full canonical package and VM-kernel suite
-make benchmark-core
-
-# Pull-request-sized benchmark suite
-make benchmark-pr
-
-# Cross-runtime comparison, matching the table below
+# Full external comparison used by the complete matrix
 cd benchmarks
 go test -tags=compare -run='^$' -bench='.' -benchmem -benchtime=300ms -count=3 ./...
+
+# Public interpreter and pool API costs
+go test -run='^$' \
+  -bench='^(BenchmarkNew|BenchmarkInterpreter_(Reset|Push|Pop|PopBoxed|Peek|Alloc|Retain|Release)|BenchmarkPool_(Get|Put))$' \
+  -benchmem -benchtime=300ms -count=3 ./interp
+
+# Exact threaded execution samples
+go test -run='^$' -bench='^BenchmarkInterpreter_Run/.*/Threaded$' \
+  -benchmem -benchtime=300ms -count=3 ./interp
+
+# Reference traversal
+go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
+  -benchmem -benchtime=300ms -count=3 ./types
 ```
-
-The cross-runtime command runs each benchmark three times. The tables below report the median `ns/op`, `B/op`, and `allocs/op` for every workload/runtime combination.
-
-The comparison is informational rather than a strict end-to-end latency ranking. minivm reports execution-only `Interpreter.Run` time and excludes result extraction and reset, while other runtimes may include host-call result materialization and conversion. This boundary difference is most significant for short workloads, so small ratios should not be treated as precise runtime speedups.
 
 ## Summary
 
-The canonical cross-runtime suite shows both the strengths and the current limits of minivm:
+- `RecursiveFib(35)` places `minivm/default` at **48.43 ms**, within about **3.5%** of wazero's **46.79 ms**, while remaining allocation-free after warmup.
+- Adaptive native traces reduce `IterativeFib(30)` from **730.9 ns** threaded to **71.83 ns**, `TypedArraySum(256)` from **6.239 us** to **655.2 ns**, and `BranchTree(96)` from **986.4 ns** to **228.0 ns**.
+- Primitive array mutation now stays on the native loop path in `Sieve(256)`: `default` is **5.269 us** and eager `jit` is **5.261 us**, versus **16.143 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
+- Threshold-zero `jit` is not a warmed-JIT guarantee. It matches `default` on Sieve and BranchTree, but is slower on IterativeFib, TypedArraySum, and recursive Fibonacci because it can compile before representative traces are learned.
+- Allocation-heavy workloads remain interpreter-bound. `AllocationGraph(128)` is fastest in minivm's threaded mode at **7.513 us**; adaptive and eager modes add profiling cost without native coverage.
+- Indirect recursion remains a major gap: `IndirectRecursiveFib(20)` takes about **598 us** in adaptive/eager modes, versus **41.8 us** in wazero.
 
-- `RecursiveFib(35)` places `minivm/default` near wazero and ahead of the script runtimes measured here, while remaining zero-allocation after warmup.
-- `IterativeFib(30)` and `BranchTree(96)` show the adaptive default tier in the same order of magnitude as wazero while remaining allocation-free.
-- `TypedArraySum(256)` is allocation-free in all minivm modes, but wazero remains materially faster in this fixture.
-- `Sieve(256)` now favors native loop traces: `default` is **5.165 us** and eager `jit` is **5.172 us**, versus **15.831 us** for the threaded interpreter. All three modes allocate only the typed array itself (`1,048 B`, `2 allocs`).
-- `IndirectRecursiveFib(20)` is a clear weak point: `minivm/default` is substantially slower than wazero despite remaining allocation-free.
-- `AllocationGraph(128)` exposes object-management cost. minivm is faster than Tengo, Goja, and Yaegi, but slower than gpython and gopher-lua in this fixture.
-
-These results are workload measurements, not general language rankings. The runtimes use different value models, safety boundaries, and compilation strategies.
+These results are workload measurements, not general language rankings. The runtimes use different value models, safety boundaries, host-call conventions, and compilation strategies.
 
 ## Cross-Runtime Comparison
 
@@ -65,300 +68,248 @@ These results are workload measurements, not general language rankings. The runt
 
 | Mode | Construction | Meaning |
 |---|---|---|
-| `default` | `interp.New(prog)` | standard adaptive policy; may install and enter ARM64 traces after profiling |
-| `threaded` | `interp.New(prog, interp.WithThreshold(-1))` | JIT disabled; pure threaded execution |
-| `jit` | `interp.New(prog, interp.WithThreshold(0))` | eager profiling/compilation policy; not a precompiled or guaranteed-native steady state |
+| `default` | `interp.New(prog)` | adaptive policy; hot ARM64 entries and loop roots may become native |
+| `threaded` | `interp.New(prog, interp.WithThreshold(-1))` | JIT disabled; generated threaded execution only |
+| `jit` | `interp.New(prog, interp.WithThreshold(0))` | eager profiling and compilation policy; native entry is not guaranteed |
 
-The `jit` label therefore means **threshold zero**, not “fully warmed native code.” Function and module entries become eligible on the first sample, while loop roots reached through an unconditional backward branch wait for eight exact back-edges so the first iteration does not bias the recorded branch path. It can still be slower than `default` when early entry compilation produces incomplete traces or when the workload is dominated by unsupported allocation paths.
+Function and module entries in threshold-zero mode become eligible on the first sample. Loop roots reached through unconditional backward branches wait for eight exact hits to avoid specializing on the first iteration.
 
-Each runtime measures an already prepared callable through result recovery. Compilation, module construction, fixture injection, warmup, and minivm `Reset` are excluded. Runtime-specific host-call and result-conversion costs remain part of the measured invocation, so small differences should not be interpreted as VM-core instruction throughput alone.
+Each minivm kernel times `Interpreter.Run` only. Result extraction, reset, fixture construction, verification, and warmup remain outside the measured duration. External runtimes time repeated invocation of an already prepared program or function where their APIs permit; result materialization and conversion boundaries still differ, so small ratios are not precise VM-core comparisons.
 
 ### Complete Results
 
-Environment: Apple M4 Pro, `darwin/arm64`, Go 1.26.2. Command: `go test -tags=compare -run='^$' -bench='.' -benchmem -benchtime=300ms -count=3 ./...`. Each row is the median of three samples.
-
 | Workload | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| IterativeFib(30) | minivm/default | 69.9 | 0 | 0 |
-| IterativeFib(30) | minivm/threaded | 718.5 | 0 | 0 |
-| IterativeFib(30) | minivm/jit | 73.59 | 0 | 0 |
-| IterativeFib(30) | native | 8.444 | 0 | 0 |
-| IterativeFib(30) | wazero | 47.98 | 8 | 1 |
-| IterativeFib(30) | tengo | 9,670 | 90,592 | 61 |
-| IterativeFib(30) | gopher-lua | 496.9 | 160 | 0 |
-| IterativeFib(30) | goja | 2,137 | 368 | 20 |
-| IterativeFib(30) | gpython | 2,440 | 2,448 | 88 |
-| IterativeFib(30) | yaegi | 2,695 | 2,036 | 101 |
-| Sieve(256) | minivm/default | 5,165 | 1,048 | 2 |
-| Sieve(256) | minivm/threaded | 15,831 | 1,048 | 2 |
-| Sieve(256) | minivm/jit | 5,172 | 1,048 | 2 |
-| Sieve(256) | native | 229.9 | 0 | 0 |
-| Sieve(256) | wazero | 642.4 | 8 | 1 |
-| Sieve(256) | tengo | 51,497 | 122,504 | 1,611 |
-| Sieve(256) | gopher-lua | 22,080 | 18,416 | 44 |
-| Sieve(256) | goja | 42,387 | 1,872 | 25 |
-| Sieve(256) | gpython | 34,919 | 5,704 | 30 |
-| Sieve(256) | yaegi | 18,998 | 1,800 | 37 |
-| RecursiveFib(20) | minivm/default | 37,686 | 0 | 0 |
-| RecursiveFib(20) | minivm/threaded | 353,404 | 0 | 0 |
-| RecursiveFib(20) | minivm/jit | 359,322 | 0 | 0 |
-| RecursiveFib(20) | native | 13,699 | 0 | 0 |
-| RecursiveFib(20) | wazero | 30,896 | 8 | 1 |
-| RecursiveFib(20) | tengo | 811,030 | 319,346 | 28,655 |
-| RecursiveFib(20) | gopher-lua | 1,040,265 | 704 | 2 |
-| RecursiveFib(20) | goja | 1,461,585 | 4,680 | 39 |
-| RecursiveFib(20) | gpython | 3,656,195 | 9,807,935 | 109,494 |
-| RecursiveFib(20) | yaegi | 3,752,830 | 8,302,126 | 192,840 |
-| RecursiveFib(35) | minivm/default | 47,048,123 | 0 | 0 |
-| RecursiveFib(35) | minivm/threaded | 487,293,996 | 0 | 0 |
-| RecursiveFib(35) | minivm/jit | 496,864,164 | 0 | 0 |
-| RecursiveFib(35) | native | 19,129,096 | 0 | 0 |
-| RecursiveFib(35) | wazero | 44,150,405 | 9 | 1 |
-| RecursiveFib(35) | tengo | 1,139,802,250 | 312,798,144 | 39,088,182 |
-| RecursiveFib(35) | gopher-lua | 1,448,413,000 | 971,008 | 3,793 |
-| RecursiveFib(35) | goja | 2,033,437,791 | 375,360 | 46,373 |
-| RecursiveFib(35) | gpython | 5,148,001,292 | 13,378,035,136 | 149,350,297 |
-| RecursiveFib(35) | yaegi | 5,357,106,709 | 11,324,346,072 | 263,043,770 |
-| IndirectRecursiveFib(20) | minivm/default | 569,521 | 0 | 0 |
-| IndirectRecursiveFib(20) | minivm/threaded | 555,324 | 0 | 0 |
-| IndirectRecursiveFib(20) | minivm/jit | 569,709 | 0 | 0 |
-| IndirectRecursiveFib(20) | native | 15,576 | 0 | 0 |
-| IndirectRecursiveFib(20) | wazero | 42,267 | 8 | 1 |
-| IndirectRecursiveFib(20) | tengo | 922,213 | 319,346 | 28,655 |
-| IndirectRecursiveFib(20) | gopher-lua | 932,204 | 704 | 2 |
-| IndirectRecursiveFib(20) | goja | 1,337,977 | 4,680 | 39 |
-| IndirectRecursiveFib(20) | gpython | 3,712,726 | 10,158,210 | 109,494 |
-| IndirectRecursiveFib(20) | yaegi | 10,443,107 | 13,059,874 | 394,041 |
-| ClosureCounter(128) | minivm/default | 3,032 | 64 | 2 |
-| ClosureCounter(128) | minivm/threaded | 2,841 | 64 | 2 |
-| ClosureCounter(128) | minivm/jit | 3,047 | 64 | 2 |
-| ClosureCounter(128) | native | 33.74 | 0 | 0 |
+| IterativeFib(30) | minivm/default | 71.83 | 0 | 0 |
+| IterativeFib(30) | minivm/threaded | 730.9 | 0 | 0 |
+| IterativeFib(30) | minivm/jit | 108.6 | 0 | 0 |
+| IterativeFib(30) | native Go | 8.337 | 0 | 0 |
+| IterativeFib(30) | wazero | 49.84 | 8 | 1 |
+| IterativeFib(30) | Tengo | 9,722 | 90,592 | 61 |
+| IterativeFib(30) | gopher-lua | 494.4 | 160 | 0 |
+| IterativeFib(30) | Goja | 2,166 | 368 | 20 |
+| IterativeFib(30) | gpython | 2,427 | 2,448 | 88 |
+| IterativeFib(30) | Yaegi | 2,709 | 2,036 | 101 |
+| Sieve(256) | minivm/default | 5,269 | 1,048 | 2 |
+| Sieve(256) | minivm/threaded | 16,143 | 1,048 | 2 |
+| Sieve(256) | minivm/jit | 5,261 | 1,048 | 2 |
+| Sieve(256) | native Go | 247.8 | 0 | 0 |
+| Sieve(256) | wazero | 645.4 | 8 | 1 |
+| Sieve(256) | Tengo | 51,918 | 122,504 | 1,611 |
+| Sieve(256) | gopher-lua | 22,102 | 18,416 | 44 |
+| Sieve(256) | Goja | 41,769 | 1,872 | 25 |
+| Sieve(256) | gpython | 34,104 | 5,704 | 30 |
+| Sieve(256) | Yaegi | 18,673 | 1,800 | 37 |
+| RecursiveFib(20) | minivm/default | 41,053 | 0 | 0 |
+| RecursiveFib(20) | minivm/threaded | 377,151 | 0 | 0 |
+| RecursiveFib(20) | minivm/jit | 395,583 | 0 | 0 |
+| RecursiveFib(20) | native Go | 15,333 | 0 | 0 |
+| RecursiveFib(20) | wazero | 34,224 | 8 | 1 |
+| RecursiveFib(20) | Tengo | 915,188 | 319,346 | 28,655 |
+| RecursiveFib(20) | gopher-lua | 1,130,909 | 704 | 2 |
+| RecursiveFib(20) | Goja | 1,529,105 | 4,680 | 39 |
+| RecursiveFib(20) | gpython | 4,124,278 | 9,807,929 | 109,494 |
+| RecursiveFib(20) | Yaegi | 4,258,056 | 8,302,133 | 192,840 |
+| RecursiveFib(35) | minivm/default | 48,426,669 | 0 | 0 |
+| RecursiveFib(35) | minivm/threaded | 512,675,498 | 0 | 0 |
+| RecursiveFib(35) | minivm/jit | 539,464,080 | 0 | 0 |
+| RecursiveFib(35) | native Go | 20,957,448 | 0 | 0 |
+| RecursiveFib(35) | wazero | 46,785,131 | 9 | 1 |
+| RecursiveFib(35) | Tengo | 1,171,601,625 | 312,797,728 | 39,088,178 |
+| RecursiveFib(35) | gopher-lua | 1,475,545,292 | 971,008 | 3,793 |
+| RecursiveFib(35) | Goja | 2,033,197,667 | 375,360 | 46,373 |
+| RecursiveFib(35) | gpython | 5,238,414,292 | 13,378,035,520 | 149,350,319 |
+| RecursiveFib(35) | Yaegi | 5,439,306,583 | 11,324,340,056 | 263,043,718 |
+| IndirectRecursiveFib(20) | minivm/default | 598,302 | 0 | 0 |
+| IndirectRecursiveFib(20) | minivm/threaded | 564,863 | 0 | 0 |
+| IndirectRecursiveFib(20) | minivm/jit | 598,147 | 0 | 0 |
+| IndirectRecursiveFib(20) | native Go | 15,610 | 0 | 0 |
+| IndirectRecursiveFib(20) | wazero | 41,827 | 8 | 1 |
+| IndirectRecursiveFib(20) | Tengo | 919,605 | 319,345 | 28,655 |
+| IndirectRecursiveFib(20) | gopher-lua | 935,191 | 704 | 2 |
+| IndirectRecursiveFib(20) | Goja | 1,335,157 | 4,680 | 39 |
+| IndirectRecursiveFib(20) | gpython | 3,757,153 | 10,158,202 | 109,494 |
+| IndirectRecursiveFib(20) | Yaegi | 10,576,088 | 13,059,851 | 394,041 |
+| ClosureCounter(128) | minivm/default | 3,089 | 64 | 2 |
+| ClosureCounter(128) | minivm/threaded | 2,877 | 64 | 2 |
+| ClosureCounter(128) | minivm/jit | 3,119 | 64 | 2 |
+| ClosureCounter(128) | native Go | 33.77 | 0 | 0 |
 | ClosureCounter(128) | wazero | N/A | N/A | N/A |
-| ClosureCounter(128) | tengo | 13,045 | 92,272 | 261 |
-| ClosureCounter(128) | gopher-lua | 5,748 | 151 | 3 |
-| ClosureCounter(128) | goja | 9,827 | 1,264 | 13 |
-| ClosureCounter(128) | gpython | 25,897 | 58,312 | 659 |
-| ClosureCounter(128) | yaegi | 31,750 | 34,784 | 786 |
-| TypedArraySum(256) | minivm/default | 635.6 | 0 | 0 |
-| TypedArraySum(256) | minivm/threaded | 6,309 | 0 | 0 |
-| TypedArraySum(256) | minivm/jit | 579.3 | 0 | 0 |
-| TypedArraySum(256) | native | 64.21 | 0 | 0 |
-| TypedArraySum(256) | wazero | 150.1 | 8 | 1 |
-| TypedArraySum(256) | tengo | 15,340 | 94,208 | 513 |
-| TypedArraySum(256) | gopher-lua | 3,263 | 4,000 | 15 |
-| TypedArraySum(256) | goja | 12,695 | 2,080 | 238 |
-| TypedArraySum(256) | gpython | 7,251 | 2,496 | 246 |
-| TypedArraySum(256) | yaegi | 4,274 | 296 | 8 |
-| AllocationGraph(128) | minivm/default | 7,542 | 5,120 | 256 |
-| AllocationGraph(128) | minivm/threaded | 7,390 | 5,120 | 256 |
-| AllocationGraph(128) | minivm/jit | 7,502 | 5,120 | 256 |
-| AllocationGraph(128) | native | 900.4 | 1,024 | 128 |
+| ClosureCounter(128) | Tengo | 12,936 | 92,272 | 261 |
+| ClosureCounter(128) | gopher-lua | 5,720 | 152 | 3 |
+| ClosureCounter(128) | Goja | 9,752 | 1,264 | 13 |
+| ClosureCounter(128) | gpython | 26,111 | 58,312 | 659 |
+| ClosureCounter(128) | Yaegi | 32,116 | 34,784 | 786 |
+| TypedArraySum(256) | minivm/default | 655.2 | 0 | 0 |
+| TypedArraySum(256) | minivm/threaded | 6,239 | 0 | 0 |
+| TypedArraySum(256) | minivm/jit | 3,484 | 0 | 0 |
+| TypedArraySum(256) | native Go | 64.34 | 0 | 0 |
+| TypedArraySum(256) | wazero | 151.9 | 8 | 1 |
+| TypedArraySum(256) | Tengo | 15,603 | 94,208 | 513 |
+| TypedArraySum(256) | gopher-lua | 3,291 | 4,000 | 15 |
+| TypedArraySum(256) | Goja | 12,877 | 2,080 | 238 |
+| TypedArraySum(256) | gpython | 7,210 | 2,496 | 246 |
+| TypedArraySum(256) | Yaegi | 3,897 | 296 | 8 |
+| AllocationGraph(128) | minivm/default | 9,044 | 5,120 | 256 |
+| AllocationGraph(128) | minivm/threaded | 7,513 | 5,120 | 256 |
+| AllocationGraph(128) | minivm/jit | 9,099 | 5,120 | 256 |
+| AllocationGraph(128) | native Go | 906.1 | 1,024 | 128 |
 | AllocationGraph(128) | wazero | N/A | N/A | N/A |
-| AllocationGraph(128) | tengo | 13,697 | 96,288 | 388 |
-| AllocationGraph(128) | gopher-lua | 5,958 | 14,376 | 256 |
-| AllocationGraph(128) | goja | 24,155 | 78,016 | 770 |
-| AllocationGraph(128) | gpython | 5,401 | 5,712 | 266 |
-| AllocationGraph(128) | yaegi | 11,502 | 1,492 | 142 |
-| BranchTree(96) | minivm/default | 222.4 | 0 | 0 |
-| BranchTree(96) | minivm/threaded | 949.4 | 0 | 0 |
-| BranchTree(96) | minivm/jit | 224.7 | 0 | 0 |
-| BranchTree(96) | native | 77.55 | 0 | 0 |
-| BranchTree(96) | wazero | 156.3 | 16 | 1 |
-| BranchTree(96) | tengo | 16,906 | 95,384 | 660 |
-| BranchTree(96) | gopher-lua | 8,225 | 2,464 | 9 |
-| BranchTree(96) | goja | 13,464 | 1,992 | 196 |
-| BranchTree(96) | gpython | 11,627 | 2,168 | 203 |
-| BranchTree(96) | yaegi | 10,412 | 1,832 | 308 |
+| AllocationGraph(128) | Tengo | 13,677 | 96,288 | 388 |
+| AllocationGraph(128) | gopher-lua | 6,030 | 14,376 | 256 |
+| AllocationGraph(128) | Goja | 24,285 | 78,016 | 770 |
+| AllocationGraph(128) | gpython | 5,431 | 5,712 | 266 |
+| AllocationGraph(128) | Yaegi | 11,804 | 1,492 | 142 |
+| BranchTree(96) | minivm/default | 228 | 0 | 0 |
+| BranchTree(96) | minivm/threaded | 986.4 | 0 | 0 |
+| BranchTree(96) | minivm/jit | 230 | 0 | 0 |
+| BranchTree(96) | native Go | 77.39 | 0 | 0 |
+| BranchTree(96) | wazero | 156.9 | 16 | 1 |
+| BranchTree(96) | Tengo | 16,719 | 95,384 | 660 |
+| BranchTree(96) | gopher-lua | 8,215 | 2,464 | 9 |
+| BranchTree(96) | Goja | 13,476 | 1,992 | 196 |
+| BranchTree(96) | gpython | 11,504 | 2,168 | 203 |
+| BranchTree(96) | Yaegi | 10,476 | 1,832 | 308 |
 
-Wazero has no corresponding canonical implementation for `ClosureCounter(128)` or `AllocationGraph(128)`, so those rows are marked `N/A`.
+Wazero has no equivalent canonical fixture for `ClosureCounter(128)` or `AllocationGraph(128)`, so those rows are `N/A`.
 
-## Threaded Interpreter Throughput
+## Public API Costs
 
-The following results measure the pure threaded interpreter with JIT disabled.
+These benchmarks measure the named public operation. Setup, validation, cleanup, and paired operations stay outside the manually reported `ns/op` interval; allocation metrics still describe the complete benchmark iteration.
 
-Each row represents a full `Interpreter.Run` + `Reset` cycle. Setup instructions are included, so the numbers reflect practical dispatch overhead rather than isolated opcode cost.
+| Area | Operation | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Construction | `empty program` | 2,545 | 34,985 | 26 |
+| Construction | `program, JIT disabled` | 2,624 | 35,064 | 29 |
+| Construction | `program, JIT enabled` | 2,606 | 35,064 | 29 |
+| Reset | `scalar state` | 24.43 | 0 | 0 |
+| Reset | `heap state` | 28.99 | 0 | 0 |
+| Reset | `installed JIT state` | 28.63 | 0 | 0 |
+| Stack | `Push scalar` | 15.25 | 0 | 0 |
+| Stack | `Push reference` | 62.18 | 16 | 1 |
+| Stack | `Pop` | 5.414 | 0 | 0 |
+| Stack | `PopBoxed` | 5.436 | 0 | 0 |
+| Stack | `Peek` | 1.607 | 0 | 0 |
+| Heap | `Alloc` | 32.77 | 16 | 1 |
+| Heap | `Retain` | 19.98 | 0 | 0 |
+| Heap | `Release` | 19.31 | 0 | 0 |
+| Pool | `Get, uncontended` | 22.97 | 0 | 0 |
+| Pool | `Get, miss` | 2,094 | 34,840 | 23 |
+| Pool | `Get, shared-JIT miss` | 10,133 | 44,456 | 282 |
+| Pool | `parallel round trip` | 280.3 | 0 | 0 |
+| Pool | `Put, uncontended` | 125.5 | 0 | 0 |
 
-| Area | Typical result |
-|---|---:|
-| `nop` | 8 ns/op |
-| constants | 9 ns/op |
-| i32 arithmetic, bitwise, comparison | about 11 ns/op |
-| i64 arithmetic and comparison | about 12-13 ns/op |
-| f32/f64 arithmetic and comparison | about 11 ns/op |
-| numeric conversions | about 11-12 ns/op |
-| branches | about 10-14 ns/op |
-| bytecode calls | about 15-16 ns/op |
-| host function calls | about 18 ns/op |
-| array operations | about 30-44 ns/op |
-| struct operations | about 25-39 ns/op |
-| map operations | about 55-139 ns/op |
+Scalar stack access, reset, retain/release, and uncontended pool reuse are allocation-free. Construction and pool misses are dominated by interpreter state allocation. `SharedJITMiss` includes a new pooled interpreter synchronizing against shared JIT state.
 
-Detailed opcode semantics belong in `docs/instruction-set.md`; this document keeps benchmark interpretation only.
+## Threaded Execution Samples
 
-## Heap Lifecycle and Traversal
+The following rows use `BenchmarkInterpreter_Run/.../Threaded`: `WithTick(1)` and `WithThreshold(-1)`. Each result times one complete `Run`; setup opcodes are intentionally included, while `Reset` and result validation stay outside the measured interval.
 
-Lifecycle benchmarks use public heap APIs and include forced cyclic GC.
+| Area | Case | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `nop` | `i32.const_nop_returns_i32` | 94.36 | 0 | 0 |
+| constant | `i32.const_returns_i32` | 95.39 | 0 | 0 |
+| i32 arithmetic | `i32.add` | 100.9 | 0 | 0 |
+| i64 arithmetic | `i64.add` | 109.8 | 0 | 0 |
+| f32 arithmetic | `f32.add` | 118.2 | 0 | 0 |
+| f64 arithmetic | `f64.add` | 103.8 | 0 | 0 |
+| conversion | `i32.to_i64_s` | 104.3 | 0 | 0 |
+| branch | `br` | 99.49 | 0 | 0 |
+| branch | `br_if` | 116.6 | 0 | 0 |
+| branch | `br_table` | 104.1 | 0 | 0 |
+| call | `direct bytecode call` | 148.4 | 0 | 0 |
+| array | `constant array get` | 105.8 | 0 | 0 |
+| array | `new + get` | 179.3 | 40 | 2 |
+| array | `set + get` | 218 | 40 | 2 |
+| struct | `constant struct get` | 113.9 | 0 | 0 |
+| struct | `new` | 124.1 | 64 | 1 |
+| struct | `set + get` | 188.4 | 64 | 1 |
+| map | `default + len` | 132.7 | 72 | 2 |
+| map | `new + get` | 202.1 | 216 | 3 |
+| map | `set + len` | 208.3 | 216 | 3 |
 
-| Benchmark | ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| `Alloc/free_slot_reuse` | 10.1 | 0 | 0 |
-| `Alloc/small_heap_cyclic_gc` | 48.1 | 40 | 2 |
-| `Release/primitive_struct` | 28.6 | 64 | 1 |
-| `Release/ref_array` | 52.7 | 48 | 4 |
-| `Release/ref_struct` | 54.4 | 72 | 3 |
-| `Release/ref_valued_map` | 155.0 | 224 | 5 |
+These are complete program cases, not isolated opcode latency. Allocation-bearing array, struct, and map rows include object construction in the same run.
 
-Reference traversal avoids allocation when no child references are present.
+### `BenchmarkInterpreter_Run` Modes
 
-| Workload | ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| `no_refs` | 1.0 | 0 | 0 |
-| `inline_i64` | 25.1 | 0 | 0 |
-| `child_refs` | 32.4 | 8 | 1 |
+| Mode | Options | Timed state |
+|---|---|---|
+| `Threaded` | `WithTick(1)`, `WithThreshold(-1)` | exact generated threaded dispatch; JIT and fusion disabled |
+| `Fused` | `WithThreshold(-1)` | default generated fusion with JIT disabled |
+| `JITWarm` | `WithTick(1)`, `WithThreshold(0)` | warmup runs until a native entry is installed, then `Run` only |
 
-## Marshal
+The representative table above shows `Threaded` cases. The complete package suite also emits applicable `Fused` and `JITWarm` sub-benchmarks; unsupported JIT entries are skipped rather than reported as native results.
 
-`BenchmarkInterpreter_Marshal` measures conversion from ordinary Go values into VM values.
+## Reference Traversal
 
-| Value | ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| `i32` | 39.2 | 80 | 2 |
-| `string` | 49.9 | 96 | 3 |
-| `function` | 64.4 | 144 | 4 |
-| `slice_i32` | 81.5 | 136 | 4 |
-| `host_object` | 139.6 | 324 | 7 |
-| `struct_plain` | 141.8 | 200 | 6 |
-| `nested_slice_struct` | 479.2 | 426 | 13 |
-| `map_string_i32` | 547.3 | 712 | 18 |
+`types.Traceable.Refs` implementations reuse caller-provided storage. The current canonical cases are allocation-free.
 
-Simple scalar and string values are inexpensive to marshal. Nested structures and maps are more expensive because they require additional heap objects and reflection work.
+| Value | Case | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| array | no child refs | 2.463 | 0 | 0 |
+| array | child refs | 2.13 | 0 | 0 |
+| struct | no child refs | 1.713 | 0 | 0 |
+| struct | child refs | 1.8 | 0 | 0 |
+| typed map | child refs | 22.92 | 0 | 0 |
+| dynamic map | no child refs | 1.757 | 0 | 0 |
+| dynamic map | child refs | 24.94 | 0 | 0 |
 
-## Recursive Workloads
+## ARM64 JIT Interpretation
 
-These results use the threaded interpreter with JIT disabled.
+The adaptive default tier is strongest on stable numeric loops, direct recursive calls, typed-array reads, primitive typed-array writes, and branch-heavy scalar code. Unsupported allocation, complex ref-bearing mutation, host calls, and heap-promoted `i64` paths deoptimize or remain threaded.
 
-| Program | ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| `fib(20)` — i32 recursive | 353,404 | 0 | 0 |
-| `factorial(10)` — i64 with early exit via `br_if` | 310 | 0 | 0 |
-
-For the deep-recursion `fib(35)` result with JIT enabled, see the cross-runtime comparison above.
-
-## ARM64 JIT
-
-On ARM64, minivm compiles hot recorded traces to native code. Supported paths include numeric operations, direct calls, selected indirect function dispatch, ref-counted slots, selected read-only heap operations, and loops with safepoint polling.
-
-Unsupported paths either deoptimize or continue through the threaded interpreter. These include allocation, ref-bearing or complex mutation, host calls, heap-promoted i64 values, and unsupported heap shapes. Guarded primitive typed-array stores can remain inside native loop traces.
-
-The default threshold is `4096` executed instructions, which is about 32 samples at the default tick interval of 128.
-
-### Canonical Kernel Observations
-
-The current canonical kernels show that native trace coverage is workload-dependent:
-
-- adaptive `default` is effective for direct recursive calls, iterative numeric loops, typed-array reads, guarded primitive typed-array writes, and branch-heavy scalar code
-- threshold-zero `jit` is not equivalent to a warmed native cache, but exact back-edge warmup keeps loop capture from over-specializing the first iteration
-- `Sieve(256)` now runs about 3.1 times faster in `default` and eager `jit` than in the threaded interpreter, while preserving the same allocation count
-- allocation-heavy object kernels such as `AllocationGraph` remain limited by heap management rather than scalar trace throughput
-- indirect recursive calls remain substantially slower than wazero and are a priority for call-target and trace-continuation optimization
-
-Use the complete cross-runtime table above for current numbers. Do not infer JIT entry solely from the `jit` sub-benchmark name; profiler metrics are required when a benchmark specifically claims native entry.
-
-On x86-64, JIT is not implemented yet. The runtime falls back to threaded execution.
+Do not infer native execution solely from the `jit` sub-benchmark name. A benchmark that claims a warmed native entry must prove it through a native stub or profiler metrics. On architectures without a native backend, all modes remain threaded.
 
 ## Methodology
 
-- Cross-runtime results use `-benchtime=300ms -count=3`; every table value is the median of the three samples.
-- Each minivm fixture is verified before measurement. The benchmark performs one correctness run, four untimed warmup runs, and 32 untimed allocation samples before timing.
-- minivm reports execution-only time for `Interpreter.Run`. Result transfer through `PopBoxed` and `Reset` remains outside the measured duration.
-- `interp.New()` is called once outside the timed loop. `default` leaves all options unchanged, `threaded` changes only the threshold to `-1`, and `jit` changes only the threshold to `0`.
-- External runtime parsing, compilation, module creation, and function lookup remain outside the timer where the runtime API permits. The timed loop repeatedly invokes the prepared function or compiled program.
-- wazero uses its default compiler runtime, with module compilation and instantiation excluded from timing.
-- Cross-runtime benchmarks live in the separate `benchmarks/` Go module and are enabled only with the `compare` build tag.
-- The workload sources preserve the same input and expected result, but runtime-specific object representation and call conventions differ. Treat the results as end-to-end kernel comparisons rather than isolated opcode comparisons.
+- Every canonical kernel has a correctness test with a fixed expected result or checksum.
+- The cross-runtime suite performs one correctness run, four untimed warmup runs, and 32 untimed allocation samples before timing minivm.
+- minivm `default`, `threaded`, and `jit` differ only in their threshold option.
+- External parsing, compilation, module creation, and function lookup remain outside the timer where the runtime API permits.
+- Wazero uses its default compiler runtime; module compilation and instantiation are excluded from timing.
+- Cross-runtime comparisons live in the separate `benchmarks/` module and require the `compare` build tag.
+- Output was grouped by exact benchmark name, and each documented value is the median of exactly three samples.
 
 Cross-runtime library versions:
 
 - wazero v1.12.0
 - gopher-lua v1.1.2
 - Tengo v2.17.0
-- goja v0.0.0-20260311135729-065cd970411c
+- Goja v0.0.0-20260311135729-065cd970411c
 - gpython v0.2.0
 - Yaegi v0.16.1
 
 ## Benchmark Ownership
 
-Use two benchmark layers:
-
 | Owner | Measures |
 |---|---|
-| `interp/interp_test.go` | public interpreter and pool API costs, dispatch, opcode families, lifecycle, heap operations, and JIT lifecycle states |
-| `benchmarks/` | runtime-neutral VM kernels and optional cross-runtime comparisons |
+| `interp/interp_test.go` | interpreter construction, execution tiers, reset, stack/heap operations, pool behavior, JIT lifecycle |
+| `types/*_test.go` | reference traversal contracts |
+| `benchmarks/` | runtime-neutral VM kernels and optional external comparisons |
 
-Package-owned microbenchmarks may remain beside their production owner only when they measure a distinct package contract, such as `types.Traceable.Refs` or analysis construction. Service-domain workloads do not define canonical VM performance.
-
-Every benchmark behavior has an independently owned correctness test. Interpreter execution cases map to `TestInterpreter_Run`; construction, reset, stack, heap, and pool cases map to their same-named public API tests.
-
-## Interpreter Benchmark Methodology
-
-Interpreter benchmark names match public API owners:
-
-```text
-BenchmarkNew
-BenchmarkInterpreter_Run
-BenchmarkInterpreter_Reset
-BenchmarkInterpreter_Push
-BenchmarkInterpreter_Pop
-BenchmarkInterpreter_PopBoxed
-BenchmarkInterpreter_Peek
-BenchmarkInterpreter_Alloc
-BenchmarkInterpreter_Retain
-BenchmarkInterpreter_Release
-BenchmarkPool_Get
-BenchmarkPool_Put
-```
-
-Each fixture is validated once before timing. `BenchmarkInterpreter_Run` times only `Run`; `Reset`, result validation, fixture construction, and JIT warmup remain outside the timer. `BenchmarkInterpreter_Reset` times only `Reset`; re-execution remains outside the timer. Pool miss benchmarks time `Get` while pool construction and cleanup remain outside the timer.
-
-Execution modes are explicit sub-benchmarks:
-
-| Mode | Boundary |
-|---|---|
-| `Threaded` | exact threaded dispatch with fusion and JIT disabled |
-| `Fused` | generated fused threaded execution with JIT disabled |
-| `JITWarm` | native stub already emitted; execution only |
-| `JITCold` | trace capture and compilation included; interpreter construction excluded |
-| `JITExit` | first alternate branch from a warmed native trace |
-| `JITDeopt` | first trapping guard failure from a warmed native trace |
-
-Warm, exit, and deoptimization fixtures assert that a native stub exists before timing. Cold fixtures assert native emission after timing. Straight dispatch and numeric cases report fixed `opcodes/op` alongside `ns/op`.
-
-Pool benchmarks separate uncontended reuse, capacity miss, shared-JIT miss, parallel round trips, and put cost. Parallel workers use independent interpreter instances obtained from the pool.
+A benchmark must have a correctness test owned by the same public behavior or canonical fixture. Service-domain workloads do not define VM performance baselines.
 
 ## Execution Tiers
 
 | Target | Use | Contents |
 |---|---|---|
-| `make benchmark-pr` | pull requests | stable construction, reset, dispatch, representative numeric/control/call/array cases, and four threaded kernels |
+| `make benchmark-pr` | pull requests | stable construction, reset, dispatch, representative interpreter cases, and threaded kernels |
 | `make benchmark-core` | local canonical run | all package benchmarks and all runtime-neutral VM kernels |
-| `make benchmark-nightly` | scheduled report | canonical suite with repeated samples, including cold JIT, exits, deoptimization, large collections, and parallel pool cases |
-| `make benchmark-compare` | optional analysis | `compare`-tagged external runtimes only |
+| `make benchmark-nightly` | scheduled report | repeated canonical suite, including JIT lifecycle and parallel pool cases |
+| `make benchmark-compare` | optional analysis | external runtime comparisons enabled by the `compare` build tag |
 
-Pull-request and nightly jobs report results without comparing against golden numbers. Use repeated output with `benchstat` for manual analysis. Add an automated threshold only after a benchmark has stable variance and both statistical and practical limits are documented.
+Pull-request and nightly targets report raw results without comparing against golden numbers. Use repeated output with `benchstat` for statistical comparison before making regression claims.
 
 ## Maintenance Notes
 
-When changing benchmark documentation:
-
-- keep claims tied to concrete benchmark rows
-- include platform, Go version, and benchmark command
-- avoid repeating opcode semantics already covered by `instruction-set.md`
-- avoid repeating JIT internals already covered by `jit-internals.md`
-- update README headline numbers only after this document changes
+- Run benchmark processes sequentially when publishing absolute numbers.
+- Keep claims tied to concrete rows and record the platform, Go version, command, and sample count.
+- Remove a metric when its benchmark no longer exists; do not preserve historical numbers as current results.
+- Update the README headline only after this document is updated.
 
 ## Related Docs
 
 - `docs/profile.md` — sampling and runtime counters
 - `docs/jit-internals.md` — trace JIT behavior
-- `docs/instruction-set.md` — opcode semantics
+- `docs/instruction-set.md` — opcode semantics and JIT support
 - `docs/compatibility.md` — platform support

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -46,8 +46,8 @@ go test -run='^$' \
 go test -run='^$' -bench='^BenchmarkInterpreter_Run/.*/Threaded$' \
   -benchmem -benchtime=300ms -count=3 ./interp
 
-# Pre-hot unconditional-backedge overhead
-go test -run='^$' -bench='^BenchmarkInterpreter_PreHotBackedge$' \
+# Cold unconditional-backedge overhead
+go test -run='^$' -bench='^BenchmarkInterpreter_ColdBackedge$' \
   -benchmem -benchtime=300ms -count=3 ./interp
 
 # Reference traversal
@@ -207,11 +207,11 @@ Scalar stack access, reset, retain/release, and uncontended pool reuse are alloc
 
 ## JIT Activation Overhead
 
-`BenchmarkInterpreter_PreHotBackedge` runs a 256-iteration counting loop with `WithTick(1<<20)` and `WithThreshold(1<<30)`, including `Run`, `PopBoxed`, and `Reset`. The function remains below the sample threshold, so it keeps the ordinary generated `BR` handler.
+`BenchmarkInterpreter_ColdBackedge` runs a 256-iteration counting loop with `WithTick(1<<20)` and `WithThreshold(1<<30)`, including `Run`, `PopBoxed`, and `Reset`. The function remains below the sample threshold, so it keeps the ordinary generated `BR` handler.
 
 | Case | ns/op | B/op | allocs/op |
 |---|---:|---:|---:|
-| pre-hot unconditional backedge | 2,446 | 0 | 0 |
+| cold unconditional backedge | 2,446 | 0 | 0 |
 
 This benchmark guards the cold-path boundary: exact backedge observation is installed only after periodic sampling marks a function hot, rather than adding a callback or header scan to every cold loop iteration.
 

--- a/docs/instruction-set.md
+++ b/docs/instruction-set.md
@@ -260,7 +260,7 @@ Do not group multiple opcodes in one row. Keep this table in opcode-value order 
 | Arrays | `ARRAY_NEW_DEFAULT` | `array.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Arrays | `ARRAY_LEN` | `array.len` | ✅ | 🔲 | native typed-array length fast path |
 | Arrays | `ARRAY_GET` | `array.get` | ✅ | 🔲 | native typed-array get fast path |
-| Arrays | `ARRAY_SET` | `array.set` | ◐ | 🔲 | terminal native mutation; scalar and ref-kind elements |
+| Arrays | `ARRAY_SET` | `array.set` | ◐ | 🔲 | primitive typed arrays may continue; boxed/ref writes stay terminal |
 | Arrays | `ARRAY_FILL` | `array.fill` | ⬜ | 🔲 | bulk mutation stays threaded |
 | Arrays | `ARRAY_COPY` | `array.copy` | ⬜ | 🔲 | bulk mutation stays threaded |
 | Arrays | `ARRAY_APPEND` | `array.append` | ⬜ | 🔲 | grow/mutation stays threaded |

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -127,7 +127,7 @@ Each recorded step stores the data needed for speculative lowering:
 - partial-trace resume boundary
 - selected heap values for read-only fast paths
 
-The tracer aborts before host calls and allocation. It records ref-bearing array writes and struct writes only as terminal fallback boundaries. A primitive typed-array write may remain inside the trace when it occurs in the anchor frame before any inlined call. Capture deep-copies primitive typed arrays so speculative execution never mutates the live interpreter heap.
+The tracer aborts before host calls and allocation. It records ref-bearing array writes and struct writes only as terminal fallback boundaries. A primitive typed-array write may remain inside the trace when it occurs in the anchor frame before any inlined call. Capture deep-copies typed arrays, boxed arrays, and structs before stepping mutations so speculative execution never changes the live interpreter heap. The clone also owns mutable dispatch metadata and suppresses external finalizers, so speculative reference reclamation cannot alter live functions, trace trees, or host resources.
 
 Every recorded `trace` has one outcome: `loop`, `returned`, `completed`, `partial`, or `aborted`. The trace frontend maps usable outcomes to plan terminators and excludes aborted fragments from learned continuations. When an observed block runs out of steps, lowering decides completion from that block's terminator, never from the root trace. This prevents an unsupported side fragment from being mistaken for normal completion.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -321,7 +321,7 @@ Before that fallback triggers, `asm.Assembler.encode` runs a branch relaxation f
 
 A loop root is anchored at a loop header: the target of a backward branch.
 
-The tracer discovers headers statically. Periodic samples still drive normal hotness, while JIT-enabled unconditional backward `BR` handlers also call `observeLoop` after moving the live frame to the exact target header. This prevents a deterministic tick phase from permanently missing those loops. Threshold-zero mode waits for eight exact hits on those headers before capture so the first iteration does not over-specialize the recorded branch path.
+The tracer discovers headers statically. Periodic samples still drive normal hotness, while JIT-enabled unconditional backward `BR` handlers also notify the interpreter after moving the live frame to the exact target header. This prevents a deterministic tick phase from permanently missing those loops. Threshold-zero mode waits for eight exact hits on those headers before capture so the first iteration does not over-specialize the recorded branch path.
 
 Loop lowering builds the normal native prologue, binds a back-edge label, lowers the loop body, commits loop-carried locals to VM stack homes, decrements `journalBudget`, and branches back while budget remains.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -83,8 +83,9 @@ Pool interpreters use a shared `Cache`:
 
 The cache claims a build's root and trigger together. Each function owns a
 coalescing queue of exact anchors rather than one pending slot: distinct loop
-roots are retained, duplicate hot requests are discarded while active, and
-side-exit requests take priority because they represent newer trace work.
+roots are retained, duplicate requests are discarded, and a side exit arriving
+behind an active hot build remains queued because it represents newer trace work.
+Side-exit requests take priority over queued hot roots.
 Publication finishes only the claimed build and leaves queued requests cold for
 the next winner.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -90,7 +90,7 @@ The published native code is shared. The dispatch table remains interpreter-loca
 
 ## Compiler
 
-`compiler` is private to `interp` and lives in `jit.go`. The interpreter calls only `compiler.Compile(i, addr)` and receives an opaque `module`; it does not select or inspect a compilation strategy.
+`compiler` is private to `interp` and lives in `jit.go`. The interpreter calls only `compiler.Compile(i, root)` and receives an opaque `module`; it does not select or inspect a compilation strategy. A frontend may discover several recorded roots, but compilation selects only the requested anchor so later loop attempts do not re-emit already-installed entries.
 
 The compiler builds one read-only `compileInput`, then runs two ordered frontends:
 
@@ -127,7 +127,7 @@ Each recorded step stores the data needed for speculative lowering:
 - partial-trace resume boundary
 - selected heap values for read-only fast paths
 
-The tracer aborts before host calls, allocation, and mutating heap operations. These remain interpreter-owned.
+The tracer aborts before host calls and allocation. It records ref-bearing array writes and struct writes only as terminal fallback boundaries. A primitive typed-array write may remain inside the trace when it occurs in the anchor frame before any inlined call. Capture deep-copies primitive typed arrays so speculative execution never mutates the live interpreter heap.
 
 Every recorded `trace` has one outcome: `loop`, `returned`, `completed`, `partial`, or `aborted`. The trace frontend maps usable outcomes to plan terminators and excludes aborted fragments from learned continuations. When an observed block runs out of steps, lowering decides completion from that block's terminator, never from the root trace. This prevents an unsupported side fragment from being mistaken for normal completion.
 
@@ -193,12 +193,12 @@ corrupting the native stack at runtime.
 
 Register allocation (`asm/rewriter.go`) is a single linear-scan pass: it spills the vreg with the farthest-away next use to a stack slot at the stream position where pressure was observed. Rewritten labels target the start of any inserted reload/store prefix, and labels on a return target its inserted frame epilogue. Only a call whose target label is bound inside the same `Code` (an intra-Code self-call, which runs through the shared epilogue on return) reserves the caller's spill area again before continuing; a call to a label resolved externally by `Link` never runs this `Code`'s epilogue, so the rewriter must not re-reserve after it. `Assembler.Entry` documents the matching limitation for non-primary entries: only the primary entry (offset 0) runs the frame prologue, so `Build` returns `asm.ErrEntryRequiresFrame` when spilling occurs and a non-primary entry exists.
 
-Linear spill state is unsafe across a loop back-edge, and terminal `ARRAY_SET` or `STRUCT_SET` blocks can combine paths before their exit. Two layers enforce safety:
+Linear spill state is unsafe across a loop back-edge, and mutation blocks can combine paths around state materialization. Two layers enforce safety:
 
 - `asm/rewriter.go` rejects spilling for code containing an intra-code backward branch.
-- `noSpill` scans every block in the completed plan, including learned continuations, and forbids spilling when a terminal mutation is present.
+- `noSpill` scans every step in the completed plan, including learned continuations, and forbids spilling whenever `ARRAY_SET` or `STRUCT_SET` is present.
 
-When a plan forbids spilling, the compiler wraps the target architecture in `noSpillArch`. Its `Frame()` returns `nil` according to the assembler contract, so register exhaustion rejects native compilation cleanly and threaded dispatch remains installed.
+When a plan forbids spilling, the compiler wraps the target architecture in `noSpillArch`. Its `Frame()` returns `nil` according to the assembler contract, so register exhaustion rejects native compilation cleanly and threaded dispatch remains installed. Continuable primitive array stores therefore lower through an explicit state barrier and reuse dead registers rather than depending on spill slots.
 
 Native code does not marshal parameters or returns. It writes results and trap state into the journal, and the Go wrapper restores interpreter state from there.
 
@@ -274,7 +274,7 @@ Native lowering supports selected calls:
 
 A call may lower to native `BL` when the observed target is a JIT-eligible `*types.Function` with matching arity.
 
-Unsupported targets fall back, including host calls, allocation, heap mutation, maps, unsupported functions, and unsupported closures.
+Unsupported targets fall back, including host calls, allocation, maps, unsupported functions, unsupported closures, and heap mutations outside the selected guarded fast paths.
 
 Static plans recognize direct `CONST_GET function; CALL` pairs. Each interpreter owns a fixed-size `natives` slot array; installing or synchronizing a function entry publishes its executable address atomically. The caller loads the slot at runtime and uses `BLR`, so compile order does not matter: a null slot falls back at the CALL, while a later callee installation is visible without recompiling the caller. Self-recursion remains on the established trace self-call path, and `RETURN_CALL` remains threaded.
 
@@ -316,13 +316,13 @@ Before that fallback triggers, `asm.Assembler.encode` runs a branch relaxation f
 
 A loop root is anchored at a loop header: the target of a backward branch.
 
-The tracer discovers headers statically. Once the function or module is hot, it records one iteration from the live state at the header.
+The tracer discovers headers statically. Periodic samples still drive normal hotness, while JIT-enabled unconditional backward `BR` handlers also call `observeLoop` after moving the live frame to the exact target header. This prevents a deterministic tick phase from permanently missing those loops. Threshold-zero mode waits for eight exact hits on those headers before capture so the first iteration does not over-specialize the recorded branch path.
 
 Loop lowering builds the normal native prologue, binds a back-edge label, lowers the loop body, commits loop-carried locals to VM stack homes, decrements `journalBudget`, and branches back while budget remains.
 
 Loop-carried locals round-trip through the VM stack each iteration. This avoids a cross-back-edge register fixpoint.
 
-Loops whose header is the function entry (`ip == 0`) remain threaded.
+Module loops at `addr == 0` are valid when their header IP is positive. Only loops whose header is the module or function entry (`ip == 0`) remain threaded.
 
 Loop callables install at:
 
@@ -391,16 +391,13 @@ Ref reads retain loaded refs. `CORO_VALUE` retains the value and releases the ha
 
 Heap-promoted `i64` values fall back before boxing.
 
-Primitive `ARRAY_SET` and `STRUCT_SET` are terminal mutations. The hot path may perform the store, flush state, and resume threaded execution at the next instruction. Shape, bounds, field-kind, or release failure deoptimizes at the original opcode so the interpreter owns full semantics.
+A primitive typed-array `ARRAY_SET` may continue through native execution when it occurs in the anchor frame before any inlined call. Lowering first materializes one resumable pre-op snapshot, clears the local register cache, and lets shape, bounds, and release guards share that snapshot. Guard failure resumes at the original opcode; success performs the primitive store and continues to later operations or the loop back-edge.
 
-A loop body that inlines two or more branchy calls before a terminal
-`ARRAY_SET`/`STRUCT_SET` can push register pressure past the physical bank.
-The allocator rejects spilling across backward edges, and the compiler disables
-spilling for loop and terminal-mutation roots; register exhaustion then keeps
-threaded dispatch installed (regression test:
-`interp.TestInterpreter_JITArraySetAfterBranchyCallsInLoop`).
+Ref-bearing `ARRAY_SET` and `STRUCT_SET` remain terminal mutations. Their hot path may perform the store and resume threaded execution at the next instruction, while recursive release or any failed guard remains interpreter-owned.
 
-Allocation and complex ref-bearing mutations stay threaded.
+Mutation plans are always no-spill. Leaf traces reuse pinned and dead registers for stack homes, heap cells, refcounts, and boxing scratch so primitive mutation loops fit the physical register bank. A mutation after inlined calls retains the terminal boundary; register exhaustion still rejects compilation cleanly instead of spilling across a back-edge (regression test: `interp.TestARM64_ArraySetAfterNestedCalls`).
+
+Allocation and complex ref-bearing mutations stay threaded or terminate the native trace.
 
 ## Structured Errors
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -81,10 +81,12 @@ Pool interpreters use a shared `Cache`:
 - compiled modules publish immutable `asm.Callable`s
 - each interpreter installs those callables into its own dispatch table at a safepoint
 
-The cache claims a build's root and trigger together. A side-exit or loop-root
-request arriving while that build is active remains pending; publication
-finishes only the claimed build and leaves the pending request cold for the
-next winner. This prevents a completed build from clearing newer trace work.
+The cache claims a build's root and trigger together. Each function owns a
+coalescing queue of exact anchors rather than one pending slot: distinct loop
+roots are retained, duplicate hot requests are discarded while active, and
+side-exit requests take priority because they represent newer trace work.
+Publication finishes only the claimed build and leaves queued requests cold for
+the next winner.
 
 The published native code is shared. The dispatch table remains interpreter-local.
 
@@ -127,13 +129,15 @@ Each recorded step stores the data needed for speculative lowering:
 - partial-trace resume boundary
 - selected heap values for read-only fast paths
 
-The tracer aborts before host calls and allocation. It records ref-bearing array writes and struct writes only as terminal fallback boundaries. A primitive typed-array write may remain inside the trace when it occurs in the anchor frame before any inlined call. Capture deep-copies typed arrays, boxed arrays, and structs before stepping mutations so speculative execution never changes the live interpreter heap. The clone also owns mutable dispatch metadata and suppresses external finalizers, so speculative reference reclamation cannot alter live functions, trace trees, or host resources.
+The tracer aborts before host calls and allocation. It records ref-bearing array writes and struct writes only as terminal fallback boundaries. A primitive typed-array write may remain inside the trace when it occurs in the anchor frame before any inlined call. Capture clones every overlapping visible range of aliased primitive typed arrays into one replacement backing store, preserving slice offsets while leaving the live heap unchanged. Boxed arrays and structs are copied before their terminal mutation. The clone also owns mutable dispatch metadata and suppresses external finalizers, so speculative reference reclamation cannot alter live functions, trace trees, or host resources.
 
 Every recorded `trace` has one outcome: `loop`, `returned`, `completed`, `partial`, or `aborted`. The trace frontend maps usable outcomes to plan terminators and excludes aborted fragments from learned continuations. When an observed block runs out of steps, lowering decides completion from that block's terminator, never from the root trace. This prevents an unsupported side fragment from being mistaken for normal completion.
 
 `Tracer.capture` serializes recording and returns an already-published root when one exists, so sampling and compilation cannot record the same entry concurrently. A tracer is bound to one `program.Program`; binding it to a different program clears exact bytecode, tree, and loop caches before reuse.
 
 `Tracer.headers` (the static loop-header scan) uses `instr.Targets(code, ip)` rather than switching on `BR`/`BR_IF` directly, so a loop formed only through a backward `BR_TABLE` case target is recognized as a header too.
+
+Non-eager functions initially keep the ordinary generated `BR` handler. When periodic sampling first reaches the rounded threshold, the interpreter rethreads that function once with an exact unconditional-backedge callback, preserving installed native handlers and replacing only their threaded fallbacks. Eager mode enables the callback from construction. Cold loops therefore pay no callback, mutex, or header-scan cost.
 
 ## Trace Snapshots
 

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -169,9 +169,11 @@ With the default tick of `128`, this is about `32` samples.
 
 | Setting | Effect |
 |---|---|
-| `WithThreshold(0)` | compile on the first sample |
+| `WithThreshold(0)` | make entries eligible on the first sample and unconditional-backedge loop roots after eight exact hits |
 | `WithThreshold(n > 0)` | compile after the rounded sample threshold |
 | `WithThreshold(n < 0)` | disable compilation |
+
+JIT-enabled unconditional backward branches observe their target after updating the live frame IP, so those module and function loops cannot be permanently missed by the periodic tick phase. Threshold-zero capture for those roots waits eight exact hits to avoid specializing on an unrepresentative first iteration.
 
 Pool members use the same rounded threshold. With a shared cache, trigger counts are aggregated so only one member compiles each module or function slot.
 

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -173,9 +173,9 @@ With the default tick of `128`, this is about `32` samples.
 | `WithThreshold(n > 0)` | compile after the rounded sample threshold |
 | `WithThreshold(n < 0)` | disable compilation |
 
-JIT-enabled unconditional backward branches observe their target after updating the live frame IP, so those module and function loops cannot be permanently missed by the periodic tick phase. Threshold-zero capture for those roots waits eight exact hits to avoid specializing on an unrepresentative first iteration.
+Threshold-zero mode installs exact unconditional-backedge observation immediately and waits eight exact hits before capturing a loop root. For positive thresholds, cold functions keep the ordinary branch handler; the periodic sampler rethreads a function once when it becomes hot, after which unconditional backedges report their already-known target without a header scan. This prevents deterministic tick phases from missing a hot loop without adding pre-hot loop overhead.
 
-Pool members use the same rounded threshold. With a shared cache, trigger counts are aggregated so only one member compiles each module or function slot.
+Pool members use the same rounded threshold. With a shared cache, trigger counts are aggregated so only one member compiles at a time, while a per-function queue retains distinct exact loop roots and prioritizes newer side-exit work.
 
 minivm does not currently tier beyond the ARM64 trace backend.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -825,7 +825,7 @@ ARM64 instruction factories are the sole shared-family exception. `TestEncoder_E
 | `ARRAY_NEW_DEFAULT` | `array.new_default` | ✅ | fixed metadata | ✅ | ✅ | ⬜ | Runtime corpus only |
 | `ARRAY_LEN` | `array.len` | ✅ | fixed metadata | ✅ | — | ✅ | Runtime corpus only |
 | `ARRAY_GET` | `array.get` | ✅ | fixed metadata | ✅ | ✅ | ✅ | Representative differential |
-| `ARRAY_SET` | `array.set` | ✅ | fixed metadata | ✅ | ✅ | ◐ | Runtime corpus only |
+| `ARRAY_SET` | `array.set` | ✅ | fixed metadata | ✅ | ✅ | ◐ | Representative differential |
 | `ARRAY_FILL` | `array.fill` | ✅ | fixed metadata | ✅ | ✅ | ⬜ | Runtime corpus only |
 | `ARRAY_COPY` | `array.copy` | ✅ | fixed metadata | ✅ | ✅ | ⬜ | Runtime corpus only |
 | `ARRAY_APPEND` | `array.append` | ✅ | indeterminate arity | ✅ | — | ⬜ | Runtime corpus only |

--- a/internal/cmd/geninterp/generate.go
+++ b/internal/cmd/geninterp/generate.go
@@ -63,7 +63,6 @@ func declare(file *jen.File) {
 		jen.Id("code").Index().Byte(),
 		jen.Id("ip").Int(),
 		jen.Id("exact").Bool(),
-		jen.Id("hot").Bool(),
 		jen.Id("backedge").Func().Params(jen.Op("*").Id("Interpreter"), jen.Op("*").Id("frame")).Error(),
 	)
 }

--- a/internal/cmd/geninterp/generate.go
+++ b/internal/cmd/geninterp/generate.go
@@ -63,6 +63,8 @@ func declare(file *jen.File) {
 		jen.Id("code").Index().Byte(),
 		jen.Id("ip").Int(),
 		jen.Id("exact").Bool(),
+		jen.Id("hot").Bool(),
+		jen.Id("backedge").Func().Params(jen.Op("*").Id("Interpreter"), jen.Op("*").Id("frame")).Error(),
 	)
 }
 

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -2445,7 +2445,7 @@ func br() jen.Code {
 	).Block(
 		jen.Id("offset").Op(":=").Id("instr").Dot("ParseI16").Call(jen.Id("c").Dot("code"), jen.Id("c").Dot("ip").Op("+").Lit(1)),
 		jen.Id("c").Dot("ip").Op("+=").Lit(3),
-		jen.If(jen.Op("!").Id("c").Dot("hot").Op("||").Id("c").Dot("backedge").Op("==").Nil().Op("||").Id("offset").Op(">").Lit(-3)).Block(
+		jen.If(jen.Id("c").Dot("backedge").Op("==").Nil().Op("||").Id("offset").Op(">").Lit(-3)).Block(
 			jen.Return(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(apply...)),
 		),
 		jen.Return(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(observe...)),

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -2430,10 +2430,26 @@ func arraySlice() jen.Code {
 }
 
 func br() jen.Code {
-	return jen.Func().Params(jen.Id("c").Add(jen.Op("*").Add(jen.Id("threader")))).Params(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter"))))).Block(jen.List(jen.Id("offset")).Op(":=").List(jen.Id("instr").Dot("ParseI16").Call(jen.Id("c").Dot("code"), jen.Id("c").Dot("ip").Op("+").Add(jen.Lit(1)))),
-		jen.List(jen.Id("c").Dot("ip")).Op("+=").List(jen.Lit(3)),
-		jen.Return(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter")))).Block(jen.List(jen.Id("f")).Op(":=").List(jen.Id("i").Dot("fr")),
-			jen.List(jen.Id("f").Dot("ip")).Op("+=").List(jen.Id("offset").Op("+").Add(jen.Lit(3))))))
+	apply := []jen.Code{
+		jen.Id("f").Op(":=").Id("i").Dot("fr"),
+		jen.Id("f").Dot("ip").Op("+=").Id("offset").Op("+").Lit(3),
+	}
+	observe := append([]jen.Code(nil), apply...)
+	observe = append(observe,
+		jen.If(jen.Id("err").Op(":=").Id("c").Dot("backedge").Call(jen.Id("i"), jen.Id("f")), jen.Id("err").Op("!=").Nil()).Block(
+			jen.Panic(jen.Id("err")),
+		),
+	)
+	return jen.Func().Params(jen.Id("c").Op("*").Id("threader")).Params(
+		jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")),
+	).Block(
+		jen.Id("offset").Op(":=").Id("instr").Dot("ParseI16").Call(jen.Id("c").Dot("code"), jen.Id("c").Dot("ip").Op("+").Lit(1)),
+		jen.Id("c").Dot("ip").Op("+=").Lit(3),
+		jen.If(jen.Op("!").Id("c").Dot("hot").Op("||").Id("c").Dot("backedge").Op("==").Nil().Op("||").Id("offset").Op(">").Lit(-3)).Block(
+			jen.Return(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(apply...)),
+		),
+		jen.Return(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(observe...)),
+	)
 }
 
 func brTable() jen.Code {

--- a/interp/cache.go
+++ b/interp/cache.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -21,9 +22,9 @@ type Cache struct {
 	active  []cacheRequest
 	pending [][]cacheRequest
 	refs    atomic.Int64
+	closed  bool
 
-	mu     sync.Mutex
-	closed bool
+	mu sync.Mutex
 }
 
 type cacheRequest struct {
@@ -114,7 +115,9 @@ func (c *Cache) request(next cacheRequest) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if c.active[addr].trigger != prof.TriggerNone && c.active[addr].root == next.root && next.trigger == prof.TriggerHot {
+	active := c.active[addr]
+	sameRoot := active.trigger != prof.TriggerNone && active.root == next.root
+	if sameRoot && (active.trigger == prof.TriggerSideExit || next.trigger == prof.TriggerHot) {
 		return
 	}
 	pending := c.pending[addr]
@@ -134,9 +137,7 @@ func (c *Cache) request(next cacheRequest) {
 		for insert < len(pending) && pending[insert].trigger == prof.TriggerSideExit {
 			insert++
 		}
-		pending = append(pending, cacheRequest{})
-		copy(pending[insert+1:], pending[insert:])
-		pending[insert] = next
+		pending = slices.Insert(pending, insert, next)
 	} else {
 		pending = append(pending, next)
 	}

--- a/interp/cache.go
+++ b/interp/cache.go
@@ -18,7 +18,8 @@ type Cache struct {
 	buffers []*asm.Buffer
 	hits    []atomic.Int64
 	state   []atomic.Int32
-	pending []cacheRequest
+	active  []cacheRequest
+	pending [][]cacheRequest
 	refs    atomic.Int64
 
 	mu     sync.Mutex
@@ -42,7 +43,8 @@ func NewCache(prog *program.Program) *Cache {
 	c := &Cache{
 		hits:    make([]atomic.Int64, size),
 		state:   make([]atomic.Int32, size),
-		pending: make([]cacheRequest, size),
+		active:  make([]cacheRequest, size),
+		pending: make([][]cacheRequest, size),
 	}
 	c.refs.Store(1)
 	c.modules.Store(&mods)
@@ -90,11 +92,12 @@ func (c *Cache) claim(addr int, threshold int64) (cacheRequest, bool) {
 	if c.state[addr].Load() != cacheCold {
 		return cacheRequest{}, false
 	}
-	request := c.pending[addr]
-	if request.trigger == prof.TriggerNone {
-		request = cacheRequest{root: anchor{addr: addr}, trigger: prof.TriggerHot}
+	request := cacheRequest{root: anchor{addr: addr}, trigger: prof.TriggerHot}
+	if len(c.pending[addr]) > 0 {
+		request = c.pending[addr][0]
+		c.pending[addr] = c.pending[addr][1:]
 	}
-	c.pending[addr] = cacheRequest{}
+	c.active[addr] = request
 	c.state[addr].Store(cacheBuild)
 	return request, true
 }
@@ -111,10 +114,33 @@ func (c *Cache) request(next cacheRequest) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	trigger := c.pending[addr].trigger
-	if trigger == prof.TriggerNone || trigger == prof.TriggerHot && next.trigger == prof.TriggerSideExit {
-		c.pending[addr] = next
+	if c.active[addr].trigger != prof.TriggerNone && c.active[addr].root == next.root && next.trigger == prof.TriggerHot {
+		return
 	}
+	pending := c.pending[addr]
+	for idx := range pending {
+		if pending[idx].root != next.root {
+			continue
+		}
+		if pending[idx].trigger == prof.TriggerSideExit || next.trigger == prof.TriggerHot {
+			return
+		}
+		copy(pending[idx:], pending[idx+1:])
+		pending = pending[:len(pending)-1]
+		break
+	}
+	if next.trigger == prof.TriggerSideExit {
+		insert := 0
+		for insert < len(pending) && pending[insert].trigger == prof.TriggerSideExit {
+			insert++
+		}
+		pending = append(pending, cacheRequest{})
+		copy(pending[insert+1:], pending[insert:])
+		pending[insert] = next
+	} else {
+		pending = append(pending, next)
+	}
+	c.pending[addr] = pending
 	if c.state[addr].Load() == cacheReady {
 		c.state[addr].Store(cacheCold)
 	}
@@ -140,7 +166,7 @@ func (c *Cache) publish(addr int, mod *module, buf *asm.Buffer) {
 		c.modules.Store(&next)
 		for target := range mod.entries {
 			if target.addr >= 0 && target.addr < len(c.state) && target.addr != addr &&
-				c.state[target.addr].Load() == cacheCold && c.pending[target.addr].trigger == prof.TriggerNone {
+				c.state[target.addr].Load() == cacheCold && len(c.pending[target.addr]) == 0 {
 				c.state[target.addr].Store(cacheReady)
 			}
 		}
@@ -164,7 +190,8 @@ func (c *Cache) release() error {
 
 func (c *Cache) finishLocked(addr int) {
 	if addr >= 0 && addr < len(c.state) {
-		if c.pending[addr].trigger == prof.TriggerNone {
+		c.active[addr] = cacheRequest{}
+		if len(c.pending[addr]) == 0 {
 			c.state[addr].Store(cacheReady)
 		} else {
 			c.state[addr].Store(cacheCold)

--- a/interp/cache_test.go
+++ b/interp/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/siyul-park/minivm/instr"
+	"github.com/siyul-park/minivm/prof"
 	"github.com/siyul-park/minivm/program"
 	"github.com/stretchr/testify/require"
 )
@@ -29,4 +30,72 @@ func TestCache_Close(t *testing.T) {
 	require.NoError(t, cache.Close())
 	require.NoError(t, cache.Close())
 	require.NoError(t, i.Close())
+}
+
+func TestCache_Request(t *testing.T) {
+	t.Run("queues distinct loop roots", func(t *testing.T) {
+		cache := NewCache(program.New(nil))
+		defer cache.Close()
+
+		first := cacheRequest{root: anchor{ip: 4}, trigger: prof.TriggerHot}
+		second := cacheRequest{root: anchor{ip: 8}, trigger: prof.TriggerHot}
+		cache.request(first)
+		cache.request(second)
+
+		request, ok := cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, first, request)
+		cache.fail(0)
+
+		request, ok = cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, second, request)
+	})
+
+	t.Run("prioritizes side exits", func(t *testing.T) {
+		cache := NewCache(program.New(nil))
+		defer cache.Close()
+
+		hot := cacheRequest{root: anchor{ip: 4}, trigger: prof.TriggerHot}
+		upgraded := cacheRequest{root: anchor{ip: 8}, trigger: prof.TriggerSideExit}
+		cache.request(hot)
+		cache.request(cacheRequest{root: upgraded.root, trigger: prof.TriggerHot})
+		cache.request(upgraded)
+
+		request, ok := cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, upgraded, request)
+		cache.fail(0)
+
+		request, ok = cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, hot, request)
+	})
+
+	t.Run("deduplicates active hot root", func(t *testing.T) {
+		cache := NewCache(program.New(nil))
+		defer cache.Close()
+
+		request := cacheRequest{root: anchor{ip: 4}, trigger: prof.TriggerHot}
+		cache.request(request)
+		claimed, ok := cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, request, claimed)
+
+		cache.request(request)
+		cache.fail(0)
+		_, ok = cache.claim(0, 1)
+		require.False(t, ok)
+	})
+
+	t.Run("queues entry root", func(t *testing.T) {
+		cache := NewCache(program.New(nil))
+		defer cache.Close()
+
+		request := cacheRequest{root: anchor{}, trigger: prof.TriggerHot}
+		cache.request(request)
+		claimed, ok := cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, request, claimed)
+	})
 }

--- a/interp/cache_test.go
+++ b/interp/cache_test.go
@@ -3,36 +3,12 @@ package interp
 import (
 	"testing"
 
-	"github.com/siyul-park/minivm/instr"
 	"github.com/siyul-park/minivm/prof"
 	"github.com/siyul-park/minivm/program"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewCache(t *testing.T) {
-	cache := NewCache(program.New([]instr.Instruction{
-		instr.New(instr.NOP),
-	}))
-	defer cache.Close()
-
-	i := New(program.New([]instr.Instruction{
-		instr.New(instr.NOP),
-	}), WithCache(cache))
-	defer i.Close()
-
-	require.Same(t, cache, i.cache)
-}
-
-func TestCache_Close(t *testing.T) {
-	cache := NewCache(program.New(nil))
-	i := New(program.New(nil), WithCache(cache))
-
-	require.NoError(t, cache.Close())
-	require.NoError(t, cache.Close())
-	require.NoError(t, i.Close())
-}
-
-func TestCache_Request(t *testing.T) {
 	t.Run("queues distinct loop roots", func(t *testing.T) {
 		cache := NewCache(program.New(nil))
 		defer cache.Close()
@@ -52,19 +28,26 @@ func TestCache_Request(t *testing.T) {
 		require.Equal(t, second, request)
 	})
 
-	t.Run("prioritizes side exits", func(t *testing.T) {
+	t.Run("prioritizes side exits in arrival order", func(t *testing.T) {
 		cache := NewCache(program.New(nil))
 		defer cache.Close()
 
 		hot := cacheRequest{root: anchor{ip: 4}, trigger: prof.TriggerHot}
-		upgraded := cacheRequest{root: anchor{ip: 8}, trigger: prof.TriggerSideExit}
+		first := cacheRequest{root: anchor{ip: 8}, trigger: prof.TriggerSideExit}
+		second := cacheRequest{root: anchor{ip: 12}, trigger: prof.TriggerSideExit}
 		cache.request(hot)
-		cache.request(cacheRequest{root: upgraded.root, trigger: prof.TriggerHot})
-		cache.request(upgraded)
+		cache.request(cacheRequest{root: first.root, trigger: prof.TriggerHot})
+		cache.request(first)
+		cache.request(second)
 
 		request, ok := cache.claim(0, 1)
 		require.True(t, ok)
-		require.Equal(t, upgraded, request)
+		require.Equal(t, first, request)
+		cache.fail(0)
+
+		request, ok = cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, second, request)
 		cache.fail(0)
 
 		request, ok = cache.claim(0, 1)
@@ -72,20 +55,56 @@ func TestCache_Request(t *testing.T) {
 		require.Equal(t, hot, request)
 	})
 
-	t.Run("deduplicates active hot root", func(t *testing.T) {
+	t.Run("coalesces pending roots", func(t *testing.T) {
+		for _, trigger := range []prof.Trigger{prof.TriggerHot, prof.TriggerSideExit} {
+			cache := NewCache(program.New(nil))
+			request := cacheRequest{root: anchor{ip: 4}, trigger: trigger}
+			cache.request(request)
+			cache.request(request)
+
+			claimed, ok := cache.claim(0, 1)
+			require.True(t, ok, "trigger=%v", trigger)
+			require.Equal(t, request, claimed, "trigger=%v", trigger)
+			cache.fail(0)
+			_, ok = cache.claim(0, 1)
+			require.False(t, ok, "trigger=%v", trigger)
+			require.NoError(t, cache.Close())
+		}
+	})
+
+	t.Run("queues side exit behind active hot root", func(t *testing.T) {
 		cache := NewCache(program.New(nil))
 		defer cache.Close()
 
-		request := cacheRequest{root: anchor{ip: 4}, trigger: prof.TriggerHot}
-		cache.request(request)
+		hot := cacheRequest{root: anchor{ip: 4}, trigger: prof.TriggerHot}
+		sideExit := cacheRequest{root: hot.root, trigger: prof.TriggerSideExit}
+		cache.request(hot)
 		claimed, ok := cache.claim(0, 1)
 		require.True(t, ok)
-		require.Equal(t, request, claimed)
+		require.Equal(t, hot, claimed)
 
-		cache.request(request)
+		cache.request(sideExit)
 		cache.fail(0)
-		_, ok = cache.claim(0, 1)
-		require.False(t, ok)
+		claimed, ok = cache.claim(0, 1)
+		require.True(t, ok)
+		require.Equal(t, sideExit, claimed)
+	})
+
+	t.Run("deduplicates active roots", func(t *testing.T) {
+		for _, trigger := range []prof.Trigger{prof.TriggerHot, prof.TriggerSideExit} {
+			cache := NewCache(program.New(nil))
+			request := cacheRequest{root: anchor{ip: 4}, trigger: trigger}
+			cache.request(request)
+			claimed, ok := cache.claim(0, 1)
+			require.True(t, ok, "trigger=%v", trigger)
+			require.Equal(t, request, claimed, "trigger=%v", trigger)
+
+			cache.request(request)
+			cache.fail(0)
+			_, ok = cache.claim(0, 1)
+			require.False(t, ok, "trigger=%v", trigger)
+			require.NoError(t, cache.Close())
+		}
 	})
 
 	t.Run("queues entry root", func(t *testing.T) {
@@ -98,4 +117,13 @@ func TestCache_Request(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, request, claimed)
 	})
+}
+
+func TestCache_Close(t *testing.T) {
+	cache := NewCache(program.New(nil))
+	i := New(program.New(nil), WithCache(cache))
+
+	require.NoError(t, cache.Close())
+	require.NoError(t, cache.Close())
+	require.NoError(t, i.Close())
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -17,11 +17,12 @@ import (
 )
 
 type Interpreter struct {
-	ctx       context.Context
-	done      <-chan struct{}
-	tracer    *Tracer
-	hook      func(*Interpreter) error
-	marshaler Marshaler
+	ctx         context.Context
+	done        <-chan struct{}
+	tracer      *Tracer
+	hook        func(*Interpreter) error
+	marshaler   Marshaler
+	speculative bool
 
 	compiler *compiler
 	cache    *Cache
@@ -31,7 +32,7 @@ type Interpreter struct {
 	stubs    []func(*Interpreter)
 	natives  []unsafe.Pointer
 	tried    map[anchor]bool
-	loops    map[anchor]uint8
+	warmup   map[anchor]uint8
 	journal  []uint64
 
 	types       []types.Type
@@ -252,7 +253,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		stubs:     make([]func(*Interpreter), len(prog.Constants)+1),
 		natives:   make([]unsafe.Pointer, len(prog.Constants)+1),
 		tried:     map[anchor]bool{},
-		loops:     map[anchor]uint8{},
+		warmup:    map[anchor]uint8{},
 		dynamic:   map[int]bool{},
 		journal:   make([]uint64, journalHead+journalStride*opt.frame),
 		frames:    make([]frame, opt.frame),
@@ -344,16 +345,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		i.globals[j] = i.zero(kind)
 	}
 
-	c := &threader{
-		types:     i.types,
-		constants: i.constants,
-		heap:      i.heap,
-		coros:     i.coros,
-		globals:   i.globalKinds,
-		exact:     opt.tick == 1,
-		hot:       nativeBackend && i.threshold >= 0,
-		backedge:  (*Interpreter).observeLoop,
-	}
+	c := i.threader()
 	i.code[0] = c.Compile(prog.Code, i.module.LocalKinds(), types.Kinds(i.module.Captures))
 
 	for j, v := range prog.Constants {
@@ -1029,8 +1021,8 @@ func (i *Interpreter) observeLoop(f *frame) error {
 		if samples == 0 {
 			i.sample(f)
 		}
-		hits := i.loops[root] + 1
-		i.loops[root] = hits
+		hits := i.warmup[root] + 1
+		i.warmup[root] = hits
 		if hits < loopWarmup {
 			return nil
 		}
@@ -1745,16 +1737,7 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	if addr >= len(i.coros) {
 		i.coros = append(i.coros, make([]bool, n-len(i.coros))...)
 	}
-	c := &threader{
-		types:     i.types,
-		constants: i.constants,
-		heap:      i.heap,
-		coros:     i.coros,
-		globals:   i.globalKinds,
-		exact:     i.tick == 1,
-		hot:       nativeBackend && i.threshold >= 0,
-		backedge:  (*Interpreter).observeLoop,
-	}
+	c := i.threader()
 	if dynamic {
 		i.coros[addr] = i.yields(fn.Code)
 	}
@@ -1764,6 +1747,24 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	if dynamic {
 		i.dynamic[addr] = true
 	}
+}
+
+// threader builds generated dispatch state. The loop callback is injected at
+// runtime instead of referenced by the generated global handler table, avoiding
+// an initialization cycle through trace compilation.
+func (i *Interpreter) threader() *threader {
+	c := &threader{
+		types:     i.types,
+		constants: i.constants,
+		heap:      i.heap,
+		coros:     i.coros,
+		globals:   i.globalKinds,
+		exact:     i.tick == 1,
+	}
+	if nativeBackend && i.threshold >= 0 {
+		c.backedge = (*Interpreter).observeLoop
+	}
+	return c
 }
 
 // recount rebuilds baseline counts from constant roots and heap edges after
@@ -1993,8 +1994,12 @@ func (i *Interpreter) finalize(addr int, v types.Value) {
 	if s, ok := v.(types.String); ok && i.interned[string(s)] == types.Ref(addr) {
 		delete(i.interned, string(s))
 	}
-	if c, ok := v.(io.Closer); ok {
-		_ = c.Close()
+	// External finalizers belong to committed execution, never speculative
+	// trace capture.
+	if !i.speculative {
+		if c, ok := v.(io.Closer); ok {
+			_ = c.Close()
+		}
 	}
 }
 
@@ -2018,9 +2023,9 @@ func (i *Interpreter) remove(addr int) {
 			delete(i.tried, a)
 		}
 	}
-	for a := range i.loops {
+	for a := range i.warmup {
 		if a.addr == addr {
-			delete(i.loops, a)
+			delete(i.warmup, a)
 		}
 	}
 	if i.tracer != nil {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -347,7 +347,8 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		i.globals[j] = i.zero(kind)
 	}
 
-	c := i.threader(0, i.eager)
+	i.backedges[0] = nativeBackend && i.eager
+	c := i.threader(i.backedges[0])
 	i.code[0] = c.Compile(prog.Code, i.module.LocalKinds(), types.Kinds(i.module.Captures))
 
 	for j, v := range prog.Constants {
@@ -977,16 +978,13 @@ func (i *Interpreter) safepoint() error {
 // The caller guarantees the entry fallback is still nil, so the gates that the
 // threaded safepoint used to repeat on that lookup are already satisfied.
 func (i *Interpreter) observe(f *frame) error {
-	i.sample(f)
+	samples := i.sample(f)
 	if f.ip == 0 {
-		if _, err := i.tracer.capture(i, anchor{addr: f.addr}); err != nil {
-			return err
-		}
+		i.tracer.capture(i, anchor{addr: f.addr})
 	}
-	if err := i.observeLoop(f); err != nil {
+	if err := i.observeLoop(f, samples); err != nil {
 		return err
 	}
-	samples := i.samples.Samples(f.addr)
 	root := anchor{addr: f.addr}
 	if i.cache == nil && i.threshold >= 0 && samples >= uint64(i.threshold) && !i.tried[root] {
 		i.tried[root] = true
@@ -999,9 +997,9 @@ func (i *Interpreter) observe(f *frame) error {
 
 // observeLoop records a sampled loop only after the function is hot, then
 // verifies that the sampled IP is a static loop header.
-func (i *Interpreter) observeLoop(f *frame) error {
-	if i.threshold < 0 || f == nil || f.ip <= 0 ||
-		!i.eager && i.samples.Samples(f.addr) < uint64(i.threshold) {
+func (i *Interpreter) observeLoop(f *frame, samples uint64) error {
+	if i.threshold < 0 || f.ip <= 0 ||
+		!i.eager && samples < uint64(i.threshold) {
 		return nil
 	}
 	for _, header := range i.tracer.headers(i, f.addr) {
@@ -1017,7 +1015,7 @@ func (i *Interpreter) observeLoop(f *frame) error {
 // once when periodic profiling reaches the threshold, so cold BR handlers stay
 // unchanged and no header scan is needed here.
 func (i *Interpreter) observeBackedge(f *frame) error {
-	if f == nil || f.ip <= 0 {
+	if f.ip <= 0 {
 		return nil
 	}
 	return i.captureLoop(f)
@@ -1039,10 +1037,7 @@ func (i *Interpreter) captureLoop(f *frame) error {
 		}
 	}
 	i.tried[root] = true
-	result, err := i.tracer.capture(i, root)
-	if err != nil {
-		return err
-	}
+	result := i.tracer.capture(i, root)
 	if result.trace == nil {
 		return nil
 	}
@@ -1180,10 +1175,7 @@ func (i *Interpreter) loop(callable asm.Callable, stats counters) func(*Interpre
 }
 
 func (i *Interpreter) exit(root anchor) {
-	hits, err := i.tracer.exit(i, root, anchor{addr: i.fr.addr, ip: i.fr.ip})
-	if err != nil {
-		panic(err)
-	}
+	hits := i.tracer.branch(i, root, anchor{addr: i.fr.addr, ip: i.fr.ip})
 	if i.cache != nil {
 		if hits < exitThreshold || hits%exitThreshold != 0 {
 			return
@@ -1310,28 +1302,29 @@ func (i *Interpreter) function(addr int) (*types.Function, bool) {
 	return fn, ok
 }
 
-// sample records one profile hit for the frame's current instruction.
-func (i *Interpreter) sample(f *frame) {
+// sample records one profile hit for the frame's current instruction and
+// returns the updated function count.
+func (i *Interpreter) sample(f *frame) uint64 {
 	i.samples.Add(f.addr, f.ip, i.instrs[f.addr][f.ip])
-	if i.eager || i.threshold < 0 || i.samples.Samples(f.addr) < uint64(i.threshold) {
-		return
+	samples := i.samples.Samples(f.addr)
+	if nativeBackend && !i.eager && i.threshold >= 0 && samples >= uint64(i.threshold) {
+		i.enableBackedges(f.addr)
 	}
-	i.enableBackedges(f.addr)
+	return samples
 }
 
 // enableBackedges rethreads one hot function with exact unconditional
 // back-edge observation. Cold functions keep the original zero-overhead BR
 // handler until periodic sampling reaches the configured threshold.
 func (i *Interpreter) enableBackedges(addr int) {
-	if !nativeBackend || addr < 0 || addr >= len(i.backedges) ||
-		i.backedges[addr] {
+	if addr < 0 || addr >= len(i.backedges) || i.backedges[addr] {
 		return
 	}
 	fn, ok := i.function(addr)
 	if !ok || fn == nil {
 		return
 	}
-	c := i.threader(addr, true)
+	c := i.threader(true)
 	previous := i.code[addr]
 	compiled := c.Compile(fn.Code, fn.LocalKinds(), types.Kinds(fn.Captures))
 	// Rethreading replaces only interpreted handlers. Installed native entries
@@ -1347,6 +1340,7 @@ func (i *Interpreter) enableBackedges(addr int) {
 		compiled[root.ip] = previous[root.ip]
 	}
 	i.code[addr] = compiled
+	i.backedges[addr] = true
 	for idx := 0; idx < i.fp; idx++ {
 		if i.frames[idx].addr == addr {
 			i.frames[idx].code = i.code[addr]
@@ -1788,7 +1782,8 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	if addr >= len(i.coros) {
 		i.coros = append(i.coros, make([]bool, n-len(i.coros))...)
 	}
-	c := i.threader(addr, i.eager)
+	i.backedges[addr] = nativeBackend && i.eager
+	c := i.threader(i.backedges[addr])
 	if dynamic {
 		i.coros[addr] = i.yields(fn.Code)
 	}
@@ -1803,7 +1798,7 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 // threader builds generated dispatch state. The loop callback is injected at
 // runtime instead of referenced by the generated global handler table, avoiding
 // an initialization cycle through trace compilation.
-func (i *Interpreter) threader(addr int, backedges bool) *threader {
+func (i *Interpreter) threader(backedge bool) *threader {
 	c := &threader{
 		types:     i.types,
 		constants: i.constants,
@@ -1812,11 +1807,8 @@ func (i *Interpreter) threader(addr int, backedges bool) *threader {
 		globals:   i.globalKinds,
 		exact:     i.tick == 1,
 	}
-	if nativeBackend && backedges {
+	if backedge {
 		c.backedge = (*Interpreter).observeBackedge
-	}
-	if addr >= 0 && addr < len(i.backedges) {
-		i.backedges[addr] = c.backedge != nil
 	}
 	return c
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -32,7 +32,7 @@ type Interpreter struct {
 	stubs    []func(*Interpreter)
 	natives  []unsafe.Pointer
 	tried    map[anchor]bool
-	warmup   map[anchor]uint8
+	loopHits map[anchor]uint8
 	journal  []uint64
 
 	types       []types.Type
@@ -255,7 +255,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		stubs:     make([]func(*Interpreter), len(prog.Constants)+1),
 		natives:   make([]unsafe.Pointer, len(prog.Constants)+1),
 		tried:     map[anchor]bool{},
-		warmup:    map[anchor]uint8{},
+		loopHits:  map[anchor]uint8{},
 		dynamic:   map[int]bool{},
 		journal:   make([]uint64, journalHead+journalStride*opt.frame),
 		frames:    make([]frame, opt.frame),
@@ -348,7 +348,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 	}
 
 	i.backedges[0] = nativeBackend && i.eager
-	c := i.threader(i.backedges[0])
+	c := i.newThreader(i.backedges[0])
 	i.code[0] = c.Compile(prog.Code, i.module.LocalKinds(), types.Kinds(i.module.Captures))
 
 	for j, v := range prog.Constants {
@@ -982,8 +982,16 @@ func (i *Interpreter) observe(f *frame) error {
 	if f.ip == 0 {
 		i.tracer.capture(i, anchor{addr: f.addr})
 	}
-	if err := i.observeLoop(f, samples); err != nil {
-		return err
+	if i.threshold >= 0 && f.ip > 0 && (i.eager || samples >= uint64(i.threshold)) {
+		for _, header := range i.tracer.headers(i, f.addr) {
+			if header != f.ip {
+				continue
+			}
+			if err := i.traceLoop(f); err != nil {
+				return err
+			}
+			break
+		}
 	}
 	root := anchor{addr: f.addr}
 	if i.cache == nil && i.threshold >= 0 && samples >= uint64(i.threshold) && !i.tried[root] {
@@ -995,33 +1003,18 @@ func (i *Interpreter) observe(f *frame) error {
 	return nil
 }
 
-// observeLoop records a sampled loop only after the function is hot, then
-// verifies that the sampled IP is a static loop header.
-func (i *Interpreter) observeLoop(f *frame, samples uint64) error {
-	if i.threshold < 0 || f.ip <= 0 ||
-		!i.eager && samples < uint64(i.threshold) {
-		return nil
-	}
-	for _, header := range i.tracer.headers(i, f.addr) {
-		if header == f.ip {
-			return i.captureLoop(f)
-		}
-	}
-	return nil
-}
-
-// observeBackedge receives the exact target of an unconditional backward
+// backedge receives the exact target of an unconditional backward
 // branch. Eager functions install it immediately; sampled functions install it
 // once when periodic profiling reaches the threshold, so cold BR handlers stay
 // unchanged and no header scan is needed here.
-func (i *Interpreter) observeBackedge(f *frame) error {
+func (i *Interpreter) backedge(f *frame) error {
 	if f.ip <= 0 {
 		return nil
 	}
-	return i.captureLoop(f)
+	return i.traceLoop(f)
 }
 
-func (i *Interpreter) captureLoop(f *frame) error {
+func (i *Interpreter) traceLoop(f *frame) error {
 	root := anchor{addr: f.addr, ip: f.ip}
 	if i.exits[root] != nil || i.tried[root] {
 		return nil
@@ -1030,8 +1023,8 @@ func (i *Interpreter) captureLoop(f *frame) error {
 		if i.samples.Samples(f.addr) == 0 {
 			i.sample(f)
 		}
-		hits := i.warmup[root] + 1
-		i.warmup[root] = hits
+		hits := i.loopHits[root] + 1
+		i.loopHits[root] = hits
 		if hits < loopWarmup {
 			return nil
 		}
@@ -1324,7 +1317,7 @@ func (i *Interpreter) enableBackedges(addr int) {
 	if !ok || fn == nil {
 		return
 	}
-	c := i.threader(true)
+	c := i.newThreader(true)
 	previous := i.code[addr]
 	compiled := c.Compile(fn.Code, fn.LocalKinds(), types.Kinds(fn.Captures))
 	// Rethreading replaces only interpreted handlers. Installed native entries
@@ -1783,7 +1776,7 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 		i.coros = append(i.coros, make([]bool, n-len(i.coros))...)
 	}
 	i.backedges[addr] = nativeBackend && i.eager
-	c := i.threader(i.backedges[addr])
+	c := i.newThreader(i.backedges[addr])
 	if dynamic {
 		i.coros[addr] = i.yields(fn.Code)
 	}
@@ -1795,10 +1788,10 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	}
 }
 
-// threader builds generated dispatch state. The loop callback is injected at
+// newThreader builds generated dispatch state. The backedge callback is injected at
 // runtime instead of referenced by the generated global handler table, avoiding
 // an initialization cycle through trace compilation.
-func (i *Interpreter) threader(backedge bool) *threader {
+func (i *Interpreter) newThreader(backedge bool) *threader {
 	c := &threader{
 		types:     i.types,
 		constants: i.constants,
@@ -1808,7 +1801,7 @@ func (i *Interpreter) threader(backedge bool) *threader {
 		exact:     i.tick == 1,
 	}
 	if backedge {
-		c.backedge = (*Interpreter).observeBackedge
+		c.backedge = (*Interpreter).backedge
 	}
 	return c
 }
@@ -2070,9 +2063,9 @@ func (i *Interpreter) remove(addr int) {
 			delete(i.tried, a)
 		}
 	}
-	for a := range i.warmup {
+	for a := range i.loopHits {
 		if a.addr == addr {
-			delete(i.warmup, a)
+			delete(i.loopHits, a)
 		}
 	}
 	if i.tracer != nil {

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -41,6 +41,7 @@ type Interpreter struct {
 	globalKinds []types.Kind
 	instrs      [][]byte
 	code        [][]func(*Interpreter)
+	backedges   []bool
 	coros       []bool
 	handlers    [][]instr.Handler
 	module      *types.Function
@@ -247,6 +248,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		globals:   make([]types.Boxed, len(prog.Globals)),
 		instrs:    make([][]byte, len(prog.Constants)+1),
 		code:      make([][]func(*Interpreter), len(prog.Constants)+1),
+		backedges: make([]bool, len(prog.Constants)+1),
 		coros:     make([]bool, len(prog.Constants)+1),
 		handlers:  make([][]instr.Handler, len(prog.Constants)+1),
 		exits:     map[anchor]func(*Interpreter){},
@@ -345,7 +347,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		i.globals[j] = i.zero(kind)
 	}
 
-	c := i.threader()
+	c := i.threader(0, i.eager)
 	i.code[0] = c.Compile(prog.Code, i.module.LocalKinds(), types.Kinds(i.module.Captures))
 
 	for j, v := range prog.Constants {
@@ -995,30 +997,39 @@ func (i *Interpreter) observe(f *frame) error {
 	return nil
 }
 
-// observeLoop records and compiles a hot loop from an exact header state. It is
-// called both by periodic sampling and by JIT-enabled backward branches so a
-// deterministic tick phase cannot permanently miss a loop header.
+// observeLoop records a sampled loop only after the function is hot, then
+// verifies that the sampled IP is a static loop header.
 func (i *Interpreter) observeLoop(f *frame) error {
-	if i.threshold < 0 || f == nil || f.ip <= 0 {
+	if i.threshold < 0 || f == nil || f.ip <= 0 ||
+		!i.eager && i.samples.Samples(f.addr) < uint64(i.threshold) {
 		return nil
 	}
+	for _, header := range i.tracer.headers(i, f.addr) {
+		if header == f.ip {
+			return i.captureLoop(f)
+		}
+	}
+	return nil
+}
+
+// observeBackedge receives the exact target of an unconditional backward
+// branch. Eager functions install it immediately; sampled functions install it
+// once when periodic profiling reaches the threshold, so cold BR handlers stay
+// unchanged and no header scan is needed here.
+func (i *Interpreter) observeBackedge(f *frame) error {
+	if f == nil || f.ip <= 0 {
+		return nil
+	}
+	return i.captureLoop(f)
+}
+
+func (i *Interpreter) captureLoop(f *frame) error {
 	root := anchor{addr: f.addr, ip: f.ip}
 	if i.exits[root] != nil || i.tried[root] {
 		return nil
 	}
-	var found bool
-	for _, header := range i.tracer.headers(i, f.addr) {
-		if header == f.ip {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return nil
-	}
-	samples := i.samples.Samples(f.addr)
 	if i.eager {
-		if samples == 0 {
+		if i.samples.Samples(f.addr) == 0 {
 			i.sample(f)
 		}
 		hits := i.warmup[root] + 1
@@ -1026,8 +1037,6 @@ func (i *Interpreter) observeLoop(f *frame) error {
 		if hits < loopWarmup {
 			return nil
 		}
-	} else if samples < uint64(i.threshold) {
-		return nil
 	}
 	i.tried[root] = true
 	result, err := i.tracer.capture(i, root)
@@ -1304,6 +1313,45 @@ func (i *Interpreter) function(addr int) (*types.Function, bool) {
 // sample records one profile hit for the frame's current instruction.
 func (i *Interpreter) sample(f *frame) {
 	i.samples.Add(f.addr, f.ip, i.instrs[f.addr][f.ip])
+	if i.eager || i.threshold < 0 || i.samples.Samples(f.addr) < uint64(i.threshold) {
+		return
+	}
+	i.enableBackedges(f.addr)
+}
+
+// enableBackedges rethreads one hot function with exact unconditional
+// back-edge observation. Cold functions keep the original zero-overhead BR
+// handler until periodic sampling reaches the configured threshold.
+func (i *Interpreter) enableBackedges(addr int) {
+	if !nativeBackend || addr < 0 || addr >= len(i.backedges) ||
+		i.backedges[addr] {
+		return
+	}
+	fn, ok := i.function(addr)
+	if !ok || fn == nil {
+		return
+	}
+	c := i.threader(addr, true)
+	previous := i.code[addr]
+	compiled := c.Compile(fn.Code, fn.LocalKinds(), types.Kinds(fn.Captures))
+	// Rethreading replaces only interpreted handlers. Installed native entries
+	// stay live while their saved fallbacks advance to the exact-backedge table.
+	for root := range i.exits {
+		if root.addr != addr || root.ip < 0 || root.ip >= len(compiled) || root.ip >= len(previous) {
+			continue
+		}
+		i.exits[root] = compiled[root.ip]
+		if root.ip == 0 {
+			i.stubs[addr] = compiled[root.ip]
+		}
+		compiled[root.ip] = previous[root.ip]
+	}
+	i.code[addr] = compiled
+	for idx := 0; idx < i.fp; idx++ {
+		if i.frames[idx].addr == addr {
+			i.frames[idx].code = i.code[addr]
+		}
+	}
 }
 
 func (i *Interpreter) stub(addr int) func(*Interpreter) {
@@ -1728,6 +1776,9 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	if addr >= len(i.code) {
 		i.code = append(i.code, make([][]func(*Interpreter), n-len(i.code))...)
 	}
+	if addr >= len(i.backedges) {
+		i.backedges = append(i.backedges, make([]bool, n-len(i.backedges))...)
+	}
 	if addr >= len(i.stubs) {
 		i.stubs = append(i.stubs, make([]func(*Interpreter), n-len(i.stubs))...)
 	}
@@ -1737,7 +1788,7 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 	if addr >= len(i.coros) {
 		i.coros = append(i.coros, make([]bool, n-len(i.coros))...)
 	}
-	c := i.threader()
+	c := i.threader(addr, i.eager)
 	if dynamic {
 		i.coros[addr] = i.yields(fn.Code)
 	}
@@ -1752,7 +1803,7 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 // threader builds generated dispatch state. The loop callback is injected at
 // runtime instead of referenced by the generated global handler table, avoiding
 // an initialization cycle through trace compilation.
-func (i *Interpreter) threader() *threader {
+func (i *Interpreter) threader(addr int, backedges bool) *threader {
 	c := &threader{
 		types:     i.types,
 		constants: i.constants,
@@ -1761,8 +1812,11 @@ func (i *Interpreter) threader() *threader {
 		globals:   i.globalKinds,
 		exact:     i.tick == 1,
 	}
-	if nativeBackend && i.threshold >= 0 {
-		c.backedge = (*Interpreter).observeLoop
+	if nativeBackend && backedges {
+		c.backedge = (*Interpreter).observeBackedge
+	}
+	if addr >= 0 && addr < len(i.backedges) {
+		i.backedges[addr] = c.backedge != nil
 	}
 	return c
 }
@@ -2010,6 +2064,7 @@ func (i *Interpreter) remove(addr int) {
 	}
 	i.instrs[addr] = nil
 	i.code[addr] = nil
+	i.backedges[addr] = false
 	i.stubs[addr] = nil
 	i.handlers[addr] = nil
 	i.coros[addr] = false

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -30,7 +30,8 @@ type Interpreter struct {
 	exits    map[anchor]func(*Interpreter)
 	stubs    []func(*Interpreter)
 	natives  []unsafe.Pointer
-	tried    map[int]bool
+	tried    map[anchor]bool
+	loops    map[anchor]uint8
 	journal  []uint64
 
 	types       []types.Type
@@ -63,6 +64,7 @@ type Interpreter struct {
 	gas int64
 
 	threshold int64
+	eager     bool
 	tick      int
 	fuel      int64
 	limit     int
@@ -103,6 +105,7 @@ type option struct {
 }
 
 const heapRunway = 64
+const loopWarmup = 8
 
 func WithHook(fn func(*Interpreter) error) func(*option) {
 	return func(o *option) { o.hook = fn }
@@ -237,6 +240,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		profiler:  opt.profiler,
 		samples:   samples,
 		threshold: threshold,
+		eager:     opt.threshold == 0,
 		types:     prog.Types,
 		constants: make([]types.Boxed, len(prog.Constants)),
 		globals:   make([]types.Boxed, len(prog.Globals)),
@@ -247,7 +251,8 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		exits:     map[anchor]func(*Interpreter){},
 		stubs:     make([]func(*Interpreter), len(prog.Constants)+1),
 		natives:   make([]unsafe.Pointer, len(prog.Constants)+1),
-		tried:     map[int]bool{},
+		tried:     map[anchor]bool{},
+		loops:     map[anchor]uint8{},
 		dynamic:   map[int]bool{},
 		journal:   make([]uint64, journalHead+journalStride*opt.frame),
 		frames:    make([]frame, opt.frame),
@@ -346,6 +351,8 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		coros:     i.coros,
 		globals:   i.globalKinds,
 		exact:     opt.tick == 1,
+		hot:       nativeBackend && i.threshold >= 0,
+		backedge:  (*Interpreter).observeLoop,
 	}
 	i.code[0] = c.Compile(prog.Code, i.module.LocalKinds(), types.Kinds(i.module.Captures))
 
@@ -978,47 +985,71 @@ func (i *Interpreter) safepoint() error {
 func (i *Interpreter) observe(f *frame) error {
 	i.sample(f)
 	if f.ip == 0 {
-		if _, err := i.tracer.capture(i, anchor{addr: f.addr, ip: 0}); err != nil {
+		if _, err := i.tracer.capture(i, anchor{addr: f.addr}); err != nil {
 			return err
 		}
 	}
-	// A hot loop header sampled mid-function: f.ip is genuinely at the back-edge
-	// target, so the clone's operand stack matches the header and a one-iteration
-	// loop trace can be recorded from the live state. A loopy function's entry
-	// trace aborts on the unrolled body, so the one-shot entry threshold never
-	// installs anything; compile here, once the function is hot and the loop
-	// trace first appears, so the loop header gets its own native. The hotness
-	// gate keeps WithThreshold(-1) a pure interpreter.
-	samples := i.samples.Samples(f.addr)
-	if i.threshold >= 0 && f.ip > 0 &&
-		samples >= uint64(i.threshold) &&
-		i.exits[anchor{addr: f.addr, ip: f.ip}] == nil {
-		for _, h := range i.tracer.headers(i, f.addr) {
-			if h != f.ip {
-				continue
-			}
-			result, err := i.tracer.capture(i, anchor{addr: f.addr, ip: f.ip})
-			if err != nil {
-				return err
-			}
-			if result.trace != nil {
-				root := anchor{addr: f.addr, ip: f.ip}
-				if i.cache != nil {
-					i.cache.request(cacheRequest{root: root, trigger: prof.TriggerHot})
-				} else if err := i.compile(root); err != nil {
-					return err
-				}
-			}
-			break
-		}
+	if err := i.observeLoop(f); err != nil {
+		return err
 	}
-	if i.cache == nil && i.threshold >= 0 && samples >= uint64(i.threshold) && !i.tried[f.addr] {
-		i.tried[f.addr] = true
-		if err := i.compile(anchor{addr: f.addr}); err != nil {
+	samples := i.samples.Samples(f.addr)
+	root := anchor{addr: f.addr}
+	if i.cache == nil && i.threshold >= 0 && samples >= uint64(i.threshold) && !i.tried[root] {
+		i.tried[root] = true
+		if err := i.compile(root); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// observeLoop records and compiles a hot loop from an exact header state. It is
+// called both by periodic sampling and by JIT-enabled backward branches so a
+// deterministic tick phase cannot permanently miss a loop header.
+func (i *Interpreter) observeLoop(f *frame) error {
+	if i.threshold < 0 || f == nil || f.ip <= 0 {
+		return nil
+	}
+	root := anchor{addr: f.addr, ip: f.ip}
+	if i.exits[root] != nil || i.tried[root] {
+		return nil
+	}
+	var found bool
+	for _, header := range i.tracer.headers(i, f.addr) {
+		if header == f.ip {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	samples := i.samples.Samples(f.addr)
+	if i.eager {
+		if samples == 0 {
+			i.sample(f)
+		}
+		hits := i.loops[root] + 1
+		i.loops[root] = hits
+		if hits < loopWarmup {
+			return nil
+		}
+	} else if samples < uint64(i.threshold) {
+		return nil
+	}
+	i.tried[root] = true
+	result, err := i.tracer.capture(i, root)
+	if err != nil {
+		return err
+	}
+	if result.trace == nil {
+		return nil
+	}
+	if i.cache != nil {
+		i.cache.request(cacheRequest{root: root, trigger: prof.TriggerHot})
+		return nil
+	}
+	return i.compile(root)
 }
 
 // call wraps a native trace Entry Callable. The CALL handler has already
@@ -1721,6 +1752,8 @@ func (i *Interpreter) bind(addr int, fn *types.Function, dynamic bool) {
 		coros:     i.coros,
 		globals:   i.globalKinds,
 		exact:     i.tick == 1,
+		hot:       nativeBackend && i.threshold >= 0,
+		backedge:  (*Interpreter).observeLoop,
 	}
 	if dynamic {
 		i.coros[addr] = i.yields(fn.Code)
@@ -1980,7 +2013,16 @@ func (i *Interpreter) remove(addr int) {
 			delete(i.exits, a)
 		}
 	}
-	delete(i.tried, addr)
+	for a := range i.tried {
+		if a.addr == addr {
+			delete(i.tried, a)
+		}
+	}
+	for a := range i.loops {
+		if a.addr == addr {
+			delete(i.loops, a)
+		}
+	}
 	if i.tracer != nil {
 		i.tracer.remove(addr)
 	}

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1527,6 +1527,82 @@ func TestInterpreter_Run(t *testing.T) {
 		require.Empty(t, missing)
 	})
 
+	t.Run("keeps cold backedges on ordinary dispatch", func(t *testing.T) {
+		b := program.NewBuilder()
+		loop := b.Label()
+		done := b.Label()
+		b.Locals(types.TypeI32)
+		b.Emit(instr.I32_CONST, 0).
+			Emit(instr.LOCAL_SET, 0).
+			Bind(loop).
+			Emit(instr.LOCAL_GET, 0).
+			Emit(instr.I32_CONST, 64).
+			Emit(instr.I32_GE_S).
+			BrIf(done).
+			Emit(instr.LOCAL_GET, 0).
+			Emit(instr.I32_CONST, 1).
+			Emit(instr.I32_ADD).
+			Emit(instr.LOCAL_SET, 0).
+			Br(loop).
+			Bind(done).
+			Emit(instr.LOCAL_GET, 0)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		i := New(prog, WithTick(1<<20), WithThreshold(1<<30))
+		defer i.Close()
+		require.Empty(t, i.tracer.loops)
+
+		require.NoError(t, i.Run(context.Background()))
+		value, err := i.PopBoxed()
+		require.NoError(t, err)
+		require.Equal(t, types.BoxI32(64), value)
+		require.Empty(t, i.tracer.loops)
+		require.Empty(t, i.warmup)
+		require.Empty(t, i.tried)
+	})
+
+	if runtime.GOARCH == "arm64" {
+		t.Run("preserves native handlers when enabling backedges", func(t *testing.T) {
+			b := program.NewBuilder()
+			loop := b.Label()
+			done := b.Label()
+			b.Locals(types.TypeI32)
+			b.Emit(instr.I32_CONST, 0).
+				Emit(instr.LOCAL_SET, 0).
+				Bind(loop).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 2).
+				Emit(instr.I32_GE_S).
+				BrIf(done).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_ADD).
+				Emit(instr.LOCAL_SET, 0).
+				Br(loop).
+				Bind(done).
+				Emit(instr.LOCAL_GET, 0)
+			prog, err := b.Build()
+			require.NoError(t, err)
+
+			i := New(prog, WithThreshold(1))
+			defer i.Close()
+			headers := i.tracer.headers(i, 0)
+			require.NotEmpty(t, headers)
+			root := anchor{ip: headers[0]}
+			fallback := i.code[0][root.ip]
+			native := func(*Interpreter) {}
+			i.exits[root] = fallback
+			i.code[0][root.ip] = native
+
+			i.enableBackedges(0)
+
+			require.Equal(t, reflect.ValueOf(native).Pointer(), reflect.ValueOf(i.code[0][root.ip]).Pointer())
+			require.NotNil(t, i.exits[root])
+			require.True(t, i.backedges[0])
+		})
+	}
+
 	modes := []struct {
 		name string
 		opts []func(*option)
@@ -3889,71 +3965,6 @@ func TestWithHook(t *testing.T) {
 
 	require.NoError(t, i.Run(context.Background()))
 	require.Equal(t, 3, calls)
-}
-
-func counter(tb testing.TB, limit int32) *program.Program {
-	tb.Helper()
-	b := program.NewBuilder()
-	loop := b.Label()
-	done := b.Label()
-	b.Locals(types.TypeI32)
-	b.Emit(instr.I32_CONST, 0).
-		Emit(instr.LOCAL_SET, 0).
-		Bind(loop).
-		Emit(instr.LOCAL_GET, 0).
-		Emit(instr.I32_CONST, uint64(uint32(limit))).
-		Emit(instr.I32_GE_S).
-		BrIf(done).
-		Emit(instr.LOCAL_GET, 0).
-		Emit(instr.I32_CONST, 1).
-		Emit(instr.I32_ADD).
-		Emit(instr.LOCAL_SET, 0).
-		Br(loop).
-		Bind(done).
-		Emit(instr.LOCAL_GET, 0)
-	prog, err := b.Build()
-	require.NoError(tb, err)
-	return prog
-}
-
-func TestInterpreter_BackedgeDefersHeaderScanUntilHot(t *testing.T) {
-	prog := counter(t, 64)
-
-	i := New(prog, WithTick(1<<20), WithThreshold(1<<30))
-	defer i.Close()
-	require.Empty(t, i.tracer.loops)
-
-	require.NoError(t, i.Run(context.Background()))
-	value, err := i.PopBoxed()
-	require.NoError(t, err)
-	require.Equal(t, types.BoxI32(64), value)
-	require.Empty(t, i.tracer.loops)
-	require.Empty(t, i.warmup)
-	require.Empty(t, i.tried)
-}
-
-func TestInterpreter_EnableBackedgesPreservesInstalledHandler(t *testing.T) {
-	if runtime.GOARCH != "arm64" {
-		t.Skip("native JIT is only available on arm64")
-	}
-	prog := counter(t, 2)
-
-	i := New(prog, WithThreshold(1))
-	defer i.Close()
-
-	headers := i.tracer.headers(i, 0)
-	require.NotEmpty(t, headers)
-	root := anchor{ip: headers[0]}
-	fallback := i.code[0][root.ip]
-	native := func(*Interpreter) {}
-	i.exits[root] = fallback
-	i.code[0][root.ip] = native
-
-	i.enableBackedges(0)
-
-	require.Equal(t, reflect.ValueOf(native).Pointer(), reflect.ValueOf(i.code[0][root.ip]).Pointer())
-	require.NotNil(t, i.exits[root])
-	require.True(t, i.backedges[0])
 }
 
 func TestWithMarshaler(t *testing.T) {
@@ -7002,7 +7013,27 @@ func BenchmarkNew(b *testing.B) {
 }
 
 func BenchmarkInterpreter_PreHotBackedge(b *testing.B) {
-	vm := New(counter(b, 256), WithTick(1<<20), WithThreshold(1<<30))
+	builder := program.NewBuilder()
+	loop := builder.Label()
+	done := builder.Label()
+	builder.Locals(types.TypeI32)
+	builder.Emit(instr.I32_CONST, 0).
+		Emit(instr.LOCAL_SET, 0).
+		Bind(loop).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, 256).
+		Emit(instr.I32_GE_S).
+		BrIf(done).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, 1).
+		Emit(instr.I32_ADD).
+		Emit(instr.LOCAL_SET, 0).
+		Br(loop).
+		Bind(done).
+		Emit(instr.LOCAL_GET, 0)
+	prog, err := builder.Build()
+	require.NoError(b, err)
+	vm := New(prog, WithTick(1<<20), WithThreshold(1<<30))
 	b.Cleanup(func() { require.NoError(b, vm.Close()) })
 	ctx := context.Background()
 	b.ReportAllocs()

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -3891,6 +3891,71 @@ func TestWithHook(t *testing.T) {
 	require.Equal(t, 3, calls)
 }
 
+func counter(tb testing.TB, limit int32) *program.Program {
+	tb.Helper()
+	b := program.NewBuilder()
+	loop := b.Label()
+	done := b.Label()
+	b.Locals(types.TypeI32)
+	b.Emit(instr.I32_CONST, 0).
+		Emit(instr.LOCAL_SET, 0).
+		Bind(loop).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, uint64(uint32(limit))).
+		Emit(instr.I32_GE_S).
+		BrIf(done).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, 1).
+		Emit(instr.I32_ADD).
+		Emit(instr.LOCAL_SET, 0).
+		Br(loop).
+		Bind(done).
+		Emit(instr.LOCAL_GET, 0)
+	prog, err := b.Build()
+	require.NoError(tb, err)
+	return prog
+}
+
+func TestInterpreter_BackedgeDefersHeaderScanUntilHot(t *testing.T) {
+	prog := counter(t, 64)
+
+	i := New(prog, WithTick(1<<20), WithThreshold(1<<30))
+	defer i.Close()
+	require.Empty(t, i.tracer.loops)
+
+	require.NoError(t, i.Run(context.Background()))
+	value, err := i.PopBoxed()
+	require.NoError(t, err)
+	require.Equal(t, types.BoxI32(64), value)
+	require.Empty(t, i.tracer.loops)
+	require.Empty(t, i.warmup)
+	require.Empty(t, i.tried)
+}
+
+func TestInterpreter_EnableBackedgesPreservesInstalledHandler(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+	prog := counter(t, 2)
+
+	i := New(prog, WithThreshold(1))
+	defer i.Close()
+
+	headers := i.tracer.headers(i, 0)
+	require.NotEmpty(t, headers)
+	root := anchor{ip: headers[0]}
+	fallback := i.code[0][root.ip]
+	native := func(*Interpreter) {}
+	i.exits[root] = fallback
+	i.code[0][root.ip] = native
+
+	i.enableBackedges(0)
+
+	require.Equal(t, reflect.ValueOf(native).Pointer(), reflect.ValueOf(i.code[0][root.ip]).Pointer())
+	require.NotNil(t, i.exits[root])
+	require.True(t, i.backedges[0])
+}
+
 func TestWithMarshaler(t *testing.T) {
 	i := New(program.New(nil), WithMarshaler(upperMarshaler(0)))
 	defer i.Close()
@@ -6934,6 +6999,20 @@ func BenchmarkNew(b *testing.B) {
 		b.ReportMetric(float64(elapsed.Nanoseconds())/float64(b.N), "ns/op")
 		require.NoError(b, closeErr)
 	})
+}
+
+func BenchmarkInterpreter_PreHotBackedge(b *testing.B) {
+	vm := New(counter(b, 256), WithTick(1<<20), WithThreshold(1<<30))
+	b.Cleanup(func() { require.NoError(b, vm.Close()) })
+	ctx := context.Background()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		require.NoError(b, vm.Run(ctx))
+		_, err := vm.PopBoxed()
+		require.NoError(b, err)
+		vm.Reset()
+	}
 }
 
 func BenchmarkInterpreter_Run(b *testing.B) {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1558,7 +1558,7 @@ func TestInterpreter_Run(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, types.BoxI32(64), value)
 		require.Empty(t, i.tracer.loops)
-		require.Empty(t, i.warmup)
+		require.Empty(t, i.loopHits)
 		require.Empty(t, i.tried)
 	})
 
@@ -7012,7 +7012,7 @@ func BenchmarkNew(b *testing.B) {
 	})
 }
 
-func BenchmarkInterpreter_PreHotBackedge(b *testing.B) {
+func BenchmarkInterpreter_ColdBackedge(b *testing.B) {
 	builder := program.NewBuilder()
 	loop := builder.Label()
 	done := builder.Label()

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -70,10 +70,11 @@ type lowering struct {
 	descriptors []exitDescriptor
 	saved       []value
 
-	addr        int
-	returns     int
-	kind        entryKind
-	leaf        bool
+	addr    int
+	returns int
+	kind    entryKind
+	leaf    bool
+
 	reuseLocals bool
 	spare       asm.VReg
 }

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -70,12 +70,12 @@ type lowering struct {
 	descriptors []exitDescriptor
 	saved       []value
 
-	addr    int
-	returns int
-	kind    entryKind
-	leaf    bool
-	reuse   bool
-	spare   asm.VReg
+	addr        int
+	returns     int
+	kind        entryKind
+	leaf        bool
+	reuseLocals bool
+	spare       asm.VReg
 }
 
 // value is one typed operand: a register plus the runtime kind the trace
@@ -228,16 +228,6 @@ func (c *compiler) Close() error {
 	return c.buffer.Free()
 }
 
-func requestedPlans(plans []plan, root anchor) []plan {
-	selected := plans[:0]
-	for _, planned := range plans {
-		if planned.anchor == root {
-			selected = append(selected, planned)
-		}
-	}
-	return selected
-}
-
 // Compile selects and lowers the first frontend that emits native code.
 func (c *compiler) Compile(i *Interpreter, root anchor) compileResult {
 	input, ok := newCompileInput(i, root.addr)
@@ -254,10 +244,12 @@ func (c *compiler) Compile(i *Interpreter, root anchor) compileResult {
 		if err != nil {
 			return compileResult{anchor: root, frontend: frontend.kind, outcome: prof.CompileOutcomeError, reason: prof.CompileReasonError, err: err}
 		}
-		plans = requestedPlans(plans, root)
 		result = result.prefer(compileResult{anchor: root, frontend: frontend.kind, outcome: prof.CompileOutcomeEmpty, reason: prof.CompileReasonNoPlan})
 		mod := &module{entries: map[anchor]native{}}
 		for _, plan := range plans {
+			if plan.anchor != root {
+				continue
+			}
 			if !plan.valid() {
 				result = result.prefer(compileResult{anchor: root, frontend: frontend.kind, outcome: prof.CompileOutcomeRejected, reason: prof.CompileReasonInvalidPlan})
 				continue

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -73,6 +73,9 @@ type lowering struct {
 	addr    int
 	returns int
 	kind    entryKind
+	leaf    bool
+	reuse   bool
+	spare   asm.VReg
 }
 
 // value is one typed operand: a register plus the runtime kind the trace
@@ -225,6 +228,16 @@ func (c *compiler) Close() error {
 	return c.buffer.Free()
 }
 
+func requestedPlans(plans []plan, root anchor) []plan {
+	selected := plans[:0]
+	for _, planned := range plans {
+		if planned.anchor == root {
+			selected = append(selected, planned)
+		}
+	}
+	return selected
+}
+
 // Compile selects and lowers the first frontend that emits native code.
 func (c *compiler) Compile(i *Interpreter, root anchor) compileResult {
 	input, ok := newCompileInput(i, root.addr)
@@ -241,6 +254,7 @@ func (c *compiler) Compile(i *Interpreter, root anchor) compileResult {
 		if err != nil {
 			return compileResult{anchor: root, frontend: frontend.kind, outcome: prof.CompileOutcomeError, reason: prof.CompileReasonError, err: err}
 		}
+		plans = requestedPlans(plans, root)
 		result = result.prefer(compileResult{anchor: root, frontend: frontend.kind, outcome: prof.CompileOutcomeEmpty, reason: prof.CompileReasonNoPlan})
 		mod := &module{entries: map[anchor]native{}}
 		for _, plan := range plans {

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -1436,10 +1436,7 @@ func (l arm64Lowerer) directCall(ctx *lowering, op step) bool {
 		stack := ctx.pin(scratchStack)
 		base := l.base(ctx, stack)
 		for idx := params; idx < len(localKinds); idx++ {
-			zero, ok := zeroValue(localKinds[idx])
-			if !ok {
-				return false
-			}
+			zero := types.Zero(localKinds[idx])
 			reg := a.Reg(asm.RegTypeInt, asm.Width64)
 			a.Emit(arm64.LDI(reg, uint64(zero))...)
 			a.Emit(arm64.STR(reg, base, int16((ctx.sp()-params+idx)*8)))
@@ -3718,18 +3715,18 @@ func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.
 	return addr, itab, data
 }
 
-func (arm64Lowerer) sliceHeaderTo(ctx *lowering, data, ptr, n asm.VReg, base int16) {
-	ctx.assembler.Emit(
-		arm64.LDR(ptr, data, base+sliceData),
-		arm64.LDR(n, data, base+sliceLen),
-	)
-}
-
 func (l arm64Lowerer) sliceHeader(ctx *lowering, data asm.VReg, base int16) (asm.VReg, asm.VReg) {
 	ptr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	n := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	l.sliceHeaderTo(ctx, data, ptr, n, base)
 	return ptr, n
+}
+
+func (arm64Lowerer) sliceHeaderTo(ctx *lowering, data, ptr, n asm.VReg, base int16) {
+	ctx.assembler.Emit(
+		arm64.LDR(ptr, data, base+sliceData),
+		arm64.LDR(n, data, base+sliceLen),
+	)
 }
 
 // guardIndex uses one unsigned check: sign-extended negative i32 indexes are
@@ -3746,15 +3743,15 @@ func (arm64Lowerer) matchItab(ctx *lowering, got asm.VReg, want uintptr, hit asm
 	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBEQ, hit))
 }
 
+func (l arm64Lowerer) guardItab(ctx *lowering, got asm.VReg, want uintptr, fail asm.Label) {
+	v := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.guardItabTo(ctx, got, v, want, fail)
+}
+
 func (arm64Lowerer) guardItabTo(ctx *lowering, got, scratch asm.VReg, want uintptr, fail asm.Label) {
 	ctx.assembler.Emit(arm64.LDI(scratch, uint64(want))...)
 	ctx.assembler.Emit(arm64.CMP(got, scratch))
 	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
-}
-
-func (l arm64Lowerer) guardItab(ctx *lowering, got asm.VReg, want uintptr, fail asm.Label) {
-	v := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	l.guardItabTo(ctx, got, v, want, fail)
 }
 
 func (arm64Lowerer) matchKind(ctx *lowering, got asm.VReg, want types.Kind, hit asm.Label) {
@@ -3844,6 +3841,8 @@ func (l arm64Lowerer) retainBox(ctx *lowering, v asm.VReg) {
 	})
 }
 
+// retainKnownBox retains a boxed value already proven to be a ref, avoiding a
+// tag guard and reusing the pinned spare register on leaf plans.
 func (l arm64Lowerer) retainKnownBox(ctx *lowering, v asm.VReg) {
 	a := ctx.assembler
 	addr := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -3926,6 +3925,8 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 	return true
 }
 
+// localScratch returns a flushed local register that is no longer live in the
+// operand stack, or an undefined register when none can be reused safely.
 func (arm64Lowerer) localScratch(ctx *lowering) asm.VReg {
 	for fi := range ctx.frames {
 		frame := &ctx.frames[fi]
@@ -3949,6 +3950,8 @@ func (arm64Lowerer) localScratch(ctx *lowering) asm.VReg {
 	return asm.VReg{}
 }
 
+// localReg reuses target's pre-barrier register only when no live operand or
+// reloaded local aliases it.
 func (l arm64Lowerer) localReg(ctx *lowering, target *activation, idx int) (asm.VReg, bool) {
 	reg := target.locals[idx].reg
 	if !ctx.reuseLocals || reg.Width() == asm.WidthUndefined {
@@ -3973,12 +3976,6 @@ func (l arm64Lowerer) localReg(ctx *lowering, target *activation, idx int) (asm.
 	return reg, true
 }
 
-func (l arm64Lowerer) baseTo(ctx *lowering, vStack, addr asm.VReg) {
-	vBP := ctx.pin(scratchBP)
-	ctx.assembler.Emit(arm64.LSLI(addr, vBP, 3))
-	ctx.assembler.Emit(arm64.ADD(addr, vStack, addr))
-}
-
 func (l arm64Lowerer) base(ctx *lowering, vStack asm.VReg) asm.VReg {
 	if ctx.leaf {
 		addr := ctx.pin(scratchSP)
@@ -3988,6 +3985,12 @@ func (l arm64Lowerer) base(ctx *lowering, vStack asm.VReg) asm.VReg {
 	addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	l.baseTo(ctx, vStack, addr)
 	return addr
+}
+
+func (l arm64Lowerer) baseTo(ctx *lowering, vStack, addr asm.VReg) {
+	vBP := ctx.pin(scratchBP)
+	ctx.assembler.Emit(arm64.LSLI(addr, vBP, 3))
+	ctx.assembler.Emit(arm64.ADD(addr, vStack, addr))
 }
 
 func (l arm64Lowerer) boxHome(ctx *lowering, v value) (asm.VReg, bool) {
@@ -4088,17 +4091,17 @@ func (l arm64Lowerer) retain(ctx *lowering, fn int) {
 }
 
 // guardRC keeps releases that could free objects in the interpreter.
+func (l arm64Lowerer) guardRC(ctx *lowering, addr, rcBase asm.VReg, fail asm.Label) asm.VReg {
+	rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.guardRCTo(ctx, rc, addr, rcBase, fail)
+	return rc
+}
+
 func (arm64Lowerer) guardRCTo(ctx *lowering, rc, addr, rcBase asm.VReg, fail asm.Label) {
 	a := ctx.assembler
 	a.Emit(arm64.LDRR(rc, rcBase, addr))
 	a.Emit(arm64.CMPI(rc, 1))
 	a.Emit(arm64.BCondLabel(arm64.OpBLE, fail))
-}
-
-func (l arm64Lowerer) guardRC(ctx *lowering, addr, rcBase asm.VReg, fail asm.Label) asm.VReg {
-	rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	l.guardRCTo(ctx, rc, addr, rcBase, fail)
-	return rc
 }
 
 func (l arm64Lowerer) refOnly(ctx *lowering, v asm.VReg, body func(asm.VReg)) {
@@ -4118,63 +4121,27 @@ func (l arm64Lowerer) refOnly(ctx *lowering, v asm.VReg, body func(asm.VReg)) {
 	ctx.assembler.Bind(done)
 }
 
-func (arm64Lowerer) rcBaseTo(ctx *lowering, base asm.VReg) {
-	ctx.assembler.Emit(arm64.LDR(base, ctx.pin(scratchCtrl), int16(journalRC*8)))
-}
-
 func (l arm64Lowerer) rcBase(ctx *lowering) asm.VReg {
 	base := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	l.rcBaseTo(ctx, base)
 	return base
 }
 
-func join(steps, tail []int) []int {
-	if len(steps) == 0 {
-		return tail
-	}
-	if len(tail) == 0 {
-		return steps
-	}
-	return append(append([]int(nil), steps...), tail...)
-}
-
-func zeroValue(kind types.Kind) (types.Boxed, bool) {
-	switch kind {
-	case types.KindI1:
-		return types.BoxI1(false), true
-	case types.KindI8:
-		return types.BoxI8(0), true
-	case types.KindI32:
-		return types.BoxI32(0), true
-	case types.KindI64:
-		return types.BoxI64(0), true
-	case types.KindF32:
-		return types.BoxF32(0), true
-	case types.KindF64:
-		return types.BoxF64(0), true
-	case types.KindRef:
-		return types.BoxedNull, true
-	default:
-		return 0, false
-	}
-}
-
-func isLeaf(blocks []block) bool {
-	for _, block := range blocks {
-		for _, step := range block.steps {
-			switch step.op {
-			case instr.CALL, instr.RETURN_CALL:
-				return false
-			}
-		}
-	}
-	return true
+func (arm64Lowerer) rcBaseTo(ctx *lowering, base asm.VReg) {
+	ctx.assembler.Emit(arm64.LDR(base, ctx.pin(scratchCtrl), int16(journalRC*8)))
 }
 
 // lower emits one plan through the common block pipeline.
 func lower(ctx *lowering, plan plan) bool {
 	l := arm64Lowerer{}
-	ctx.leaf = isLeaf(plan.blocks)
+	ctx.leaf = true
+	for _, block := range plan.blocks {
+		for _, step := range block.steps {
+			if step.op == instr.CALL || step.op == instr.RETURN_CALL {
+				ctx.leaf = false
+			}
+		}
+	}
 	l.enter(ctx)
 	ctx.blocks = plan.blocks
 	ctx.kind = plan.kind
@@ -4215,4 +4182,14 @@ func lower(ctx *lowering, plan plan) bool {
 	}
 	l.materializeExits(ctx)
 	return true
+}
+
+func join(steps, tail []int) []int {
+	if len(steps) == 0 {
+		return tail
+	}
+	if len(tail) == 0 {
+		return steps
+	}
+	return append(append([]int(nil), steps...), tail...)
 }

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -37,6 +37,7 @@ const (
 )
 
 const branchTableLimit = 32
+const nativeBackend = true
 
 // Boxing tags used by scalar lowering, derived from the Kind
 // tag layout so they track any reordering of the Kind enum. i1/i8 share the i32
@@ -98,6 +99,8 @@ func (l arm64Lowerer) enter(ctx *lowering) {
 
 func (l arm64Lowerer) materializeExits(ctx *lowering) {
 	for _, exit := range ctx.exits {
+		ctx.reuse = false
+		ctx.spare = asm.VReg{}
 		ctx.values = exit.values
 		ctx.frames = exit.frames
 		ctx.assembler.Bind(exit.label)
@@ -580,10 +583,14 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 		case instr.ARRAY_LEN:
 			ok = l.arrayLen(ctx, op)
 		case instr.ARRAY_SET:
+			terminal := op.terminal || ctx.count() > 0 && ctx.values[len(ctx.values)-1].kind == types.KindRef
 			if !l.arraySet(ctx, op) {
 				return false, false
 			}
-			return true, idx == len(ops)-1
+			if terminal {
+				return true, idx == len(ops)-1
+			}
+			ok = true
 		case instr.STRUCT_GET:
 			if !l.structGet(ctx, op) {
 				return false, false
@@ -873,7 +880,11 @@ func (l arm64Lowerer) localGet(ctx *lowering, op step) bool {
 		return false
 	}
 	if f.locals[idx].kind == types.KindRef {
-		l.retainBox(ctx, f.locals[idx].reg)
+		if ctx.leaf {
+			l.retainKnownBox(ctx, f.locals[idx].reg)
+		} else {
+			l.retainBox(ctx, f.locals[idx].reg)
+		}
 	}
 	ctx.push(f.locals[idx])
 	return true
@@ -1237,6 +1248,8 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 }
 
 func (l arm64Lowerer) enterBlock(ctx *lowering, state []slot) {
+	ctx.reuse = false
+	ctx.spare = asm.VReg{}
 	ctx.values = ctx.values[:0]
 	for _, slot := range state {
 		ctx.values = append(ctx.values, value{kind: slot.kind, ref: slot.ref, raw: slot.refKnown})
@@ -2730,9 +2743,15 @@ func (l arm64Lowerer) loadLocal(ctx *lowering, f *activation, idx, ip int) bool 
 		return false
 	}
 	vStack := ctx.pin(scratchStack)
-	addr := l.base(ctx, vStack)
-	reg := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	ctx.assembler.Emit(arm64.LDR(reg, addr, int16((f.base+idx)*8)))
+	reg, reusable := l.localReg(ctx, f, idx)
+	if reusable {
+		l.baseTo(ctx, vStack, reg)
+		ctx.assembler.Emit(arm64.LDR(reg, reg, int16((f.base+idx)*8)))
+	} else {
+		addr := l.base(ctx, vStack)
+		reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+		ctx.assembler.Emit(arm64.LDR(reg, addr, int16((f.base+idx)*8)))
+	}
 	if kind == types.KindI64 {
 		// A heap-promoted i64 is a ref the trace cannot read as a value; guard
 		// the inline tag and deopt at the load if it promoted, then sign-extend
@@ -3110,26 +3129,83 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		return false
 	}
 	a := ctx.assembler
-	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
-	if !ok {
-		return false
+	var fail, bounds, valueFail asm.Label
+	switch {
+	case kind == types.KindRef || op.terminal:
+		fail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
+		if !ok {
+			return false
+		}
+		bounds, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
+		if !ok {
+			return false
+		}
+		valueFail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
+		if !ok {
+			return false
+		}
+	default:
+		// A continuable primitive store is a state barrier: materialize the
+		// pre-op frame once, then let all guards share that resumable snapshot.
+		// Clearing the local register cache bounds no-spill pressure and makes
+		// subsequent operations reload from the homes just written.
+		if !l.flush(ctx, false) {
+			return false
+		}
+		for idx := range ctx.frames {
+			clear(ctx.frames[idx].loaded)
+			clear(ctx.frames[idx].dirty)
+		}
+		ctx.reuse = len(ctx.values) == 3
+		fail = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardShape, int(op.op))
+		bounds = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardBounds, int(op.op))
+		valueFail = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardValue, int(op.op))
 	}
-	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
-	if !ok {
-		return false
+	var addr, itab, data, scratch asm.VReg
+	remat := false
+	if kind != types.KindRef && !op.terminal {
+		work := l.localScratch(ctx)
+		if work.Width() == asm.WidthUndefined && val.known && val.kind.Repr() == types.KindI32 {
+			work = val.reg
+			remat = true
+		}
+		cell := asm.VReg{}
+		if ctx.leaf {
+			cell = ctx.pin(scratchSP)
+		}
+		addr, itab, data, scratch = l.heapRef(ctx, ref, work, cell)
+	} else {
+		addr, itab, data = l.guardHeap(ctx, ref, fail)
 	}
-	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
-	if !ok {
-		return false
+	if kind != types.KindRef && !op.terminal {
+		l.guardItabTo(ctx, itab, scratch, want, fail)
+	} else {
+		l.guardItab(ctx, itab, want, fail)
 	}
-	addr, itab, data := l.guardHeap(ctx, ref, fail)
-	l.guardItab(ctx, itab, want, fail)
 
-	dataPtr, n := l.sliceHeader(ctx, data, base)
+	var dataPtr, n asm.VReg
+	if kind != types.KindRef && !op.terminal {
+		dataPtr = itab
+		n = data
+		l.sliceHeaderTo(ctx, data, dataPtr, n, base)
+	} else {
+		dataPtr, n = l.sliceHeader(ctx, data, base)
+	}
 	l.guardIndex(ctx, idx, n, bounds)
 
-	rcBase := l.rcBase(ctx)
-	rc := l.guardRC(ctx, addr, rcBase, valueFail)
+	var rcBase, rc, rcAddr asm.VReg
+	if kind != types.KindRef && !op.terminal {
+		rcBase = scratch
+		l.rcBaseTo(ctx, rcBase)
+		ctx.assembler.Emit(arm64.MOV(n, addr))
+		rcAddr = addr
+		rc = n
+		l.guardRCTo(ctx, rc, rcAddr, rcBase, valueFail)
+	} else {
+		rcBase = l.rcBase(ctx)
+		rcAddr = addr
+		rc = l.guardRC(ctx, rcAddr, rcBase, valueFail)
+	}
 
 	if kind == types.KindRef {
 		// The container's refcount deopt point (guardRC above) runs before the
@@ -3140,30 +3216,53 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
 		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
+		a.Emit(arm64.SUBI(rc, rc, 1))
+		a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+		a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 	} else {
+		// All primitive-store guards have passed, so release the consumed array
+		// operand before address formation. This shortens addr/rc liveness and
+		// keeps mutation loops within the no-spill register budget.
+		a.Emit(arm64.SUBI(rc, rc, 1))
+		a.Emit(arm64.STRR(rc, rcBase, rcAddr))
 		switch kind {
 		case types.KindI1, types.KindI8:
-			elemAddr := a.Reg(asm.RegTypeInt, asm.Width64)
-			a.Emit(arm64.ADD(elemAddr, dataPtr, idx))
-			a.Emit(arm64.STRB(val.reg, elemAddr, 0))
+			target := n
+			if remat {
+				target = scratch
+			}
+			a.Emit(arm64.ADD(target, dataPtr, idx))
+			if remat {
+				a.Emit(arm64.LDI(val.reg, uint64(val.imm))...)
+			}
+			a.Emit(arm64.STRB(val.reg, target, 0))
 		case types.KindI32, types.KindF32:
-			elemAddr := a.Reg(asm.RegTypeInt, asm.Width64)
-			off := a.Reg(asm.RegTypeInt, asm.Width64)
-			a.Emit(arm64.LSLI(off, idx, scale))
-			a.Emit(arm64.ADD(elemAddr, dataPtr, off))
-			a.Emit(arm64.STRW(val.reg, elemAddr, 0))
+			target := n
+			if remat {
+				target = scratch
+			}
+			a.Emit(arm64.LSLI(target, idx, scale))
+			a.Emit(arm64.ADD(target, dataPtr, target))
+			if remat {
+				a.Emit(arm64.LDI(val.reg, uint64(val.imm))...)
+			}
+			a.Emit(arm64.STRW(val.reg, target, 0))
 		case types.KindI64, types.KindF64:
+			if remat {
+				a.Emit(arm64.LDI(val.reg, uint64(val.imm))...)
+			}
 			a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 		}
-	}
-	a.Emit(arm64.SUBI(rc, rc, 1))
-	a.Emit(arm64.STRR(rc, rcBase, addr))
-	if kind == types.KindRef {
-		a.Emit(arm64.STRR(val.reg, dataPtr, idx))
+		if !op.terminal && remat {
+			ctx.spare = rc
+		}
 	}
 
-	ctx.values = pre[: len(pre)-3 : len(pre)-3]
-	return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
+	ctx.values = ctx.values[: len(ctx.values)-3 : len(ctx.values)-3]
+	if kind == types.KindRef || op.terminal {
+		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
+	}
+	return true
 }
 
 func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
@@ -3565,6 +3664,31 @@ func (l arm64Lowerer) trapFlushed(ctx *lowering, kind, resume, exitID int) {
 	)
 }
 
+// heapRef loads a heap cell for a value already proven to have ref kind by the
+// symbolic stack. The object itab guard still rejects null or a different heap
+// shape before the payload is used.
+func (arm64Lowerer) heapRef(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, asm.VReg, asm.VReg, asm.VReg) {
+	a := ctx.assembler
+	addr := a.Reg(asm.RegTypeInt, asm.Width64)
+	a.Emit(arm64.ANDI(addr, ref, maskI32))
+	if cell.Width() == asm.WidthUndefined {
+		cell = a.Reg(asm.RegTypeInt, asm.Width64)
+	}
+	a.Emit(arm64.LDR(cell, ctx.pin(scratchCtrl), int16(journalHeap*8)))
+	if off.Width() == asm.WidthUndefined {
+		off = a.Reg(asm.RegTypeInt, asm.Width64)
+	}
+	a.Emit(arm64.LSLI(off, addr, 4))
+	a.Emit(arm64.ADD(cell, cell, off))
+	itab := ref
+	data := off
+	a.Emit(
+		arm64.LDR(itab, cell, 0),
+		arm64.LDR(data, cell, 8),
+	)
+	return addr, itab, data, cell
+}
+
 // guardHeap loads a heap cell or branches to fail on a non-ref tag.
 func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
@@ -3592,13 +3716,17 @@ func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.
 	return addr, itab, data
 }
 
-func (arm64Lowerer) sliceHeader(ctx *lowering, data asm.VReg, base int16) (asm.VReg, asm.VReg) {
-	ptr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	n := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+func (arm64Lowerer) sliceHeaderTo(ctx *lowering, data, ptr, n asm.VReg, base int16) {
 	ctx.assembler.Emit(
 		arm64.LDR(ptr, data, base+sliceData),
 		arm64.LDR(n, data, base+sliceLen),
 	)
+}
+
+func (l arm64Lowerer) sliceHeader(ctx *lowering, data asm.VReg, base int16) (asm.VReg, asm.VReg) {
+	ptr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	n := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.sliceHeaderTo(ctx, data, ptr, n, base)
 	return ptr, n
 }
 
@@ -3616,11 +3744,15 @@ func (arm64Lowerer) matchItab(ctx *lowering, got asm.VReg, want uintptr, hit asm
 	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBEQ, hit))
 }
 
-func (arm64Lowerer) guardItab(ctx *lowering, got asm.VReg, want uintptr, fail asm.Label) {
-	v := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	ctx.assembler.Emit(arm64.LDI(v, uint64(want))...)
-	ctx.assembler.Emit(arm64.CMP(got, v))
+func (arm64Lowerer) guardItabTo(ctx *lowering, got, scratch asm.VReg, want uintptr, fail asm.Label) {
+	ctx.assembler.Emit(arm64.LDI(scratch, uint64(want))...)
+	ctx.assembler.Emit(arm64.CMP(got, scratch))
 	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
+}
+
+func (l arm64Lowerer) guardItab(ctx *lowering, got asm.VReg, want uintptr, fail asm.Label) {
+	v := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.guardItabTo(ctx, got, v, want, fail)
 }
 
 func (arm64Lowerer) matchKind(ctx *lowering, got asm.VReg, want types.Kind, hit asm.Label) {
@@ -3710,6 +3842,18 @@ func (l arm64Lowerer) retainBox(ctx *lowering, v asm.VReg) {
 	})
 }
 
+func (l arm64Lowerer) retainKnownBox(ctx *lowering, v asm.VReg) {
+	a := ctx.assembler
+	addr := a.Reg(asm.RegTypeInt, asm.Width64)
+	a.Emit(arm64.ANDI(addr, v, maskI32))
+	base := ctx.pin(scratchSP)
+	l.rcBaseTo(ctx, base)
+	rc := a.Reg(asm.RegTypeInt, asm.Width64)
+	a.Emit(arm64.LDRR(rc, base, addr))
+	a.Emit(arm64.ADDI(rc, rc, 1))
+	a.Emit(arm64.STRR(rc, base, addr))
+}
+
 func (l arm64Lowerer) retainRef(ctx *lowering, addr asm.VReg) {
 	base := l.rcBase(ctx)
 	rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
@@ -3757,7 +3901,7 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 			if !f.dirty[idx] {
 				continue
 			}
-			boxed, ok := l.box(ctx, f.locals[idx])
+			boxed, ok := l.boxHome(ctx, f.locals[idx])
 			if !ok {
 				return false
 			}
@@ -3771,7 +3915,7 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 		if v.kind == types.KindRef && commit {
 			return false
 		}
-		boxed, ok := l.box(ctx, v)
+		boxed, ok := l.boxHome(ctx, v)
 		if !ok {
 			return false
 		}
@@ -3780,15 +3924,88 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 	return true
 }
 
-// base returns &stack[bp] for slot-relative loads and stores.
-func (l arm64Lowerer) base(ctx *lowering, vStack asm.VReg) asm.VReg {
-	a := ctx.assembler
+func (arm64Lowerer) localScratch(ctx *lowering) asm.VReg {
+	for fi := range ctx.frames {
+		frame := &ctx.frames[fi]
+		for _, local := range frame.locals {
+			reg := local.reg
+			if reg.Width() == asm.WidthUndefined {
+				continue
+			}
+			used := false
+			for _, value := range ctx.values {
+				if value.reg.Width() != asm.WidthUndefined && value.reg.ID() == reg.ID() {
+					used = true
+					break
+				}
+			}
+			if !used {
+				return reg
+			}
+		}
+	}
+	return asm.VReg{}
+}
+
+func (l arm64Lowerer) localReg(ctx *lowering, target *activation, idx int) (asm.VReg, bool) {
+	reg := target.locals[idx].reg
+	if !ctx.reuse || reg.Width() == asm.WidthUndefined {
+		return asm.VReg{}, false
+	}
+	for _, value := range ctx.values {
+		if value.reg.Width() != asm.WidthUndefined && value.reg.ID() == reg.ID() {
+			return asm.VReg{}, false
+		}
+	}
+	for fi := range ctx.frames {
+		frame := &ctx.frames[fi]
+		for li, value := range frame.locals {
+			if frame == target && li == idx || !frame.loaded[li] {
+				continue
+			}
+			if value.reg.Width() != asm.WidthUndefined && value.reg.ID() == reg.ID() {
+				return asm.VReg{}, false
+			}
+		}
+	}
+	return reg, true
+}
+
+func (l arm64Lowerer) baseTo(ctx *lowering, vStack, addr asm.VReg) {
 	vBP := ctx.pin(scratchBP)
-	off := a.Reg(asm.RegTypeInt, asm.Width64)
-	a.Emit(arm64.LSLI(off, vBP, 3))
-	addr := a.Reg(asm.RegTypeInt, asm.Width64)
-	a.Emit(arm64.ADD(addr, vStack, off))
+	ctx.assembler.Emit(arm64.LSLI(addr, vBP, 3))
+	ctx.assembler.Emit(arm64.ADD(addr, vStack, addr))
+}
+
+func (l arm64Lowerer) base(ctx *lowering, vStack asm.VReg) asm.VReg {
+	if ctx.leaf {
+		addr := ctx.pin(scratchSP)
+		l.baseTo(ctx, vStack, addr)
+		return addr
+	}
+	addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.baseTo(ctx, vStack, addr)
 	return addr
+}
+
+func (l arm64Lowerer) boxHome(ctx *lowering, v value) (asm.VReg, bool) {
+	if ctx.spare.Width() != asm.WidthUndefined && ctx.spare.ID() != v.reg.ID() && v.raw {
+		var tag uint64
+		switch v.kind {
+		case types.KindI1:
+			tag = tagI1
+		case types.KindI8:
+			tag = tagI8
+		case types.KindI32:
+			tag = tagI32
+		default:
+			return l.box(ctx, v)
+		}
+		ctx.assembler.Emit(arm64.ANDI(ctx.spare, v.reg, maskI32))
+		ctx.assembler.Emit(arm64.MOVK(ctx.spare, uint16(tag>>48), 48))
+		return ctx.spare, true
+	}
+	return l.box(ctx, v)
 }
 
 // box produces the boxed form of v in a fresh register. A marker materializes
@@ -3869,12 +4086,16 @@ func (l arm64Lowerer) retain(ctx *lowering, fn int) {
 }
 
 // guardRC keeps releases that could free objects in the interpreter.
-func (arm64Lowerer) guardRC(ctx *lowering, addr, rcBase asm.VReg, fail asm.Label) asm.VReg {
+func (arm64Lowerer) guardRCTo(ctx *lowering, rc, addr, rcBase asm.VReg, fail asm.Label) {
 	a := ctx.assembler
-	rc := a.Reg(asm.RegTypeInt, asm.Width64)
 	a.Emit(arm64.LDRR(rc, rcBase, addr))
 	a.Emit(arm64.CMPI(rc, 1))
 	a.Emit(arm64.BCondLabel(arm64.OpBLE, fail))
+}
+
+func (l arm64Lowerer) guardRC(ctx *lowering, addr, rcBase asm.VReg, fail asm.Label) asm.VReg {
+	rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.guardRCTo(ctx, rc, addr, rcBase, fail)
 	return rc
 }
 
@@ -3895,9 +4116,13 @@ func (l arm64Lowerer) refOnly(ctx *lowering, v asm.VReg, body func(asm.VReg)) {
 	ctx.assembler.Bind(done)
 }
 
-func (arm64Lowerer) rcBase(ctx *lowering) asm.VReg {
-	base := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+func (arm64Lowerer) rcBaseTo(ctx *lowering, base asm.VReg) {
 	ctx.assembler.Emit(arm64.LDR(base, ctx.pin(scratchCtrl), int16(journalRC*8)))
+}
+
+func (l arm64Lowerer) rcBase(ctx *lowering) asm.VReg {
+	base := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	l.rcBaseTo(ctx, base)
 	return base
 }
 
@@ -3932,9 +4157,22 @@ func zeroValue(kind types.Kind) (types.Boxed, bool) {
 	}
 }
 
+func isLeaf(blocks []block) bool {
+	for _, block := range blocks {
+		for _, step := range block.steps {
+			switch step.op {
+			case instr.CALL, instr.RETURN_CALL:
+				return false
+			}
+		}
+	}
+	return true
+}
+
 // lower emits one plan through the common block pipeline.
 func lower(ctx *lowering, plan plan) bool {
 	l := arm64Lowerer{}
+	ctx.leaf = isLeaf(plan.blocks)
 	l.enter(ctx)
 	ctx.blocks = plan.blocks
 	ctx.kind = plan.kind
@@ -3963,6 +4201,8 @@ func lower(ctx *lowering, plan plan) bool {
 	}
 	for n := 0; n < len(ctx.work); n++ {
 		work := ctx.work[n]
+		ctx.reuse = false
+		ctx.spare = asm.VReg{}
 		ctx.values = work.values
 		ctx.frames = work.frames
 		ctx.assembler.Bind(work.label)

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -99,7 +99,7 @@ func (l arm64Lowerer) enter(ctx *lowering) {
 
 func (l arm64Lowerer) materializeExits(ctx *lowering) {
 	for _, exit := range ctx.exits {
-		ctx.reuse = false
+		ctx.reuseLocals = false
 		ctx.spare = asm.VReg{}
 		ctx.values = exit.values
 		ctx.frames = exit.frames
@@ -1248,7 +1248,7 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 }
 
 func (l arm64Lowerer) enterBlock(ctx *lowering, state []slot) {
-	ctx.reuse = false
+	ctx.reuseLocals = false
 	ctx.spare = asm.VReg{}
 	ctx.values = ctx.values[:0]
 	for _, slot := range state {
@@ -3129,9 +3129,9 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		return false
 	}
 	a := ctx.assembler
+	continuable := kind != types.KindRef && !op.terminal
 	var fail, bounds, valueFail asm.Label
-	switch {
-	case kind == types.KindRef || op.terminal:
+	if !continuable {
 		fail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
 		if !ok {
 			return false
@@ -3144,7 +3144,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		if !ok {
 			return false
 		}
-	default:
+	} else {
 		// A continuable primitive store is a state barrier: materialize the
 		// pre-op frame once, then let all guards share that resumable snapshot.
 		// Clearing the local register cache bounds no-spill pressure and makes
@@ -3156,14 +3156,14 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 			clear(ctx.frames[idx].loaded)
 			clear(ctx.frames[idx].dirty)
 		}
-		ctx.reuse = len(ctx.values) == 3
+		ctx.reuseLocals = len(ctx.values) == 3
 		fail = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardShape, int(op.op))
 		bounds = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardBounds, int(op.op))
 		valueFail = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardValue, int(op.op))
 	}
 	var addr, itab, data, scratch asm.VReg
 	remat := false
-	if kind != types.KindRef && !op.terminal {
+	if continuable {
 		work := l.localScratch(ctx)
 		if work.Width() == asm.WidthUndefined && val.known && val.kind.Repr() == types.KindI32 {
 			work = val.reg
@@ -3177,14 +3177,14 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	} else {
 		addr, itab, data = l.guardHeap(ctx, ref, fail)
 	}
-	if kind != types.KindRef && !op.terminal {
+	if continuable {
 		l.guardItabTo(ctx, itab, scratch, want, fail)
 	} else {
 		l.guardItab(ctx, itab, want, fail)
 	}
 
 	var dataPtr, n asm.VReg
-	if kind != types.KindRef && !op.terminal {
+	if continuable {
 		dataPtr = itab
 		n = data
 		l.sliceHeaderTo(ctx, data, dataPtr, n, base)
@@ -3194,7 +3194,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	l.guardIndex(ctx, idx, n, bounds)
 
 	var rcBase, rc, rcAddr asm.VReg
-	if kind != types.KindRef && !op.terminal {
+	if continuable {
 		rcBase = scratch
 		l.rcBaseTo(ctx, rcBase)
 		ctx.assembler.Emit(arm64.MOV(n, addr))
@@ -3253,13 +3253,13 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 			}
 			a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 		}
-		if !op.terminal && remat {
+		if continuable && remat {
 			ctx.spare = rc
 		}
 	}
 
 	ctx.values = ctx.values[: len(ctx.values)-3 : len(ctx.values)-3]
-	if kind == types.KindRef || op.terminal {
+	if !continuable {
 		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
 	}
 	return true
@@ -3665,8 +3665,8 @@ func (l arm64Lowerer) trapFlushed(ctx *lowering, kind, resume, exitID int) {
 }
 
 // heapRef loads a heap cell for a value already proven to have ref kind by the
-// symbolic stack. The object itab guard still rejects null or a different heap
-// shape before the payload is used.
+// symbolic stack. It reuses ref and off as outputs, so callers use it only after
+// a state barrier whose exits reload boxed operands from their stack homes.
 func (arm64Lowerer) heapRef(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
 	addr := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -3689,7 +3689,9 @@ func (arm64Lowerer) heapRef(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, a
 	return addr, itab, data, cell
 }
 
-// guardHeap loads a heap cell or branches to fail on a non-ref tag.
+// guardHeap loads a heap cell or branches to fail on a non-ref tag. Unlike
+// heapRef, it preserves ref because queued side exits may still need the boxed
+// operand.
 func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
 	tag := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -3949,7 +3951,7 @@ func (arm64Lowerer) localScratch(ctx *lowering) asm.VReg {
 
 func (l arm64Lowerer) localReg(ctx *lowering, target *activation, idx int) (asm.VReg, bool) {
 	reg := target.locals[idx].reg
-	if !ctx.reuse || reg.Width() == asm.WidthUndefined {
+	if !ctx.reuseLocals || reg.Width() == asm.WidthUndefined {
 		return asm.VReg{}, false
 	}
 	for _, value := range ctx.values {
@@ -4201,7 +4203,7 @@ func lower(ctx *lowering, plan plan) bool {
 	}
 	for n := 0; n < len(ctx.work); n++ {
 		work := ctx.work[n]
-		ctx.reuse = false
+		ctx.reuseLocals = false
 		ctx.spare = asm.VReg{}
 		ctx.values = work.values
 		ctx.frames = work.frames

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -193,7 +193,7 @@ func (l arm64Lowerer) conditional(ctx *lowering, block block, tail []int) bool {
 			return false
 		}
 		target := block.term.edges[cold]
-		label, ok := l.label(ctx, target, join(target.tail, tail), int(instr.BR_IF))
+		label, ok := l.label(ctx, target, appendTail(target.tail, tail), int(instr.BR_IF))
 		if !ok {
 			return false
 		}
@@ -218,7 +218,7 @@ func (l arm64Lowerer) conditional(ctx *lowering, block block, tail []int) bool {
 }
 
 func (l arm64Lowerer) next(ctx *lowering, from anchor, target edge, tail []int, opcode int) bool {
-	tail = join(target.tail, tail)
+	tail = appendTail(target.tail, tail)
 	target.tail = nil
 	if target.anchor.addr == from.addr && target.anchor.ip <= from.ip {
 		if !l.flush(ctx, false) {
@@ -1308,7 +1308,7 @@ func (l arm64Lowerer) follow(ctx *lowering, tail []int) bool {
 }
 
 func (l arm64Lowerer) path(ctx *lowering, from anchor, target edge, tail []int, opcode int) bool {
-	tail = join(target.tail, tail)
+	tail = appendTail(target.tail, tail)
 	target.tail = nil
 	label, ok := l.label(ctx, target, tail, opcode)
 	if !ok {
@@ -3170,7 +3170,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		if ctx.leaf {
 			cell = ctx.pin(scratchSP)
 		}
-		addr, itab, data, scratch = l.heapRef(ctx, ref, work, cell)
+		addr, itab, data, scratch = l.loadHeap(ctx, ref, work, cell)
 	} else {
 		addr, itab, data = l.guardHeap(ctx, ref, fail)
 	}
@@ -3661,10 +3661,10 @@ func (l arm64Lowerer) trapFlushed(ctx *lowering, kind, resume, exitID int) {
 	)
 }
 
-// heapRef loads a heap cell for a value already proven to have ref kind by the
+// loadHeap loads a heap cell for a value already proven to have ref kind by the
 // symbolic stack. It reuses ref and off as outputs, so callers use it only after
 // a state barrier whose exits reload boxed operands from their stack homes.
-func (arm64Lowerer) heapRef(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, asm.VReg, asm.VReg, asm.VReg) {
+func (arm64Lowerer) loadHeap(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
 	addr := a.Reg(asm.RegTypeInt, asm.Width64)
 	a.Emit(arm64.ANDI(addr, ref, maskI32))
@@ -3687,7 +3687,7 @@ func (arm64Lowerer) heapRef(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, a
 }
 
 // guardHeap loads a heap cell or branches to fail on a non-ref tag. Unlike
-// heapRef, it preserves ref because queued side exits may still need the boxed
+// loadHeap, it preserves ref because queued side exits may still need the boxed
 // operand.
 func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
@@ -4184,7 +4184,7 @@ func lower(ctx *lowering, plan plan) bool {
 	return true
 }
 
-func join(steps, tail []int) []int {
+func appendTail(steps, tail []int) []int {
 	if len(steps) == 0 {
 		return tail
 	}

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -135,26 +135,7 @@ func TestARM64_Backedge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := program.NewBuilder()
-			loop := b.Label()
-			done := b.Label()
-			b.Locals(types.TypeI32)
-			b.Emit(instr.I32_CONST, 0).
-				Emit(instr.LOCAL_SET, 0).
-				Bind(loop).
-				Emit(instr.LOCAL_GET, 0).
-				Emit(instr.I32_CONST, uint64(uint32(tt.limit))).
-				Emit(instr.I32_GE_S).
-				BrIf(done).
-				Emit(instr.LOCAL_GET, 0).
-				Emit(instr.I32_CONST, 1).
-				Emit(instr.I32_ADD).
-				Emit(instr.LOCAL_SET, 0).
-				Br(loop).
-				Bind(done).
-				Emit(instr.LOCAL_GET, 0)
-			prog, err := b.Build()
-			require.NoError(t, err)
+			prog := counter(t, tt.limit)
 
 			i := New(prog, WithTick(1<<20), WithThreshold(tt.threshold))
 			defer i.Close()

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -117,6 +117,92 @@ func TestARM64_ArraySetAfterNestedCalls(t *testing.T) {
 	require.Equal(t, jitOut, out)
 }
 
+func arm64CountingLoop(t *testing.T, limit int32) *program.Program {
+	t.Helper()
+	b := program.NewBuilder()
+	loop := b.Label()
+	done := b.Label()
+	b.Locals(types.TypeI32)
+	b.Emit(instr.I32_CONST, 0).
+		Emit(instr.LOCAL_SET, 0).
+		Bind(loop).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, uint64(uint32(limit))).
+		Emit(instr.I32_GE_S).
+		BrIf(done).
+		Emit(instr.LOCAL_GET, 0).
+		Emit(instr.I32_CONST, 1).
+		Emit(instr.I32_ADD).
+		Emit(instr.LOCAL_SET, 0).
+		Br(loop).
+		Bind(done).
+		Emit(instr.LOCAL_GET, 0)
+	prog, err := b.Build()
+	require.NoError(t, err)
+	return prog
+}
+
+func TestARM64_BackedgeCompilesModuleLoop(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+
+	i := New(arm64CountingLoop(t, 64), WithTick(1<<20), WithThreshold(0))
+	defer i.Close()
+	require.NoError(t, i.Run(context.Background()))
+	value, err := i.PopBoxed()
+	require.NoError(t, err)
+	require.Equal(t, types.BoxI32(64), value)
+
+	headers := i.tracer.headers(i, 0)
+	require.NotEmpty(t, headers)
+	require.True(t, i.tried[anchor{ip: headers[0]}])
+	require.NotEmpty(t, i.exits)
+}
+
+func TestARM64_BackedgeWarmsEagerLoop(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+
+	i := New(arm64CountingLoop(t, 4), WithTick(1<<20), WithThreshold(0))
+	defer i.Close()
+	headers := i.tracer.headers(i, 0)
+	require.NotEmpty(t, headers)
+	root := anchor{ip: headers[0]}
+
+	require.NoError(t, i.Run(context.Background()))
+	_, err := i.PopBoxed()
+	require.NoError(t, err)
+	require.False(t, i.tried[root])
+	i.Reset()
+
+	require.NoError(t, i.Run(context.Background()))
+	_, err = i.PopBoxed()
+	require.NoError(t, err)
+	require.True(t, i.tried[root])
+}
+
+func TestARM64_BackedgeKeepsSampleThreshold(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+
+	i := New(arm64CountingLoop(t, 4), WithTick(1<<20), WithThreshold(1))
+	defer i.Close()
+	headers := i.tracer.headers(i, 0)
+	require.NotEmpty(t, headers)
+	root := anchor{ip: headers[0]}
+
+	for range 2 {
+		require.NoError(t, i.Run(context.Background()))
+		_, err := i.PopBoxed()
+		require.NoError(t, err)
+		i.Reset()
+	}
+	require.False(t, i.tried[root])
+}
+
 // AbortedSideExitDoesNotComplete protects partial unsupported traces from
 // miscompile where a captured side-exit fragment that recorded a few
 // supported opcodes and then aborted on an unsupported one (MAP_NEW_DEFAULT
@@ -343,6 +429,138 @@ func TestCompiler_Compile(t *testing.T) {
 			require.Less(t, id, len(entry.exits))
 			require.Equal(t, exitDescriptor{reason: prof.ExitGuardBounds, opcode: int(instr.ARRAY_GET)}, entry.exits[id])
 			require.Equal(t, uint64(id+1), encoded)
+		})
+
+		t.Run("primitive array set loop", func(t *testing.T) {
+			array := make(types.TypedArray[int32], 64)
+			b := program.NewBuilder()
+			loop := b.Label()
+			done := b.Label()
+			b.Locals(types.TypeI32)
+			b.Const(array)
+			b.Emit(instr.I32_CONST, 0).
+				Emit(instr.LOCAL_SET, 0).
+				Bind(loop).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 64).
+				Emit(instr.I32_GE_S).
+				BrIf(done).
+				ConstGet(array).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.ARRAY_SET).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_ADD).
+				Emit(instr.LOCAL_SET, 0).
+				Br(loop).
+				Bind(done).
+				ConstGet(array).
+				Emit(instr.I32_CONST, 0).
+				Emit(instr.ARRAY_GET)
+			prog, err := b.Build()
+			require.NoError(t, err)
+			i := New(prog, WithThreshold(-1))
+			defer i.Close()
+			compiler, err := newCompiler()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, compiler.Close()) })
+
+			compiled := compiler.Compile(i, anchor{})
+			require.NoError(t, compiled.err)
+			require.NotNil(t, compiled.module, "%+v", compiled)
+			i.install(compiled.module, false)
+			require.NoError(t, i.Run(context.Background()))
+			value, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(1), value)
+		})
+
+		t.Run("primitive array set branch", func(t *testing.T) {
+			array := make(types.TypedArray[int32], 16)
+			b := program.NewBuilder()
+			loop := b.Label()
+			skip := b.Label()
+			done := b.Label()
+			b.Locals(types.TypeI32)
+			b.Const(array)
+			b.Emit(instr.I32_CONST, 0).
+				Emit(instr.LOCAL_SET, 0).
+				Bind(loop).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 16).
+				Emit(instr.I32_GE_S).
+				BrIf(done).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_AND).
+				BrIf(skip).
+				ConstGet(array).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_ADD).
+				Emit(instr.ARRAY_SET).
+				Bind(skip).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_ADD).
+				Emit(instr.LOCAL_SET, 0).
+				Br(loop).
+				Bind(done).
+				ConstGet(array).
+				Emit(instr.I32_CONST, 0).
+				Emit(instr.ARRAY_GET).
+				ConstGet(array).
+				Emit(instr.I32_CONST, 2).
+				Emit(instr.ARRAY_GET).
+				Emit(instr.I32_ADD)
+			prog, err := b.Build()
+			require.NoError(t, err)
+			i := New(prog, WithThreshold(-1))
+			defer i.Close()
+			compiler, err := newCompiler()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, compiler.Close()) })
+
+			compiled := compiler.Compile(i, anchor{})
+			require.NoError(t, compiled.err)
+			require.NotNil(t, compiled.module, "%+v", compiled)
+			i.install(compiled.module, false)
+
+			require.NoError(t, i.Run(context.Background()))
+			value, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(4), value)
+		})
+
+		t.Run("primitive array set continues", func(t *testing.T) {
+			array := types.TypedArray[int32]{1}
+			prog := program.New([]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 0),
+				instr.New(instr.I32_CONST, 2),
+				instr.New(instr.ARRAY_SET),
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.I32_CONST, 0),
+				instr.New(instr.ARRAY_GET),
+			}, program.WithConstants(array))
+			i := New(prog, WithThreshold(-1))
+			defer i.Close()
+			compiler, err := newCompiler()
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, compiler.Close()) })
+
+			compiled := compiler.Compile(i, anchor{})
+			require.NoError(t, compiled.err)
+			require.NotNil(t, compiled.module, "%+v", compiled)
+			i.install(compiled.module, false)
+
+			require.NoError(t, i.Run(context.Background()))
+			value, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(2), value)
+			require.Equal(t, int32(2), array[0])
 		})
 
 		t.Run("array get value guard", func(t *testing.T) {

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -117,90 +117,66 @@ func TestARM64_ArraySetAfterNestedCalls(t *testing.T) {
 	require.Equal(t, jitOut, out)
 }
 
-func arm64CountingLoop(t *testing.T, limit int32) *program.Program {
-	t.Helper()
-	b := program.NewBuilder()
-	loop := b.Label()
-	done := b.Label()
-	b.Locals(types.TypeI32)
-	b.Emit(instr.I32_CONST, 0).
-		Emit(instr.LOCAL_SET, 0).
-		Bind(loop).
-		Emit(instr.LOCAL_GET, 0).
-		Emit(instr.I32_CONST, uint64(uint32(limit))).
-		Emit(instr.I32_GE_S).
-		BrIf(done).
-		Emit(instr.LOCAL_GET, 0).
-		Emit(instr.I32_CONST, 1).
-		Emit(instr.I32_ADD).
-		Emit(instr.LOCAL_SET, 0).
-		Br(loop).
-		Bind(done).
-		Emit(instr.LOCAL_GET, 0)
-	prog, err := b.Build()
-	require.NoError(t, err)
-	return prog
-}
-
-func TestARM64_BackedgeCompilesModuleLoop(t *testing.T) {
+func TestARM64_Backedge(t *testing.T) {
 	if runtime.GOARCH != "arm64" {
 		t.Skip("native JIT is only available on arm64")
 	}
 
-	i := New(arm64CountingLoop(t, 64), WithTick(1<<20), WithThreshold(0))
-	defer i.Close()
-	require.NoError(t, i.Run(context.Background()))
-	value, err := i.PopBoxed()
-	require.NoError(t, err)
-	require.Equal(t, types.BoxI32(64), value)
-
-	headers := i.tracer.headers(i, 0)
-	require.NotEmpty(t, headers)
-	require.True(t, i.tried[anchor{ip: headers[0]}])
-	require.NotEmpty(t, i.exits)
-}
-
-func TestARM64_BackedgeWarmsEagerLoop(t *testing.T) {
-	if runtime.GOARCH != "arm64" {
-		t.Skip("native JIT is only available on arm64")
+	tests := []struct {
+		name      string
+		limit     int32
+		threshold int
+		attempted []bool
+		installed bool
+	}{
+		{name: "compiles module loop", limit: 64, threshold: 0, attempted: []bool{true}, installed: true},
+		{name: "warms eager loop", limit: 4, threshold: 0, attempted: []bool{false, true}},
+		{name: "keeps sample threshold", limit: 4, threshold: 1, attempted: []bool{false, false}},
 	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := program.NewBuilder()
+			loop := b.Label()
+			done := b.Label()
+			b.Locals(types.TypeI32)
+			b.Emit(instr.I32_CONST, 0).
+				Emit(instr.LOCAL_SET, 0).
+				Bind(loop).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, uint64(uint32(tt.limit))).
+				Emit(instr.I32_GE_S).
+				BrIf(done).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_ADD).
+				Emit(instr.LOCAL_SET, 0).
+				Br(loop).
+				Bind(done).
+				Emit(instr.LOCAL_GET, 0)
+			prog, err := b.Build()
+			require.NoError(t, err)
 
-	i := New(arm64CountingLoop(t, 4), WithTick(1<<20), WithThreshold(0))
-	defer i.Close()
-	headers := i.tracer.headers(i, 0)
-	require.NotEmpty(t, headers)
-	root := anchor{ip: headers[0]}
+			i := New(prog, WithTick(1<<20), WithThreshold(tt.threshold))
+			defer i.Close()
+			headers := i.tracer.headers(i, 0)
+			require.NotEmpty(t, headers)
+			root := anchor{ip: headers[0]}
 
-	require.NoError(t, i.Run(context.Background()))
-	_, err := i.PopBoxed()
-	require.NoError(t, err)
-	require.False(t, i.tried[root])
-	i.Reset()
-
-	require.NoError(t, i.Run(context.Background()))
-	_, err = i.PopBoxed()
-	require.NoError(t, err)
-	require.True(t, i.tried[root])
-}
-
-func TestARM64_BackedgeKeepsSampleThreshold(t *testing.T) {
-	if runtime.GOARCH != "arm64" {
-		t.Skip("native JIT is only available on arm64")
+			for run, attempted := range tt.attempted {
+				require.NoError(t, i.Run(context.Background()))
+				value, err := i.PopBoxed()
+				require.NoError(t, err)
+				require.Equal(t, types.BoxI32(tt.limit), value)
+				require.Equal(t, attempted, i.tried[root])
+				if run+1 < len(tt.attempted) {
+					i.Reset()
+				}
+			}
+			if tt.installed {
+				require.NotEmpty(t, i.exits)
+			}
+		})
 	}
-
-	i := New(arm64CountingLoop(t, 4), WithTick(1<<20), WithThreshold(1))
-	defer i.Close()
-	headers := i.tracer.headers(i, 0)
-	require.NotEmpty(t, headers)
-	root := anchor{ip: headers[0]}
-
-	for range 2 {
-		require.NoError(t, i.Run(context.Background()))
-		_, err := i.PopBoxed()
-		require.NoError(t, err)
-		i.Reset()
-	}
-	require.False(t, i.tried[root])
 }
 
 // AbortedSideExitDoesNotComplete protects partial unsupported traces from

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -135,7 +135,26 @@ func TestARM64_Backedge(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prog := counter(t, tt.limit)
+			b := program.NewBuilder()
+			loop := b.Label()
+			done := b.Label()
+			b.Locals(types.TypeI32)
+			b.Emit(instr.I32_CONST, 0).
+				Emit(instr.LOCAL_SET, 0).
+				Bind(loop).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, uint64(uint32(tt.limit))).
+				Emit(instr.I32_GE_S).
+				BrIf(done).
+				Emit(instr.LOCAL_GET, 0).
+				Emit(instr.I32_CONST, 1).
+				Emit(instr.I32_ADD).
+				Emit(instr.LOCAL_SET, 0).
+				Br(loop).
+				Bind(done).
+				Emit(instr.LOCAL_GET, 0)
+			prog, err := b.Build()
+			require.NoError(t, err)
 
 			i := New(prog, WithTick(1<<20), WithThreshold(tt.threshold))
 			defer i.Close()
@@ -324,8 +343,7 @@ func TestCompiler_Compile(t *testing.T) {
 				require.NoError(t, i.SetGlobal(0, value))
 			}
 			root := anchor{}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -365,8 +383,7 @@ func TestCompiler_Compile(t *testing.T) {
 			}
 			require.NoError(t, i.SetGlobal(1, types.BoxI32(0)))
 			root := anchor{}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -531,8 +548,7 @@ func TestCompiler_Compile(t *testing.T) {
 			require.NoError(t, i.SetGlobal(0, value))
 			require.NoError(t, i.SetGlobal(1, types.BoxI32(0)))
 			root := anchor{}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -567,8 +583,7 @@ func TestCompiler_Compile(t *testing.T) {
 			}
 			require.NoError(t, i.SetGlobal(1, types.BoxI32(0)))
 			root := anchor{}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -609,8 +624,7 @@ func TestCompiler_Compile(t *testing.T) {
 			defer i.Close()
 			require.NoError(t, i.SetGlobal(0, types.BoxI32(0)))
 			root := anchor{}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -641,8 +655,7 @@ func TestCompiler_Compile(t *testing.T) {
 			i := New(program.New(instructions), WithThreshold(-1))
 			defer i.Close()
 			root := anchor{}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -732,8 +745,7 @@ func TestCompiler_Compile(t *testing.T) {
 			root := anchor{addr: addr, ip: header}
 			addrLabel := strconv.Itoa(addr)
 			headerLabel := strconv.Itoa(header)
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()
@@ -781,8 +793,7 @@ func TestCompiler_Compile(t *testing.T) {
 			i.fr.bp = 0
 			i.sp = 0
 			root := anchor{addr: addr}
-			capture, err := i.tracer.capture(i, root)
-			require.NoError(t, err)
+			capture := i.tracer.capture(i, root)
 			require.NotNil(t, capture.trace)
 			i.stubs[root.addr] = i.code[root.addr][0]
 			compiler, err := newCompiler()

--- a/interp/jit_plan.go
+++ b/interp/jit_plan.go
@@ -20,11 +20,12 @@ type shape struct {
 }
 
 type step struct {
-	op    instr.Opcode
-	args  [2]uint64
-	seen  types.Boxed
-	arg   types.Boxed
-	shape shape
+	op       instr.Opcode
+	args     [2]uint64
+	seen     types.Boxed
+	arg      types.Boxed
+	shape    shape
+	terminal bool
 
 	fn     int
 	ip     int
@@ -144,7 +145,7 @@ func (p plan) valid() bool {
 			return false
 		}
 	case entryLoop:
-		if p.anchor.addr <= 0 || p.anchor.ip <= 0 {
+		if p.anchor.addr < 0 || p.anchor.ip <= 0 {
 			return false
 		}
 	case entryModule:
@@ -539,8 +540,8 @@ func wire(p *plan, roots map[anchor]int) {
 
 func noSpill(blocks []block) bool {
 	for _, block := range blocks {
-		if len(block.steps) > 0 {
-			switch block.steps[len(block.steps)-1].op {
+		for _, step := range block.steps {
+			switch step.op {
 			case instr.ARRAY_SET, instr.STRUCT_SET:
 				return true
 			}

--- a/interp/jit_plan_test.go
+++ b/interp/jit_plan_test.go
@@ -54,6 +54,11 @@ func TestPlan(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "module loop",
+			plan: plan{anchor: anchor{ip: 4}, kind: entryLoop, blocks: []block{{anchor: anchor{ip: 4}, term: terminator{kind: terminateBranch, edges: []edge{jump(0, 4)}}}}},
+			want: true,
+		},
+		{
 			name: "module",
 			plan: plan{anchor: anchor{}, kind: entryModule, blocks: []block{{anchor: anchor{}, term: terminator{kind: terminateComplete}}}},
 			want: true,
@@ -153,6 +158,16 @@ func TestPlan(t *testing.T) {
 			{steps: []step{{op: instr.I32_ADD}}},
 			{steps: []step{{op: instr.I32_CONST}, {op: instr.STRUCT_SET}}},
 		}))
+		require.True(t, noSpill([]block{{steps: []step{
+			{op: instr.ARRAY_SET},
+			{op: instr.I32_ADD},
+		}}}))
+	})
+
+	t.Run("requested plans", func(t *testing.T) {
+		first := plan{anchor: anchor{addr: 1, ip: 4}}
+		second := plan{anchor: anchor{addr: 1, ip: 8}}
+		require.Equal(t, []plan{second}, requestedPlans([]plan{first, second}, second.anchor))
 	})
 
 }

--- a/interp/jit_plan_test.go
+++ b/interp/jit_plan_test.go
@@ -164,12 +164,6 @@ func TestPlan(t *testing.T) {
 		}}}))
 	})
 
-	t.Run("requested plans", func(t *testing.T) {
-		first := plan{anchor: anchor{addr: 1, ip: 4}}
-		second := plan{anchor: anchor{addr: 1, ip: 8}}
-		require.Equal(t, []plan{second}, requestedPlans([]plan{first, second}, second.anchor))
-	})
-
 }
 
 func TestStaticPlan(t *testing.T) {

--- a/interp/jit_stub.go
+++ b/interp/jit_stub.go
@@ -2,6 +2,8 @@
 
 package interp
 
+const nativeBackend = false
+
 // newCompiler returns (nil, nil) on architectures without a native
 // backend. A nil compiler is the interpreter's signal that JIT is
 // unavailable, so callers gate on i.compiler == nil rather than an error.

--- a/interp/pool_test.go
+++ b/interp/pool_test.go
@@ -97,7 +97,7 @@ func TestPool_Get(t *testing.T) {
 		}
 
 		// A called function with a branch tree: members share one Tracer, so one
-		// interpreter warming a side exit (Tracer.exit mutating tree.branches/hits)
+		// interpreter warming a side exit (Tracer.branch mutating tree.branches/hits)
 		// runs concurrently with another lowering the same root (rootAt reading it).
 		// Before the fix that races the shared tree; the snapshot isolates the reader.
 		b := types.NewFunctionBuilder(nil).WithParams(types.TypeI32).WithReturns(types.TypeI32)

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -22,6 +22,8 @@ type threader struct {
 	code      []byte
 	ip        int
 	exact     bool
+	hot       bool
+	backedge  func(*Interpreter, *frame) error
 }
 
 var (
@@ -87,9 +89,18 @@ var (
 		instr.BR: func(c *threader) func(i *Interpreter) {
 			offset := instr.ParseI16(c.code, c.ip+1)
 			c.ip += 3
+			if !c.hot || c.backedge == nil || offset > -3 {
+				return func(i *Interpreter) {
+					f := i.fr
+					f.ip += offset + 3
+				}
+			}
 			return func(i *Interpreter) {
 				f := i.fr
 				f.ip += offset + 3
+				if err := c.backedge(i, f); err != nil {
+					panic(err)
+				}
 			}
 		},
 		instr.BR_IF: func(c *threader) func(i *Interpreter) {

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -22,7 +22,6 @@ type threader struct {
 	code      []byte
 	ip        int
 	exact     bool
-	hot       bool
 	backedge  func(*Interpreter, *frame) error
 }
 
@@ -89,7 +88,7 @@ var (
 		instr.BR: func(c *threader) func(i *Interpreter) {
 			offset := instr.ParseI16(c.code, c.ip+1)
 			c.ip += 3
-			if !c.hot || c.backedge == nil || offset > -3 {
+			if c.backedge == nil || offset > -3 {
 				return func(i *Interpreter) {
 					f := i.fr
 					f.ip += offset + 3

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -175,6 +175,8 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 		}
 
 		st := r.op(&clone, op, startFP)
+		terminalMutation := op == instr.STRUCT_SET || op == instr.ARRAY_SET && !r.continuableArraySet(&clone, t)
+		st.terminal = terminalMutation
 		if op == instr.CALL && r.callsAnchor(&clone, a) {
 			r.skipCall(&clone, a.addr)
 			st.callee = a.addr
@@ -233,11 +235,10 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			r.publish(a, tree, t)
 			return captureResult{trace: t, outcome: prof.CaptureOutcomePartial}, nil
 		}
-		// Heap mutations still lower as terminal native fast paths: the hot
-		// path performs the store and resumes at the next threaded instruction;
-		// guard failures resume at the opcode so the interpreter owns the full
-		// handler semantics.
-		if op == instr.ARRAY_SET || op == instr.STRUCT_SET {
+		// Ref-bearing array writes and struct writes remain terminal native fast
+		// paths. Primitive array writes can continue because their guarded store
+		// has no recursive release or post-store deopt point.
+		if terminalMutation {
 			if clone.fp != startFP {
 				t.kind = aborted
 				result.reason = prof.CaptureReasonNestedTerminal
@@ -326,6 +327,18 @@ func (r *Tracer) heap(heap []types.Value) []types.Value {
 	out := make([]types.Value, len(heap))
 	for idx, val := range heap {
 		switch v := val.(type) {
+		case types.TypedArray[bool]:
+			out[idx] = append(types.TypedArray[bool](nil), v...)
+		case types.TypedArray[int8]:
+			out[idx] = append(types.TypedArray[int8](nil), v...)
+		case types.TypedArray[int32]:
+			out[idx] = append(types.TypedArray[int32](nil), v...)
+		case types.TypedArray[int64]:
+			out[idx] = append(types.TypedArray[int64](nil), v...)
+		case types.TypedArray[float32]:
+			out[idx] = append(types.TypedArray[float32](nil), v...)
+		case types.TypedArray[float64]:
+			out[idx] = append(types.TypedArray[float64](nil), v...)
 		case *types.Closure:
 			clone := *v
 			clone.Upvals = append([]types.Boxed(nil), v.Upvals...)
@@ -335,6 +348,39 @@ func (r *Tracer) heap(heap []types.Value) []types.Value {
 		}
 	}
 	return out
+}
+
+func (r *Tracer) primitiveArray(i *Interpreter) bool {
+	if i.sp < 3 || i.stack[i.sp-3].Kind() != types.KindRef {
+		return false
+	}
+	addr := i.stack[i.sp-3].Ref()
+	if addr <= 0 || addr >= len(i.heap) {
+		return false
+	}
+	switch i.heap[addr].(type) {
+	case types.TypedArray[bool],
+		types.TypedArray[int8],
+		types.TypedArray[int32],
+		types.TypedArray[int64],
+		types.TypedArray[float32],
+		types.TypedArray[float64]:
+		return true
+	default:
+		return false
+	}
+}
+
+func (r *Tracer) continuableArraySet(i *Interpreter, t *trace) bool {
+	if !r.primitiveArray(i) {
+		return false
+	}
+	for _, op := range t.ops {
+		if op.depth != 0 || op.op == instr.CALL || op.op == instr.RETURN_CALL {
+			return false
+		}
+	}
+	return true
 }
 
 func (r *Tracer) codes(i *Interpreter) [][]func(*Interpreter) {

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -315,6 +315,7 @@ func (r *Tracer) clone(i *Interpreter) Interpreter {
 	out.globals = slices.Clone(i.globals)
 	out.instrs = slices.Clone(i.instrs)
 	out.code = slices.Clone(r.exactCodes(i))
+	out.backedges = make([]bool, len(i.backedges))
 	out.exits = map[anchor]func(*Interpreter){}
 	out.stubs = make([]func(*Interpreter), len(out.code))
 	out.tried = map[anchor]bool{}
@@ -349,29 +350,99 @@ func cloneMutation(i *Interpreter, cloned map[int]bool) {
 	}
 	switch value := value.(type) {
 	case types.TypedArray[bool]:
-		i.heap[addr] = slices.Clone(value)
+		cloneTypedAliases(i.heap, value, cloned)
 	case types.TypedArray[int8]:
-		i.heap[addr] = slices.Clone(value)
+		cloneTypedAliases(i.heap, value, cloned)
 	case types.TypedArray[int32]:
-		i.heap[addr] = slices.Clone(value)
+		cloneTypedAliases(i.heap, value, cloned)
 	case types.TypedArray[int64]:
-		i.heap[addr] = slices.Clone(value)
+		cloneTypedAliases(i.heap, value, cloned)
 	case types.TypedArray[float32]:
-		i.heap[addr] = slices.Clone(value)
+		cloneTypedAliases(i.heap, value, cloned)
 	case types.TypedArray[float64]:
-		i.heap[addr] = slices.Clone(value)
+		cloneTypedAliases(i.heap, value, cloned)
 	case *types.Array:
 		clone := *value
 		clone.Elems = slices.Clone(value.Elems)
 		i.heap[addr] = &clone
+		cloned[addr] = true
 	case *types.Struct:
 		clone := *value
 		clone.Data = slices.Clone(value.Data)
 		i.heap[addr] = &clone
-	default:
+		cloned[addr] = true
+	}
+}
+
+type arrayElem interface {
+	bool | int8 | int32 | int64 | float32 | float64
+}
+
+type arrayAlias[T arrayElem] struct {
+	addr  int
+	array types.TypedArray[T]
+	start uintptr
+	end   uintptr
+}
+
+func cloneTypedAliases[T arrayElem](heap []types.Value, target types.TypedArray[T], cloned map[int]bool) {
+	if len(target) == 0 {
 		return
 	}
-	cloned[addr] = true
+	var zero T
+	size := unsafe.Sizeof(zero)
+	start := uintptr(unsafe.Pointer(unsafe.SliceData(target)))
+	end := start + uintptr(len(target))*size
+	aliases := make([]arrayAlias[T], 0, len(heap))
+	for addr, value := range heap {
+		array, ok := value.(types.TypedArray[T])
+		if !ok || len(array) == 0 {
+			continue
+		}
+		aliasStart := uintptr(unsafe.Pointer(unsafe.SliceData(array)))
+		aliases = append(aliases, arrayAlias[T]{
+			addr:  addr,
+			array: array,
+			start: aliasStart,
+			end:   aliasStart + uintptr(len(array))*size,
+		})
+	}
+	selected := make([]bool, len(aliases))
+	for changed := true; changed; {
+		changed = false
+		for idx, alias := range aliases {
+			if selected[idx] || alias.start >= end || start >= alias.end {
+				continue
+			}
+			selected[idx] = true
+			start = min(start, alias.start)
+			end = max(end, alias.end)
+			changed = true
+		}
+	}
+	var base *T
+	for idx, alias := range aliases {
+		if selected[idx] && alias.start == start {
+			base = unsafe.SliceData(alias.array)
+			break
+		}
+	}
+	if base == nil {
+		return
+	}
+	// Recorded array operations can observe only the current lengths. Clone the
+	// transitive union of overlapping visible ranges once, then rebuild each
+	// slice at its original offset so speculative writes preserve aliasing.
+	backing := make([]T, int((end-start)/size))
+	copy(backing, unsafe.Slice(base, len(backing)))
+	for idx, alias := range aliases {
+		if !selected[idx] {
+			continue
+		}
+		offset := int((alias.start - start) / size)
+		heap[alias.addr] = types.TypedArray[T](backing[offset : offset+len(alias.array)])
+		cloned[alias.addr] = true
+	}
 }
 
 func mutationTarget(i *Interpreter) (int, types.Value, bool) {

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -186,7 +186,7 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult) {
 			if cloned == nil {
 				cloned = map[int]bool{}
 			}
-			primitive := cloneMutation(&clone, cloned)
+			primitive := cloneTarget(&clone, cloned)
 			terminalMutation = op == instr.STRUCT_SET || hasCall || !primitive
 		}
 		st.terminal = terminalMutation
@@ -322,7 +322,7 @@ func (r *Tracer) clone(i *Interpreter) Interpreter {
 	out.exits = map[anchor]func(*Interpreter){}
 	out.stubs = make([]func(*Interpreter), len(out.code))
 	out.tried = map[anchor]bool{}
-	out.warmup = map[anchor]uint8{}
+	out.loopHits = map[anchor]uint8{}
 	out.journal = slices.Clone(i.journal)
 	out.coros = slices.Clone(i.coros)
 	out.handlers = slices.Clone(i.handlers)
@@ -346,9 +346,9 @@ func (r *Tracer) clone(i *Interpreter) Interpreter {
 	return out
 }
 
-// cloneMutation isolates the next mutation target and reports whether it is a
+// cloneTarget isolates the next mutation target and reports whether it is a
 // primitive typed array whose store may continue inside the trace.
-func cloneMutation(i *Interpreter, cloned map[int]bool) bool {
+func cloneTarget(i *Interpreter, cloned map[int]bool) bool {
 	if i.sp < 3 || i.stack[i.sp-3].Kind() != types.KindRef {
 		return false
 	}
@@ -360,32 +360,32 @@ func cloneMutation(i *Interpreter, cloned map[int]bool) bool {
 	switch value := value.(type) {
 	case types.TypedArray[bool]:
 		if !cloned[addr] {
-			cloneTypedAliases(i.heap, value, cloned)
+			cloneAliases(i.heap, value, cloned)
 		}
 		return true
 	case types.TypedArray[int8]:
 		if !cloned[addr] {
-			cloneTypedAliases(i.heap, value, cloned)
+			cloneAliases(i.heap, value, cloned)
 		}
 		return true
 	case types.TypedArray[int32]:
 		if !cloned[addr] {
-			cloneTypedAliases(i.heap, value, cloned)
+			cloneAliases(i.heap, value, cloned)
 		}
 		return true
 	case types.TypedArray[int64]:
 		if !cloned[addr] {
-			cloneTypedAliases(i.heap, value, cloned)
+			cloneAliases(i.heap, value, cloned)
 		}
 		return true
 	case types.TypedArray[float32]:
 		if !cloned[addr] {
-			cloneTypedAliases(i.heap, value, cloned)
+			cloneAliases(i.heap, value, cloned)
 		}
 		return true
 	case types.TypedArray[float64]:
 		if !cloned[addr] {
-			cloneTypedAliases(i.heap, value, cloned)
+			cloneAliases(i.heap, value, cloned)
 		}
 		return true
 	case *types.Array:
@@ -406,10 +406,10 @@ func cloneMutation(i *Interpreter, cloned map[int]bool) bool {
 	return false
 }
 
-// cloneTypedAliases copies the connected component of typed-array ranges that
+// cloneAliases copies the connected component of typed-array ranges that
 // overlap target. Address arithmetic only identifies overlap; each original
 // slice copies its own visible range into the replacement backing store.
-func cloneTypedAliases[T bool | int8 | int32 | int64 | float32 | float64](heap []types.Value, target types.TypedArray[T], cloned map[int]bool) {
+func cloneAliases[T bool | int8 | int32 | int64 | float32 | float64](heap []types.Value, target types.TypedArray[T], cloned map[int]bool) {
 	if len(target) == 0 {
 		return
 	}

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -1,6 +1,8 @@
 package interp
 
 import (
+	"maps"
+	"slices"
 	"sort"
 	"sync"
 	"unsafe"
@@ -159,6 +161,8 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 
 	t := &trace{anchor: a}
 	startFP := clone.fp
+	hasCall := false
+	var cloned map[int]bool
 	for len(t.ops) < opLimit {
 		f := clone.fr
 		if f.addr < 0 || f.addr >= len(clone.instrs) || f.ip < 0 || f.ip >= len(clone.instrs[f.addr]) {
@@ -175,12 +179,13 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 		}
 
 		st := r.op(&clone, op, startFP)
-		terminalMutation := op == instr.STRUCT_SET || op == instr.ARRAY_SET && !r.continuableArraySet(&clone, t)
+		terminalMutation := op == instr.STRUCT_SET || op == instr.ARRAY_SET && (hasCall || !primitiveArray(&clone))
 		st.terminal = terminalMutation
 		if op == instr.CALL && r.callsAnchor(&clone, a) {
 			r.skipCall(&clone, a.addr)
 			st.callee = a.addr
 			t.ops = append(t.ops, st)
+			hasCall = true
 			continue
 		}
 		// A tail call back to the entry anchor closes the trace as a native loop
@@ -211,6 +216,12 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			r.publish(a, tree, t)
 			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
 		}
+		if op == instr.ARRAY_SET || op == instr.STRUCT_SET {
+			if cloned == nil {
+				cloned = map[int]bool{}
+			}
+			cloneMutation(&clone, cloned)
+		}
 		if !r.step(&clone, f.addr, f.ip) {
 			t.kind = aborted
 			result.reason = prof.CaptureReasonStepTrap
@@ -219,6 +230,9 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 
 		r.finish(&clone, &st, op)
 		t.ops = append(t.ops, st)
+		if op == instr.CALL || op == instr.RETURN_CALL {
+			hasCall = true
+		}
 		// A backward edge to a different header starts a distinct loop trace.
 		// Stop this linear prefix at the header instead of unrolling the loop up
 		// to opLimit; threaded execution will make that header hot and compile it
@@ -291,74 +305,92 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 func (r *Tracer) clone(i *Interpreter) Interpreter {
 	out := *i
 	out.compiler = nil
+	out.cache = nil
+	out.tracer = nil
 	out.hook = nil
+	out.speculative = true
 	out.threshold = -1
 
 	out.constants = i.constants
-	out.globals = append([]types.Boxed(nil), i.globals...)
-	out.instrs = i.instrs
-	out.code = r.codes(i)
+	out.globals = slices.Clone(i.globals)
+	out.instrs = slices.Clone(i.instrs)
+	out.code = slices.Clone(r.exactCodes(i))
 	out.exits = map[anchor]func(*Interpreter){}
 	out.stubs = make([]func(*Interpreter), len(out.code))
-	out.journal = append([]uint64(nil), i.journal...)
-	out.frames = append([]frame(nil), i.frames...)
-	out.stack = append([]types.Boxed(nil), i.stack...)
-	out.heap = r.heap(i.heap)
-	out.free = append([]int(nil), i.free...)
-	out.rc = append([]int(nil), i.rc...)
+	out.tried = map[anchor]bool{}
+	out.warmup = map[anchor]uint8{}
+	out.journal = slices.Clone(i.journal)
+	out.coros = slices.Clone(i.coros)
+	out.handlers = slices.Clone(i.handlers)
+	out.dynamic = map[int]bool{}
+	out.frames = slices.Clone(i.frames)
+	out.stack = slices.Clone(i.stack)
+	out.heap = slices.Clone(i.heap)
+	out.free = slices.Clone(i.free)
+	out.rc = slices.Clone(i.rc)
 	out.trial = nil
 	out.work = nil
 	out.refbuf = nil
-	out.interned = make(map[string]types.Ref, len(i.interned))
-	for key, val := range i.interned {
-		out.interned[key] = val
-	}
+	out.interned = map[string]types.Ref{}
 	for idx := 0; idx < out.fp; idx++ {
 		addr := out.frames[idx].addr
 		if addr >= 0 && addr < len(out.code) {
 			out.frames[idx].code = out.code[addr]
 		}
-		out.frames[idx].upvals = append([]types.Boxed(nil), out.frames[idx].upvals...)
+		out.frames[idx].upvals = slices.Clone(out.frames[idx].upvals)
 	}
 	return out
 }
 
-func (r *Tracer) heap(heap []types.Value) []types.Value {
-	out := make([]types.Value, len(heap))
-	for idx, val := range heap {
-		switch v := val.(type) {
-		case types.TypedArray[bool]:
-			out[idx] = append(types.TypedArray[bool](nil), v...)
-		case types.TypedArray[int8]:
-			out[idx] = append(types.TypedArray[int8](nil), v...)
-		case types.TypedArray[int32]:
-			out[idx] = append(types.TypedArray[int32](nil), v...)
-		case types.TypedArray[int64]:
-			out[idx] = append(types.TypedArray[int64](nil), v...)
-		case types.TypedArray[float32]:
-			out[idx] = append(types.TypedArray[float32](nil), v...)
-		case types.TypedArray[float64]:
-			out[idx] = append(types.TypedArray[float64](nil), v...)
-		case *types.Closure:
-			clone := *v
-			clone.Upvals = append([]types.Boxed(nil), v.Upvals...)
-			out[idx] = &clone
-		default:
-			out[idx] = val
-		}
+func cloneMutation(i *Interpreter, cloned map[int]bool) {
+	addr, value, ok := mutationTarget(i)
+	if !ok || cloned[addr] {
+		return
 	}
-	return out
+	switch value := value.(type) {
+	case types.TypedArray[bool]:
+		i.heap[addr] = slices.Clone(value)
+	case types.TypedArray[int8]:
+		i.heap[addr] = slices.Clone(value)
+	case types.TypedArray[int32]:
+		i.heap[addr] = slices.Clone(value)
+	case types.TypedArray[int64]:
+		i.heap[addr] = slices.Clone(value)
+	case types.TypedArray[float32]:
+		i.heap[addr] = slices.Clone(value)
+	case types.TypedArray[float64]:
+		i.heap[addr] = slices.Clone(value)
+	case *types.Array:
+		clone := *value
+		clone.Elems = slices.Clone(value.Elems)
+		i.heap[addr] = &clone
+	case *types.Struct:
+		clone := *value
+		clone.Data = slices.Clone(value.Data)
+		i.heap[addr] = &clone
+	default:
+		return
+	}
+	cloned[addr] = true
 }
 
-func (r *Tracer) primitiveArray(i *Interpreter) bool {
+func mutationTarget(i *Interpreter) (int, types.Value, bool) {
 	if i.sp < 3 || i.stack[i.sp-3].Kind() != types.KindRef {
-		return false
+		return 0, nil, false
 	}
 	addr := i.stack[i.sp-3].Ref()
 	if addr <= 0 || addr >= len(i.heap) {
+		return 0, nil, false
+	}
+	return addr, i.heap[addr], true
+}
+
+func primitiveArray(i *Interpreter) bool {
+	_, value, ok := mutationTarget(i)
+	if !ok {
 		return false
 	}
-	switch i.heap[addr].(type) {
+	switch value.(type) {
 	case types.TypedArray[bool],
 		types.TypedArray[int8],
 		types.TypedArray[int32],
@@ -371,19 +403,7 @@ func (r *Tracer) primitiveArray(i *Interpreter) bool {
 	}
 }
 
-func (r *Tracer) continuableArraySet(i *Interpreter, t *trace) bool {
-	if !r.primitiveArray(i) {
-		return false
-	}
-	for _, op := range t.ops {
-		if op.depth != 0 || op.op == instr.CALL || op.op == instr.RETURN_CALL {
-			return false
-		}
-	}
-	return true
-}
-
-func (r *Tracer) codes(i *Interpreter) [][]func(*Interpreter) {
+func (r *Tracer) exactCodes(i *Interpreter) [][]func(*Interpreter) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if len(r.exact) == len(i.instrs) {
@@ -732,14 +752,10 @@ func (r *Tracer) unrecordableReason(i *Interpreter, op instr.Opcode) prof.Captur
 // lower a root without holding r.mu while the recorder keeps mutating the live
 // tree under lock — the concurrent map read/write that races a pooled Tracer.
 func (t *tree) snapshot() *tree {
-	branches := make(map[int]*trace, len(t.branches))
-	for id, tr := range t.branches {
-		branches[id] = tr
-	}
 	return &tree{
 		root:     t.root,
-		branches: branches,
-		hits:     append([]int64(nil), t.hits...),
+		branches: maps.Clone(t.branches),
+		hits:     slices.Clone(t.hits),
 	}
 }
 

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -91,10 +91,15 @@ func (r *Tracer) bind(prog *program.Program) bool {
 	return r.prog == prog
 }
 
-func (r *Tracer) exit(i *Interpreter, root anchor, target anchor) (int64, error) {
+func (r *Tracer) branch(i *Interpreter, root anchor, target anchor) int64 {
 	r.mu.Lock()
 	tree := r.tree(root)
-	id := r.exitIndex(tree, target)
+	id, ok := tree.exits[target]
+	if !ok {
+		id = len(tree.hits)
+		tree.exits[target] = id
+		tree.hits = append(tree.hits, 0)
+	}
 	tree.hits[id]++
 	hits := tree.hits[id]
 	if branch := tree.branches[id]; branch != nil {
@@ -103,25 +108,22 @@ func (r *Tracer) exit(i *Interpreter, root anchor, target anchor) (int64, error)
 		// cannot be folded into the parent trace, so recompiling that parent
 		// would only publish the same pair again.
 		if branch.kind == loop && hits != exitThreshold {
-			return 0, nil
+			return 0
 		}
-		return hits, nil
+		return hits
 	}
 	r.mu.Unlock()
 
-	result, err := r.capture(i, anchor{addr: target.addr, ip: target.ip})
-	if err != nil {
-		return hits, err
-	}
+	result := r.capture(i, anchor{addr: target.addr, ip: target.ip})
 	r.mu.Lock()
 	if r.trees[root] == tree {
 		tree.branches[id] = result.trace
 	}
 	r.mu.Unlock()
-	return hits, nil
+	return hits
 }
 
-func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err error) {
+func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult) {
 	r.recordMu.Lock()
 	defer r.recordMu.Unlock()
 	defer func() {
@@ -135,24 +137,24 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 	if tree != nil && tree.root != nil {
 		t := tree.root
 		r.mu.Unlock()
-		return captureResult{trace: t}, nil
+		return captureResult{trace: t}
 	}
 	if a.ip == 0 && (i.fr == nil || i.fr.addr != a.addr || i.fr.ip != 0) {
 		r.mu.Unlock()
-		return captureResult{outcome: prof.CaptureOutcomeRejected, reason: prof.CaptureReasonInvalidAnchor}, nil
+		return captureResult{outcome: prof.CaptureOutcomeRejected, reason: prof.CaptureReasonInvalidAnchor}
 	}
 	if tree == nil {
 		tree = r.tree(a)
 	}
 	if tree.attempts >= attemptLimit {
 		r.mu.Unlock()
-		return captureResult{outcome: prof.CaptureOutcomeRejected, reason: prof.CaptureReasonAttemptLimit}, nil
+		return captureResult{outcome: prof.CaptureOutcomeRejected, reason: prof.CaptureReasonAttemptLimit}
 	}
 	tree.attempts++
 	r.mu.Unlock()
 
 	if a.addr < 0 || a.addr >= len(i.instrs) || a.ip < 0 || a.ip >= len(i.instrs[a.addr]) {
-		return captureResult{outcome: prof.CaptureOutcomeRejected, reason: prof.CaptureReasonInvalidAnchor}, nil
+		return captureResult{outcome: prof.CaptureOutcomeRejected, reason: prof.CaptureReasonInvalidAnchor}
 	}
 
 	clone := r.clone(i)
@@ -179,7 +181,14 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 		}
 
 		st := r.op(&clone, op, startFP)
-		terminalMutation := op == instr.STRUCT_SET || op == instr.ARRAY_SET && (hasCall || !primitiveArray(&clone))
+		terminalMutation := false
+		if op == instr.ARRAY_SET || op == instr.STRUCT_SET {
+			if cloned == nil {
+				cloned = map[int]bool{}
+			}
+			primitive := cloneMutation(&clone, cloned)
+			terminalMutation = op == instr.STRUCT_SET || hasCall || !primitive
+		}
 		st.terminal = terminalMutation
 		if op == instr.CALL && r.callsAnchor(&clone, a) {
 			r.skipCall(&clone, a.addr)
@@ -197,7 +206,7 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			t.ops = append(t.ops, st)
 			t.kind = returned
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		}
 		// YIELD/RESUME and exception-producing ops have side effects a trace
 		// cannot represent. In the anchor frame, record the op as the
@@ -214,13 +223,7 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			t.ops = append(t.ops, st)
 			t.kind = returned
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
-		}
-		if op == instr.ARRAY_SET || op == instr.STRUCT_SET {
-			if cloned == nil {
-				cloned = map[int]bool{}
-			}
-			cloneMutation(&clone, cloned)
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		}
 		if !r.step(&clone, f.addr, f.ip) {
 			t.kind = aborted
@@ -247,7 +250,7 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			})
 			t.kind = partial
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePartial}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePartial}
 		}
 		// Ref-bearing array writes and struct writes remain terminal native fast
 		// paths. Primitive array writes can continue because their guarded store
@@ -260,27 +263,27 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			}
 			t.kind = returned
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		}
 		switch {
 		case op == instr.RETURN && st.depth == 0:
 			t.kind = returned
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		case clone.fr.addr >= 0 && clone.fr.addr < len(clone.instrs) && clone.fr.ip >= len(clone.instrs[clone.fr.addr]):
 			if clone.fr.addr == 0 {
 				t.kind = completed
 			}
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		case clone.fr.addr == a.addr && clone.fr.ip == a.ip:
 			t.kind = loop
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		case clone.fp < startFP:
 			t.kind = returned
 			r.publish(a, tree, t)
-			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}, nil
+			return captureResult{trace: t, outcome: prof.CaptureOutcomePublished}
 		}
 	}
 	if len(t.ops) >= opLimit {
@@ -296,10 +299,10 @@ func (r *Tracer) capture(i *Interpreter, a anchor) (result captureResult, err er
 			result.reason = prof.CaptureReasonUnsupportedOp
 		}
 		result.outcome = prof.CaptureOutcomeRejected
-		return result, nil
+		return result
 	}
 	r.publish(a, tree, t)
-	return captureResult{trace: t, outcome: prof.CaptureOutcomePartial, reason: result.reason}, nil
+	return captureResult{trace: t, outcome: prof.CaptureOutcomePartial, reason: result.reason}
 }
 
 func (r *Tracer) clone(i *Interpreter) Interpreter {
@@ -343,49 +346,70 @@ func (r *Tracer) clone(i *Interpreter) Interpreter {
 	return out
 }
 
-func cloneMutation(i *Interpreter, cloned map[int]bool) {
-	addr, value, ok := mutationTarget(i)
-	if !ok || cloned[addr] {
-		return
+// cloneMutation isolates the next mutation target and reports whether it is a
+// primitive typed array whose store may continue inside the trace.
+func cloneMutation(i *Interpreter, cloned map[int]bool) bool {
+	if i.sp < 3 || i.stack[i.sp-3].Kind() != types.KindRef {
+		return false
 	}
+	addr := i.stack[i.sp-3].Ref()
+	if addr <= 0 || addr >= len(i.heap) {
+		return false
+	}
+	value := i.heap[addr]
 	switch value := value.(type) {
 	case types.TypedArray[bool]:
-		cloneTypedAliases(i.heap, value, cloned)
+		if !cloned[addr] {
+			cloneTypedAliases(i.heap, value, cloned)
+		}
+		return true
 	case types.TypedArray[int8]:
-		cloneTypedAliases(i.heap, value, cloned)
+		if !cloned[addr] {
+			cloneTypedAliases(i.heap, value, cloned)
+		}
+		return true
 	case types.TypedArray[int32]:
-		cloneTypedAliases(i.heap, value, cloned)
+		if !cloned[addr] {
+			cloneTypedAliases(i.heap, value, cloned)
+		}
+		return true
 	case types.TypedArray[int64]:
-		cloneTypedAliases(i.heap, value, cloned)
+		if !cloned[addr] {
+			cloneTypedAliases(i.heap, value, cloned)
+		}
+		return true
 	case types.TypedArray[float32]:
-		cloneTypedAliases(i.heap, value, cloned)
+		if !cloned[addr] {
+			cloneTypedAliases(i.heap, value, cloned)
+		}
+		return true
 	case types.TypedArray[float64]:
-		cloneTypedAliases(i.heap, value, cloned)
+		if !cloned[addr] {
+			cloneTypedAliases(i.heap, value, cloned)
+		}
+		return true
 	case *types.Array:
-		clone := *value
-		clone.Elems = slices.Clone(value.Elems)
-		i.heap[addr] = &clone
-		cloned[addr] = true
+		if !cloned[addr] {
+			clone := *value
+			clone.Elems = slices.Clone(value.Elems)
+			i.heap[addr] = &clone
+			cloned[addr] = true
+		}
 	case *types.Struct:
-		clone := *value
-		clone.Data = slices.Clone(value.Data)
-		i.heap[addr] = &clone
-		cloned[addr] = true
+		if !cloned[addr] {
+			clone := *value
+			clone.Data = slices.Clone(value.Data)
+			i.heap[addr] = &clone
+			cloned[addr] = true
+		}
 	}
+	return false
 }
 
-type arrayElem interface {
-	bool | int8 | int32 | int64 | float32 | float64
-}
-
-type arrayAlias[T arrayElem] struct {
-	addr  int
-	array types.TypedArray[T]
-	start uintptr
-	end   uintptr
-}
-
-func cloneTypedAliases[T arrayElem](heap []types.Value, target types.TypedArray[T], cloned map[int]bool) {
+// cloneTypedAliases copies the connected component of typed-array ranges that
+// overlap target. Address arithmetic only identifies overlap; each original
+// slice copies its own visible range into the replacement backing store.
+func cloneTypedAliases[T bool | int8 | int32 | int64 | float32 | float64](heap []types.Value, target types.TypedArray[T], cloned map[int]bool) {
 	if len(target) == 0 {
 		return
 	}
@@ -393,84 +417,61 @@ func cloneTypedAliases[T arrayElem](heap []types.Value, target types.TypedArray[
 	size := unsafe.Sizeof(zero)
 	start := uintptr(unsafe.Pointer(unsafe.SliceData(target)))
 	end := start + uintptr(len(target))*size
-	aliases := make([]arrayAlias[T], 0, len(heap))
+	aliases := make([]struct {
+		addr  int
+		array types.TypedArray[T]
+		start uintptr
+		end   uintptr
+	}, 0, len(heap))
 	for addr, value := range heap {
 		array, ok := value.(types.TypedArray[T])
 		if !ok || len(array) == 0 {
 			continue
 		}
 		aliasStart := uintptr(unsafe.Pointer(unsafe.SliceData(array)))
-		aliases = append(aliases, arrayAlias[T]{
+		aliases = append(aliases, struct {
+			addr  int
+			array types.TypedArray[T]
+			start uintptr
+			end   uintptr
+		}{
 			addr:  addr,
 			array: array,
 			start: aliasStart,
 			end:   aliasStart + uintptr(len(array))*size,
 		})
 	}
-	selected := make([]bool, len(aliases))
-	for changed := true; changed; {
-		changed = false
-		for idx, alias := range aliases {
-			if selected[idx] || alias.start >= end || start >= alias.end {
+	for {
+		previousStart, previousEnd := start, end
+		for _, alias := range aliases {
+			if alias.start >= end || start >= alias.end {
 				continue
 			}
-			selected[idx] = true
 			start = min(start, alias.start)
 			end = max(end, alias.end)
-			changed = true
 		}
-	}
-	var base *T
-	for idx, alias := range aliases {
-		if selected[idx] && alias.start == start {
-			base = unsafe.SliceData(alias.array)
+		if start == previousStart && end == previousEnd {
 			break
 		}
 	}
-	if base == nil {
-		return
-	}
-	// Recorded array operations can observe only the current lengths. Clone the
+	// Recorded array operations can observe only the current lengths. Copy the
 	// transitive union of overlapping visible ranges once, then rebuild each
 	// slice at its original offset so speculative writes preserve aliasing.
 	backing := make([]T, int((end-start)/size))
-	copy(backing, unsafe.Slice(base, len(backing)))
-	for idx, alias := range aliases {
-		if !selected[idx] {
+	for _, alias := range aliases {
+		if alias.start >= end || start >= alias.end {
+			continue
+		}
+		offset := int((alias.start - start) / size)
+		copy(backing[offset:offset+len(alias.array)], alias.array)
+	}
+	for _, alias := range aliases {
+		if alias.start >= end || start >= alias.end {
 			continue
 		}
 		offset := int((alias.start - start) / size)
 		heap[alias.addr] = types.TypedArray[T](backing[offset : offset+len(alias.array)])
 		cloned[alias.addr] = true
-	}
-}
-
-func mutationTarget(i *Interpreter) (int, types.Value, bool) {
-	if i.sp < 3 || i.stack[i.sp-3].Kind() != types.KindRef {
-		return 0, nil, false
-	}
-	addr := i.stack[i.sp-3].Ref()
-	if addr <= 0 || addr >= len(i.heap) {
-		return 0, nil, false
-	}
-	return addr, i.heap[addr], true
-}
-
-func primitiveArray(i *Interpreter) bool {
-	_, value, ok := mutationTarget(i)
-	if !ok {
-		return false
-	}
-	switch value.(type) {
-	case types.TypedArray[bool],
-		types.TypedArray[int8],
-		types.TypedArray[int32],
-		types.TypedArray[int64],
-		types.TypedArray[float32],
-		types.TypedArray[float64]:
-		return true
-	default:
-		return false
 	}
 }
 
@@ -751,16 +752,6 @@ func (r *Tracer) headers(i *Interpreter, addr int) []int {
 	}
 	r.loops[addr] = hs
 	return hs
-}
-
-func (r *Tracer) exitIndex(tree *tree, target anchor) int {
-	if idx, ok := tree.exits[target]; ok {
-		return idx
-	}
-	idx := len(tree.hits)
-	tree.exits[target] = idx
-	tree.hits = append(tree.hits, 0)
-	return idx
 }
 
 func (r *Tracer) unrecordableReason(i *Interpreter, op instr.Opcode) prof.CaptureReason {

--- a/interp/trace_test.go
+++ b/interp/trace_test.go
@@ -93,21 +93,40 @@ func TestTracer_Capture(t *testing.T) {
 		require.Equal(t, instr.I32_CONST, result.trace.ops[len(result.trace.ops)-1].op)
 	})
 
-	t.Run("isolates primitive array writes", func(t *testing.T) {
-		array := types.TypedArray[int32]{1}
-		tracer := NewTracer()
-		prog := program.New([]instr.Instruction{
-			instr.New(instr.CONST_GET, 0),
-			instr.New(instr.I32_CONST, 0),
-			instr.New(instr.I32_CONST, 2),
-			instr.New(instr.ARRAY_SET),
-		}, program.WithConstants(array))
-		i := New(prog, WithTracer(tracer), WithThreshold(-1))
-		defer i.Close()
+	t.Run("isolates captured mutations", func(t *testing.T) {
+		primitive := types.TypedArray[int32]{1}
+		array := types.NewArray(types.TypeI32Array, types.BoxI32(1))
+		structure := types.NewStruct(
+			types.NewStructType(types.NewStructField(types.TypeI32)),
+			types.BoxI32(1),
+		)
+		tests := []struct {
+			name  string
+			value types.Value
+			op    instr.Opcode
+			read  func() types.Boxed
+		}{
+			{name: "primitive array", value: primitive, op: instr.ARRAY_SET, read: func() types.Boxed { return types.BoxI32(primitive[0]) }},
+			{name: "boxed array", value: array, op: instr.ARRAY_SET, read: func() types.Boxed { return array.Elems[0] }},
+			{name: "struct", value: structure, op: instr.STRUCT_SET, read: func() types.Boxed { return structure.Field(0) }},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tracer := NewTracer()
+				prog := program.New([]instr.Instruction{
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.I32_CONST, 0),
+					instr.New(instr.I32_CONST, 2),
+					instr.New(tt.op),
+				}, program.WithConstants(tt.value))
+				i := New(prog, WithTracer(tracer), WithThreshold(-1))
+				defer i.Close()
 
-		_, err := tracer.capture(i, anchor{})
-		require.NoError(t, err)
-		require.Equal(t, int32(1), array[0])
+				_, err := tracer.capture(i, anchor{})
+				require.NoError(t, err)
+				require.Equal(t, types.BoxI32(1), tt.read())
+			})
+		}
 	})
 
 	t.Run("cuts an oversized trace at a resumable boundary", func(t *testing.T) {
@@ -232,7 +251,7 @@ func TestTracer_Capture(t *testing.T) {
 		require.Nil(t, tracer.rootAt(root))
 	})
 
-	t.Run("does not deadlock when recording reclaims a function", func(t *testing.T) {
+	t.Run("isolates function reclamation", func(t *testing.T) {
 		tracer := NewTracer()
 		i := New(
 			program.New([]instr.Instruction{instr.New(instr.DROP)}),
@@ -241,7 +260,12 @@ func TestTracer_Capture(t *testing.T) {
 		)
 		defer i.Close()
 
-		addr := i.keep(&types.Function{Code: []byte{byte(instr.NOP)}})
+		fn := &types.Function{Code: []byte{byte(instr.NOP)}}
+		addr := i.keep(fn)
+		i.bind(addr, fn, true)
+		root := anchor{addr: addr}
+		tracer.trees[root] = &tree{root: &trace{anchor: root, kind: completed}}
+		require.NotEmpty(t, tracer.exactCodes(i)[addr])
 		i.stack[0] = types.BoxRef(addr)
 		i.sp = 1
 
@@ -258,6 +282,29 @@ func TestTracer_Capture(t *testing.T) {
 			t.Fatal("capture deadlocked while reclaiming a function")
 		}
 		require.NotNil(t, tracer.rootAt(anchor{}))
+		require.NotNil(t, tracer.rootAt(root))
+		require.NotEmpty(t, i.instrs[addr])
+		require.NotEmpty(t, tracer.exactCodes(i)[addr])
+		require.True(t, i.dynamic[addr])
+	})
+
+	t.Run("does not finalize live values while recording", func(t *testing.T) {
+		tracer := NewTracer()
+		i := New(
+			program.New([]instr.Instruction{instr.New(instr.DROP)}),
+			WithTracer(tracer),
+			WithThreshold(-1),
+		)
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr := i.keep(value)
+		i.stack[0] = types.BoxRef(addr)
+		i.sp = 1
+
+		_, err := tracer.capture(i, anchor{})
+		require.NoError(t, err)
+		require.Zero(t, value.closed)
 	})
 
 	t.Run("does not publish aborted traces", func(t *testing.T) {
@@ -349,11 +396,11 @@ func TestTracer_IsolatesPrograms(t *testing.T) {
 
 	left := New(first, WithTracer(tracer), WithThreshold(-1))
 	defer left.Close()
-	before := tracer.codes(left)
+	before := tracer.exactCodes(left)
 
 	right := New(second, WithTracer(tracer), WithThreshold(-1))
 	defer right.Close()
-	after := right.tracer.codes(right)
+	after := right.tracer.exactCodes(right)
 
 	require.Same(t, tracer, left.tracer)
 	require.NotSame(t, tracer, right.tracer)
@@ -369,7 +416,7 @@ func TestTracer_Remove(t *testing.T) {
 	i := New(first, WithTracer(tracer), WithThreshold(-1))
 	defer i.Close()
 
-	exact := tracer.codes(i)
+	exact := tracer.exactCodes(i)
 	require.NotNil(t, exact[1])
 	tracer.remove(1)
 	require.Nil(t, tracer.exact)
@@ -379,6 +426,6 @@ func TestTracer_Remove(t *testing.T) {
 		Build()
 	require.NoError(t, err)
 	i.bind(1, second, true)
-	rebuilt := tracer.codes(i)
+	rebuilt := tracer.exactCodes(i)
 	require.NotSame(t, &exact[1][0], &rebuilt[1][0])
 }

--- a/interp/trace_test.go
+++ b/interp/trace_test.go
@@ -44,8 +44,7 @@ func TestTracer_Capture(t *testing.T) {
 		i := New(prog, WithTracer(tracer), WithThreshold(-1))
 		defer i.Close()
 
-		result, err := tracer.capture(i, anchor{addr: i.fr.addr, ip: 0})
-		require.NoError(t, err)
+		result := tracer.capture(i, anchor{addr: i.fr.addr, ip: 0})
 		require.NotNil(t, result.trace)
 		tr := result.trace
 		require.Equal(t, completed, tr.kind)
@@ -64,8 +63,7 @@ func TestTracer_Capture(t *testing.T) {
 		i := New(prog, WithTracer(tracer), WithThreshold(-1))
 		defer i.Close()
 
-		result, err := tracer.capture(i, anchor{addr: i.fr.addr, ip: 0})
-		require.NoError(t, err)
+		result := tracer.capture(i, anchor{addr: i.fr.addr, ip: 0})
 		require.NotNil(t, result.trace)
 		tr := result.trace
 		require.Equal(t, returned, tr.kind)
@@ -86,8 +84,7 @@ func TestTracer_Capture(t *testing.T) {
 		i := New(prog, WithTracer(tracer), WithThreshold(-1))
 		defer i.Close()
 
-		result, err := tracer.capture(i, anchor{})
-		require.NoError(t, err)
+		result := tracer.capture(i, anchor{})
 		require.NotNil(t, result.trace)
 		require.Equal(t, completed, result.trace.kind)
 		require.Equal(t, instr.I32_CONST, result.trace.ops[len(result.trace.ops)-1].op)
@@ -122,8 +119,7 @@ func TestTracer_Capture(t *testing.T) {
 				i := New(prog, WithTracer(tracer), WithThreshold(-1))
 				defer i.Close()
 
-				_, err := tracer.capture(i, anchor{})
-				require.NoError(t, err)
+				tracer.capture(i, anchor{})
 				require.Equal(t, types.BoxI32(1), tt.read())
 			})
 		}
@@ -158,8 +154,7 @@ func TestTracer_Capture(t *testing.T) {
 				i := New(prog, WithTracer(tracer), WithThreshold(-1))
 				defer i.Close()
 
-				result, err := tracer.capture(i, anchor{})
-				require.NoError(t, err)
+				result := tracer.capture(i, anchor{})
 				require.NotNil(t, result.trace)
 				require.Equal(t, types.BoxI32(1), result.trace.ops[len(result.trace.ops)-1].seen)
 				require.Zero(t, tt.original())
@@ -176,8 +171,7 @@ func TestTracer_Capture(t *testing.T) {
 		i := New(program.New(code), WithTracer(tracer), WithThreshold(-1))
 		defer i.Close()
 
-		result, err := tracer.capture(i, anchor{addr: 0, ip: 0})
-		require.NoError(t, err)
+		result := tracer.capture(i, anchor{addr: 0, ip: 0})
 		require.NotNil(t, result.trace)
 		tr := result.trace
 		require.Equal(t, partial, tr.kind)
@@ -200,8 +194,7 @@ func TestTracer_Capture(t *testing.T) {
 		i := New(prog, WithTracer(tracer), WithThreshold(-1))
 		defer i.Close()
 
-		result, err := tracer.capture(i, anchor{addr: 0, ip: 0})
-		require.NoError(t, err)
+		result := tracer.capture(i, anchor{addr: 0, ip: 0})
 		require.NotNil(t, result.trace)
 		tr := result.trace
 		require.Equal(t, partial, tr.kind)
@@ -222,11 +215,11 @@ func TestTracer_Capture(t *testing.T) {
 
 		const workers = attemptLimit + 1
 		interpreters := make([]*Interpreter, workers)
-		errs := make(chan error, workers)
+		done := make(chan struct{}, workers)
 		interpreters[0] = New(prog, WithTracer(tracer), WithThreshold(-1))
 		go func() {
-			_, err := tracer.capture(interpreters[0], anchor{})
-			errs <- err
+			tracer.capture(interpreters[0], anchor{})
+			done <- struct{}{}
 		}()
 		<-iter.entered
 
@@ -236,8 +229,8 @@ func TestTracer_Capture(t *testing.T) {
 			interpreters[idx] = i
 			go func() {
 				started <- struct{}{}
-				_, err := tracer.capture(i, anchor{})
-				errs <- err
+				tracer.capture(i, anchor{})
+				done <- struct{}{}
 			}()
 		}
 		for range workers - 1 {
@@ -246,7 +239,7 @@ func TestTracer_Capture(t *testing.T) {
 		close(release)
 
 		for range workers {
-			require.NoError(t, <-errs)
+			<-done
 		}
 		for _, i := range interpreters {
 			require.NoError(t, i.Close())
@@ -275,15 +268,15 @@ func TestTracer_Capture(t *testing.T) {
 		tree := tracer.tree(root)
 		tree.root = &trace{anchor: root, kind: completed}
 
-		done := make(chan error, 1)
+		done := make(chan struct{}, 1)
 		go func() {
-			_, err := tracer.exit(i, root, anchor{addr: 0, ip: 1})
-			done <- err
+			tracer.branch(i, root, anchor{addr: 0, ip: 1})
+			done <- struct{}{}
 		}()
 		<-iter.entered
 		tracer.remove(0)
 		close(release)
-		require.NoError(t, <-done)
+		<-done
 
 		require.Empty(t, tree.branches)
 		require.Nil(t, tracer.rootAt(root))
@@ -307,15 +300,14 @@ func TestTracer_Capture(t *testing.T) {
 		i.stack[0] = types.BoxRef(addr)
 		i.sp = 1
 
-		done := make(chan error, 1)
+		done := make(chan struct{}, 1)
 		go func() {
-			_, err := tracer.capture(i, anchor{})
-			done <- err
+			tracer.capture(i, anchor{})
+			done <- struct{}{}
 		}()
 
 		select {
-		case err := <-done:
-			require.NoError(t, err)
+		case <-done:
 		case <-time.After(time.Second):
 			t.Fatal("capture deadlocked while reclaiming a function")
 		}
@@ -340,8 +332,7 @@ func TestTracer_Capture(t *testing.T) {
 		i.stack[0] = types.BoxRef(addr)
 		i.sp = 1
 
-		_, err := tracer.capture(i, anchor{})
-		require.NoError(t, err)
+		tracer.capture(i, anchor{})
 		require.Zero(t, value.closed)
 	})
 
@@ -355,8 +346,7 @@ func TestTracer_Capture(t *testing.T) {
 		defer i.Close()
 
 		for range attemptLimit + 1 {
-			tr, err := tracer.capture(i, anchor{})
-			require.NoError(t, err)
+			tr := tracer.capture(i, anchor{})
 			require.Nil(t, tr.trace)
 		}
 

--- a/interp/trace_test.go
+++ b/interp/trace_test.go
@@ -73,6 +73,43 @@ func TestTracer_Capture(t *testing.T) {
 		require.Equal(t, instr.YIELD, tr.ops[len(tr.ops)-1].op)
 	})
 
+	t.Run("continues after primitive array set", func(t *testing.T) {
+		array := types.TypedArray[int32]{1}
+		tracer := NewTracer()
+		prog := program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.ARRAY_SET),
+			instr.New(instr.I32_CONST, 7),
+		}, program.WithConstants(array))
+		i := New(prog, WithTracer(tracer), WithThreshold(-1))
+		defer i.Close()
+
+		result, err := tracer.capture(i, anchor{})
+		require.NoError(t, err)
+		require.NotNil(t, result.trace)
+		require.Equal(t, completed, result.trace.kind)
+		require.Equal(t, instr.I32_CONST, result.trace.ops[len(result.trace.ops)-1].op)
+	})
+
+	t.Run("isolates primitive array writes", func(t *testing.T) {
+		array := types.TypedArray[int32]{1}
+		tracer := NewTracer()
+		prog := program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.I32_CONST, 2),
+			instr.New(instr.ARRAY_SET),
+		}, program.WithConstants(array))
+		i := New(prog, WithTracer(tracer), WithThreshold(-1))
+		defer i.Close()
+
+		_, err := tracer.capture(i, anchor{})
+		require.NoError(t, err)
+		require.Equal(t, int32(1), array[0])
+	})
+
 	t.Run("cuts an oversized trace at a resumable boundary", func(t *testing.T) {
 		code := make([]instr.Instruction, opLimit+1)
 		for j := range code {

--- a/interp/trace_test.go
+++ b/interp/trace_test.go
@@ -129,6 +129,44 @@ func TestTracer_Capture(t *testing.T) {
 		}
 	})
 
+	t.Run("preserves typed array aliases", func(t *testing.T) {
+		shared := types.TypedArray[int32]{0}
+		backing := types.TypedArray[int32]{0, 0, 0}
+		tests := []struct {
+			name      string
+			first     types.TypedArray[int32]
+			second    types.TypedArray[int32]
+			setIndex  uint64
+			readIndex uint64
+			original  func() int32
+		}{
+			{name: "same slice", first: shared, second: shared, original: func() int32 { return shared[0] }},
+			{name: "overlapping subslices", first: backing[:2:2], second: backing[1:3], setIndex: 1, original: func() int32 { return backing[1] }},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tracer := NewTracer()
+				prog := program.New([]instr.Instruction{
+					instr.New(instr.CONST_GET, 0),
+					instr.New(instr.I32_CONST, tt.setIndex),
+					instr.New(instr.I32_CONST, 1),
+					instr.New(instr.ARRAY_SET),
+					instr.New(instr.CONST_GET, 1),
+					instr.New(instr.I32_CONST, tt.readIndex),
+					instr.New(instr.ARRAY_GET),
+				}, program.WithConstants(tt.first, tt.second))
+				i := New(prog, WithTracer(tracer), WithThreshold(-1))
+				defer i.Close()
+
+				result, err := tracer.capture(i, anchor{})
+				require.NoError(t, err)
+				require.NotNil(t, result.trace)
+				require.Equal(t, types.BoxI32(1), result.trace.ops[len(result.trace.ops)-1].seen)
+				require.Zero(t, tt.original())
+			})
+		}
+	})
+
 	t.Run("cuts an oversized trace at a resumable boundary", func(t *testing.T) {
 		code := make([]instr.Instruction, opLimit+1)
 		for j := range code {


### PR DESCRIPTION
## Summary

- allow module loop roots at address zero and cache JIT attempts per exact anchor
- observe exact unconditional back-edges so loop traces compile without repeated failed attempts
- keep guarded primitive `ARRAY_SET` operations inside ARM64 native traces while preserving safe side exits
- reduce register pressure in mutation lowering and isolate speculative array/struct writes during tracing
- expand Sieve and JIT regression coverage
- refresh all current benchmark documentation from sequential three-sample medians

## Review follow-up

Repeated code-quality reviews tightened the implementation beyond the initial performance fix:

- replace the shared cache's single pending slot with a coalescing exact-anchor queue
- retain distinct loop roots, prioritize side exits in FIFO order, and deduplicate active/pending requests
- keep cold functions on the ordinary `BR` handler and rethread once only after periodic sampling marks them hot
- preserve installed native handlers while updating their threaded fallbacks
- preserve typed-array alias topology during speculative capture without constructing out-of-range unsafe slices
- isolate speculative mutation, dynamic-function reclamation, trace metadata, and external finalizers from live interpreter state
- remove dead tracer error plumbing and ambiguous `Tracer.exit` naming
- merge mutation lookup/classification/cloning and remove `mutationTarget`, `primitiveArray`, `branchIndex`, `isLeaf`, and duplicate `zeroValue`
- make generated-dispatch construction side-effect free and reuse the sample count across hotness decisions
- rename loop, trace-clone, continuation-tail, and ARM64 heap-load helpers by role; inline the single-use sampled-loop helper
- align helper declaration order, field grouping, and test ownership with `docs/coding-patterns.md`
- inline important bytecode fixtures so tests remain executable public behavior specifications

Local added-executable-line coverage now covers every new shared-cache branch; the remaining uncovered ARM64 paths are primarily register-exhaustion and compile-rejection defenses.

## Performance

Apple M4 Pro, `darwin/arm64`, Go 1.26.2:

| Sieve(256) mode | Before | Documented after | Review follow-up median | Allocation |
|---|---:|---:|---:|---:|
| default | ~36.6–37.4 us | 5.269 us | 5.052 us | 1,048 B/op, 2 allocs/op |
| threaded | ~15.4–15.6 us | 16.143 us | 15.385 us | 1,048 B/op, 2 allocs/op |
| eager JIT | ~36.8–37.0 us | 5.261 us | 5.017 us | 1,048 B/op, 2 allocs/op |

Default and eager JIT remain about 3x faster than threaded execution for this workload. Repeated JIT compilation allocations remain reduced from roughly 407 allocs/op to 2 allocs/op.

## Verification

- `make check`
- `go test -race ./interp -count=1`
- `cd benchmarks && go test ./... -count=1 -timeout=120s`
- `go test -run='^$' -bench='^BenchmarkInterpreter_ColdBackedge$' -benchmem -benchtime=300ms -count=3` — median 2.446 us, 0 allocs/op
- `go test -run='^$' -bench='^BenchmarkControl_Sieve' -benchmem -benchtime=300ms -count=3`
- full external comparison with `-benchtime=300ms -count=3`
- automated documentation cross-check: 90 comparison rows, 19 public API rows, 20 threaded rows, and 7 reference traversal rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved ARM64 JIT handling for primitive typed-array and struct/array mutations, enabling safer continuation for primitive typed-array writes.
  - Refined JIT warmup, loop/backedge capture timing, and threshold-zero behavior.
  - Improved compilation eligibility and request queuing behavior for more predictable warmup outcomes.

- **Documentation**
  - Refreshed benchmark methodology and results (including updated labels and medians) and clarified the “current measurements” framing.
  - Updated JIT internals, architecture, and profiling notes.

- **Tests**
  - Expanded ARM64 backedge and typed-array mutation coverage, plus stronger cache and tracing isolation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

