### PR TITLE
perf(interp): defer ref operand ownership to backing slots in the ARM64 JIT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,7 @@ Violations cause silent corruption or invalid execution.
 - A JIT trace fragment's own `kind` (outcome), not the root trace's, decides whether `arm64Lowerer.walk` may lower it as a normal completion when its ops run out; only `aborted` must never fall through as completion.
 - `tree.branchIPs()` excludes `aborted` branches from continuation-inlining eligibility; a fragment that recorded a partial, unsupported prefix must never be inlined into a parent trace.
 - `interp/jit.go`'s `spillSafe` must scan the whole trace tree (root plus every branch it may inline), not just the root's last op, before deciding a trace is safe to spill.
+- A deferred (slot-backed or const) ref operand carries no retain of its own; it must be owned or redeemed before any path that hands the flushed operand stack to the interpreter (ownership transfer, guard exit stub, trap-fallback/module-completion redeem, or a real call), and a committing (loop back-edge) flush rejects any live deferred ref.
 
 ## Tests
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -174,6 +174,7 @@ The interpreter requests native compilation through `compiler.Compile(i, root)` 
 - Guard failure materializes VM state and resumes threaded dispatch.
 - ARM64 label branches are range-checked and relaxed only to replacements that are already in range; an unreachable target falls back to threaded execution.
 - Spill frames use a stable base register, and every internal call resume point must restore the active spill-frame depth. Loop traces and plans containing heap mutation disable spilling when control flow cannot preserve that contract.
+- A ref operand may be compiled deferred, borrowing its retain from backing storage. Every path handing the flushed operand stack to the interpreter must own or redeem it first, and a committing loop-backedge flush rejects any live deferred ref.
 
 See `jit-internals.md` for trace recording, journal layout, calls, branches, loops, and fallback rules.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -21,7 +21,7 @@ For implementation details, see `docs/jit-internals.md`. For profiling counters,
 
 ## Measurement Environment
 
-All numbers in this document were measured on July 15, 2026:
+All numbers in this document were measured on July 16, 2026:
 
 - Apple M4 Pro, 12 cores
 - `darwin/arm64`
@@ -57,12 +57,12 @@ go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
 
 ## Summary
 
-- `RecursiveFib(35)` places `minivm/default` at **48.43 ms**, within about **3.5%** of wazero's **46.79 ms**, while remaining allocation-free after warmup.
-- Adaptive native traces reduce `IterativeFib(30)` from **730.9 ns** threaded to **71.83 ns**, `TypedArraySum(256)` from **6.239 us** to **655.2 ns**, and `BranchTree(96)` from **986.4 ns** to **228.0 ns**.
-- Primitive array mutation stays on the native loop path in `Sieve(256)`: `default` is **5.052 us** and eager `jit` is **5.017 us**, versus **15.385 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
+- `RecursiveFib(35)` places `minivm/default` at **46.30 ms**, within about **2.6%** of wazero's **45.11 ms**, while remaining allocation-free after warmup.
+- Adaptive native traces reduce `IterativeFib(30)` from **738.6 ns** threaded to **76.14 ns**, `TypedArraySum(256)` from **6.299 us** to **669.0 ns**, and `BranchTree(96)` from **981.8 ns** to **235.1 ns**.
+- Primitive array mutation stays on the native loop path in `Sieve(256)`: deferred-ownership elision drops the per-element retain/release pair, so a runtime-allocated array reaches the same cheap native path a typed-array constant already used. `default` is **4.722 us** and eager `jit` is **4.719 us**, versus **16.172 us** threaded. All three modes allocate `1,048 B` in `2` allocations.
 - Threshold-zero `jit` is not a warmed-JIT guarantee. It matches `default` on Sieve and BranchTree, but is slower on IterativeFib, TypedArraySum, and recursive Fibonacci because it can compile before representative traces are learned.
-- Allocation-heavy workloads remain interpreter-bound. `AllocationGraph(128)` is fastest in minivm's threaded mode at **7.513 us**; adaptive and eager modes add profiling cost without native coverage.
-- Indirect recursion reaches the native self-call path in adaptive mode: `IndirectRecursiveFib(20)` is **80.55 us** in `default`, versus **557 us** threaded and **41.8 us** in wazero. Eager `jit` stays at **575 us**, consistent with the threshold-zero note above.
+- Allocation-heavy workloads remain interpreter-bound. `AllocationGraph(128)` is fastest in minivm's threaded mode at **7.617 us**; adaptive and eager modes add profiling cost without native coverage.
+- Indirect recursion reaches the native self-call path in adaptive mode: `IndirectRecursiveFib(20)` is **54.94 us** in `default`, versus **568 us** threaded and **42.3 us** in wazero. Eager `jit` stays at **589 us**, consistent with the threshold-zero note above.
 
 These results are workload measurements, not general language rankings. The runtimes use different value models, safety boundaries, host-call conventions, and compilation strategies.
 
@@ -84,96 +84,96 @@ Each minivm kernel times `Interpreter.Run` only. Result extraction, reset, fixtu
 
 | Workload | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| IterativeFib(30) | minivm/default | 71.83 | 0 | 0 |
-| IterativeFib(30) | minivm/threaded | 730.9 | 0 | 0 |
-| IterativeFib(30) | minivm/jit | 108.6 | 0 | 0 |
-| IterativeFib(30) | native Go | 8.337 | 0 | 0 |
-| IterativeFib(30) | wazero | 49.84 | 8 | 1 |
-| IterativeFib(30) | Tengo | 9,722 | 90,592 | 61 |
-| IterativeFib(30) | gopher-lua | 494.4 | 160 | 0 |
-| IterativeFib(30) | Goja | 2,166 | 368 | 20 |
-| IterativeFib(30) | gpython | 2,427 | 2,448 | 88 |
-| IterativeFib(30) | Yaegi | 2,709 | 2,036 | 101 |
-| Sieve(256) | minivm/default | 5,052 | 1,048 | 2 |
-| Sieve(256) | minivm/threaded | 15,385 | 1,048 | 2 |
-| Sieve(256) | minivm/jit | 5,017 | 1,048 | 2 |
-| Sieve(256) | native Go | 247.8 | 0 | 0 |
-| Sieve(256) | wazero | 645.4 | 8 | 1 |
-| Sieve(256) | Tengo | 51,918 | 122,504 | 1,611 |
-| Sieve(256) | gopher-lua | 22,102 | 18,416 | 44 |
-| Sieve(256) | Goja | 41,769 | 1,872 | 25 |
-| Sieve(256) | gpython | 34,104 | 5,704 | 30 |
-| Sieve(256) | Yaegi | 18,673 | 1,800 | 37 |
-| RecursiveFib(20) | minivm/default | 41,053 | 0 | 0 |
-| RecursiveFib(20) | minivm/threaded | 377,151 | 0 | 0 |
-| RecursiveFib(20) | minivm/jit | 395,583 | 0 | 0 |
-| RecursiveFib(20) | native Go | 15,333 | 0 | 0 |
-| RecursiveFib(20) | wazero | 34,224 | 8 | 1 |
-| RecursiveFib(20) | Tengo | 915,188 | 319,346 | 28,655 |
-| RecursiveFib(20) | gopher-lua | 1,130,909 | 704 | 2 |
-| RecursiveFib(20) | Goja | 1,529,105 | 4,680 | 39 |
-| RecursiveFib(20) | gpython | 4,124,278 | 9,807,929 | 109,494 |
-| RecursiveFib(20) | Yaegi | 4,258,056 | 8,302,133 | 192,840 |
-| RecursiveFib(35) | minivm/default | 48,426,669 | 0 | 0 |
-| RecursiveFib(35) | minivm/threaded | 512,675,498 | 0 | 0 |
-| RecursiveFib(35) | minivm/jit | 539,464,080 | 0 | 0 |
-| RecursiveFib(35) | native Go | 20,957,448 | 0 | 0 |
-| RecursiveFib(35) | wazero | 46,785,131 | 9 | 1 |
-| RecursiveFib(35) | Tengo | 1,171,601,625 | 312,797,728 | 39,088,178 |
-| RecursiveFib(35) | gopher-lua | 1,475,545,292 | 971,008 | 3,793 |
-| RecursiveFib(35) | Goja | 2,033,197,667 | 375,360 | 46,373 |
-| RecursiveFib(35) | gpython | 5,238,414,292 | 13,378,035,520 | 149,350,319 |
-| RecursiveFib(35) | Yaegi | 5,439,306,583 | 11,324,340,056 | 263,043,718 |
-| IndirectRecursiveFib(20) | minivm/default | 80,548 | 0 | 0 |
-| IndirectRecursiveFib(20) | minivm/threaded | 556,996 | 0 | 0 |
-| IndirectRecursiveFib(20) | minivm/jit | 575,222 | 0 | 0 |
-| IndirectRecursiveFib(20) | native Go | 15,610 | 0 | 0 |
-| IndirectRecursiveFib(20) | wazero | 41,827 | 8 | 1 |
-| IndirectRecursiveFib(20) | Tengo | 919,605 | 319,345 | 28,655 |
-| IndirectRecursiveFib(20) | gopher-lua | 935,191 | 704 | 2 |
-| IndirectRecursiveFib(20) | Goja | 1,335,157 | 4,680 | 39 |
-| IndirectRecursiveFib(20) | gpython | 3,757,153 | 10,158,202 | 109,494 |
-| IndirectRecursiveFib(20) | Yaegi | 10,576,088 | 13,059,851 | 394,041 |
-| ClosureCounter(128) | minivm/default | 3,089 | 64 | 2 |
-| ClosureCounter(128) | minivm/threaded | 2,877 | 64 | 2 |
-| ClosureCounter(128) | minivm/jit | 3,119 | 64 | 2 |
-| ClosureCounter(128) | native Go | 33.77 | 0 | 0 |
+| IterativeFib(30) | minivm/default | 76.14 | 0 | 0 |
+| IterativeFib(30) | minivm/threaded | 738.6 | 0 | 0 |
+| IterativeFib(30) | minivm/jit | 109.1 | 0 | 0 |
+| IterativeFib(30) | native Go | 8.757 | 0 | 0 |
+| IterativeFib(30) | wazero | 50.26 | 8 | 1 |
+| IterativeFib(30) | Tengo | 9,966 | 90,592 | 61 |
+| IterativeFib(30) | gopher-lua | 511.6 | 160 | 0 |
+| IterativeFib(30) | Goja | 2,218 | 368 | 20 |
+| IterativeFib(30) | gpython | 2,590 | 2,448 | 88 |
+| IterativeFib(30) | Yaegi | 2,801 | 2,036 | 101 |
+| Sieve(256) | minivm/default | 4,722 | 1,048 | 2 |
+| Sieve(256) | minivm/threaded | 16,172 | 1,048 | 2 |
+| Sieve(256) | minivm/jit | 4,719 | 1,048 | 2 |
+| Sieve(256) | native Go | 238.3 | 0 | 0 |
+| Sieve(256) | wazero | 662.8 | 8 | 1 |
+| Sieve(256) | Tengo | 53,437 | 122,504 | 1,611 |
+| Sieve(256) | gopher-lua | 23,269 | 18,416 | 44 |
+| Sieve(256) | Goja | 43,554 | 1,872 | 25 |
+| Sieve(256) | gpython | 36,598 | 5,704 | 30 |
+| Sieve(256) | Yaegi | 18,655 | 1,800 | 37 |
+| RecursiveFib(20) | minivm/default | 37,417 | 0 | 0 |
+| RecursiveFib(20) | minivm/threaded | 351,637 | 0 | 0 |
+| RecursiveFib(20) | minivm/jit | 362,772 | 0 | 0 |
+| RecursiveFib(20) | native Go | 13,553 | 0 | 0 |
+| RecursiveFib(20) | wazero | 31,262 | 8 | 1 |
+| RecursiveFib(20) | Tengo | 841,631 | 319,345 | 28,655 |
+| RecursiveFib(20) | gopher-lua | 1,032,737 | 704 | 2 |
+| RecursiveFib(20) | Goja | 1,476,390 | 4,680 | 39 |
+| RecursiveFib(20) | gpython | 3,764,356 | 9,807,927 | 109,494 |
+| RecursiveFib(20) | Yaegi | 3,840,787 | 8,302,122 | 192,840 |
+| RecursiveFib(35) | minivm/default | 46,303,288 | 0 | 0 |
+| RecursiveFib(35) | minivm/threaded | 490,321,941 | 0 | 0 |
+| RecursiveFib(35) | minivm/jit | 508,171,481 | 0 | 0 |
+| RecursiveFib(35) | native Go | 19,463,741 | 0 | 0 |
+| RecursiveFib(35) | wazero | 45,112,434 | 9 | 1 |
+| RecursiveFib(35) | Tengo | 1,180,099,833 | 312,797,184 | 39,088,173 |
+| RecursiveFib(35) | gopher-lua | 1,453,945,708 | 971,008 | 3,793 |
+| RecursiveFib(35) | Goja | 2,058,714,041 | 375,360 | 46,373 |
+| RecursiveFib(35) | gpython | 5,364,887,708 | 13,378,034,960 | 149,350,308 |
+| RecursiveFib(35) | Yaegi | 5,537,717,750 | 11,324,340,872 | 263,043,707 |
+| IndirectRecursiveFib(20) | minivm/default | 54,937 | 0 | 0 |
+| IndirectRecursiveFib(20) | minivm/threaded | 567,896 | 0 | 0 |
+| IndirectRecursiveFib(20) | minivm/jit | 589,191 | 0 | 0 |
+| IndirectRecursiveFib(20) | native Go | 16,040 | 0 | 0 |
+| IndirectRecursiveFib(20) | wazero | 42,331 | 8 | 1 |
+| IndirectRecursiveFib(20) | Tengo | 958,917 | 319,345 | 28,655 |
+| IndirectRecursiveFib(20) | gopher-lua | 944,516 | 704 | 2 |
+| IndirectRecursiveFib(20) | Goja | 1,366,603 | 4,680 | 39 |
+| IndirectRecursiveFib(20) | gpython | 3,961,904 | 10,158,200 | 109,494 |
+| IndirectRecursiveFib(20) | Yaegi | 11,013,641 | 13,059,857 | 394,041 |
+| ClosureCounter(128) | minivm/default | 3,159 | 64 | 2 |
+| ClosureCounter(128) | minivm/threaded | 3,021 | 64 | 2 |
+| ClosureCounter(128) | minivm/jit | 3,159 | 64 | 2 |
+| ClosureCounter(128) | native Go | 34.99 | 0 | 0 |
 | ClosureCounter(128) | wazero | N/A | N/A | N/A |
-| ClosureCounter(128) | Tengo | 12,936 | 92,272 | 261 |
-| ClosureCounter(128) | gopher-lua | 5,720 | 152 | 3 |
-| ClosureCounter(128) | Goja | 9,752 | 1,264 | 13 |
-| ClosureCounter(128) | gpython | 26,111 | 58,312 | 659 |
-| ClosureCounter(128) | Yaegi | 32,116 | 34,784 | 786 |
-| TypedArraySum(256) | minivm/default | 655.2 | 0 | 0 |
-| TypedArraySum(256) | minivm/threaded | 6,239 | 0 | 0 |
-| TypedArraySum(256) | minivm/jit | 3,484 | 0 | 0 |
-| TypedArraySum(256) | native Go | 64.34 | 0 | 0 |
-| TypedArraySum(256) | wazero | 151.9 | 8 | 1 |
-| TypedArraySum(256) | Tengo | 15,603 | 94,208 | 513 |
-| TypedArraySum(256) | gopher-lua | 3,291 | 4,000 | 15 |
-| TypedArraySum(256) | Goja | 12,877 | 2,080 | 238 |
-| TypedArraySum(256) | gpython | 7,210 | 2,496 | 246 |
-| TypedArraySum(256) | Yaegi | 3,897 | 296 | 8 |
-| AllocationGraph(128) | minivm/default | 9,044 | 5,120 | 256 |
-| AllocationGraph(128) | minivm/threaded | 7,513 | 5,120 | 256 |
-| AllocationGraph(128) | minivm/jit | 9,099 | 5,120 | 256 |
-| AllocationGraph(128) | native Go | 906.1 | 1,024 | 128 |
+| ClosureCounter(128) | Tengo | 13,287 | 92,272 | 261 |
+| ClosureCounter(128) | gopher-lua | 5,842 | 151 | 3 |
+| ClosureCounter(128) | Goja | 10,144 | 1,264 | 13 |
+| ClosureCounter(128) | gpython | 27,037 | 58,312 | 659 |
+| ClosureCounter(128) | Yaegi | 33,173 | 34,784 | 786 |
+| TypedArraySum(256) | minivm/default | 669.0 | 0 | 0 |
+| TypedArraySum(256) | minivm/threaded | 6,299 | 0 | 0 |
+| TypedArraySum(256) | minivm/jit | 3,537 | 0 | 0 |
+| TypedArraySum(256) | native Go | 66.26 | 0 | 0 |
+| TypedArraySum(256) | wazero | 153.5 | 8 | 1 |
+| TypedArraySum(256) | Tengo | 15,676 | 94,208 | 513 |
+| TypedArraySum(256) | gopher-lua | 3,415 | 4,000 | 15 |
+| TypedArraySum(256) | Goja | 13,303 | 2,080 | 238 |
+| TypedArraySum(256) | gpython | 7,776 | 2,496 | 246 |
+| TypedArraySum(256) | Yaegi | 4,002 | 296 | 8 |
+| AllocationGraph(128) | minivm/default | 9,226 | 5,120 | 256 |
+| AllocationGraph(128) | minivm/threaded | 7,617 | 5,120 | 256 |
+| AllocationGraph(128) | minivm/jit | 9,199 | 5,120 | 256 |
+| AllocationGraph(128) | native Go | 935.5 | 1,024 | 128 |
 | AllocationGraph(128) | wazero | N/A | N/A | N/A |
-| AllocationGraph(128) | Tengo | 13,677 | 96,288 | 388 |
-| AllocationGraph(128) | gopher-lua | 6,030 | 14,376 | 256 |
-| AllocationGraph(128) | Goja | 24,285 | 78,016 | 770 |
-| AllocationGraph(128) | gpython | 5,431 | 5,712 | 266 |
-| AllocationGraph(128) | Yaegi | 11,804 | 1,492 | 142 |
-| BranchTree(96) | minivm/default | 228 | 0 | 0 |
-| BranchTree(96) | minivm/threaded | 986.4 | 0 | 0 |
-| BranchTree(96) | minivm/jit | 230 | 0 | 0 |
-| BranchTree(96) | native Go | 77.39 | 0 | 0 |
-| BranchTree(96) | wazero | 156.9 | 16 | 1 |
-| BranchTree(96) | Tengo | 16,719 | 95,384 | 660 |
-| BranchTree(96) | gopher-lua | 8,215 | 2,464 | 9 |
-| BranchTree(96) | Goja | 13,476 | 1,992 | 196 |
-| BranchTree(96) | gpython | 11,504 | 2,168 | 203 |
-| BranchTree(96) | Yaegi | 10,476 | 1,832 | 308 |
+| AllocationGraph(128) | Tengo | 13,988 | 96,288 | 388 |
+| AllocationGraph(128) | gopher-lua | 6,273 | 14,376 | 256 |
+| AllocationGraph(128) | Goja | 25,412 | 78,016 | 770 |
+| AllocationGraph(128) | gpython | 5,941 | 5,712 | 266 |
+| AllocationGraph(128) | Yaegi | 12,222 | 1,492 | 142 |
+| BranchTree(96) | minivm/default | 235.1 | 0 | 0 |
+| BranchTree(96) | minivm/threaded | 981.8 | 0 | 0 |
+| BranchTree(96) | minivm/jit | 234.0 | 0 | 0 |
+| BranchTree(96) | native Go | 79.10 | 0 | 0 |
+| BranchTree(96) | wazero | 164.2 | 16 | 1 |
+| BranchTree(96) | Tengo | 17,274 | 95,384 | 660 |
+| BranchTree(96) | gopher-lua | 8,775 | 2,464 | 9 |
+| BranchTree(96) | Goja | 13,901 | 1,992 | 196 |
+| BranchTree(96) | gpython | 12,295 | 2,168 | 203 |
+| BranchTree(96) | Yaegi | 11,062 | 1,832 | 308 |
 
 Wazero has no equivalent canonical fixture for `ClosureCounter(128)` or `AllocationGraph(128)`, so those rows are `N/A`.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -299,9 +299,9 @@ Recorded forward branches become guarded exits or learned branch continuations.
 
 When a side exit becomes hot, the tracer records that target. A later compile may fold it into the same native callable as a pending block. Loop roots are never folded as ordinary continuations: they deoptimize at the header and use their standalone loop entry, which preserves back-edge and safepoint semantics.
 
-Pending blocks reload from VM stack homes, run through a FIFO worklist, and stop at a bounded pending cap. The trace frontend orders learned roots once; the backend does not repeatedly sort pending work.
+Pending blocks reload from VM stack slots, run through a FIFO worklist, and stop at a bounded pending cap. The trace frontend orders learned roots once; the backend does not repeatedly sort pending work.
 
-A cold branch edge may carry caller-continuation block IDs. The side trace body lowers first; on callee `RETURN`, lowering stitches the result into the caller frame and follows those IDs. The continuation reloads from VM stack homes before continuing.
+A cold branch edge may carry caller-continuation block IDs. The side trace body lowers first; on callee `RETURN`, lowering stitches the result into the caller frame and follows those IDs. The continuation reloads from VM stack slots before continuing.
 
 Each deferred profiled edge gets its own label and symbolic snapshot. Static state-backed blocks share labels only through explicit block IDs, never through bytecode-anchor equality.
 
@@ -311,7 +311,7 @@ Targets still deoptimize when they are unknown or unsupported.
 
 Branch lowering may skip hot-path flushes only when the branch state is clean. If locals or operands are dirty, flush first. Learned continuations and side exits must see the same stack image as threaded dispatch.
 
-A committing flush (`selfCall`, `tailLoop`) transfers operand ownership to the VM stack, so it accepts a live `ownerStack` ref: that ref already carries the retain taken when it was pushed, and committing hands the same edge to the stack, exactly as the inlined call path does when it stores arguments and drops them from the operand stack. It rejects any live deferred ref (a const marker or a slot-backed operand): a deferred ref carries no retain of its own, and a loop back-edge has no cold stub to take one, so owning it each iteration would leak. A self-recursive function still forwards a ref parameter to itself because the argument is owned into the callee frame (through the call-argument path) before the commit. See Reference Ownership.
+A committing flush (`selfCall`, `tailLoop`) transfers operand ownership to the VM stack, so it accepts a live `backingStack` ref: that ref already carries the retain taken when it was pushed, and committing hands the same edge to the stack, exactly as the inlined call path does when it stores arguments and drops them from the operand stack. It rejects any live deferred ref (a const marker or a slot-backed operand): a deferred ref carries no retain of its own, and a loop back-edge has no cold stub to take one, so owning it each iteration would leak. A self-recursive function still forwards a ref parameter to itself because the argument is owned into the callee frame (through the call-argument path) before the commit. See Reference Ownership.
 
 ### Branch range validation
 
@@ -325,7 +325,7 @@ A loop root is anchored at a loop header: the target of a backward branch.
 
 The tracer discovers headers statically. Periodic samples still drive normal hotness, while JIT-enabled unconditional backward `BR` handlers also notify the interpreter after moving the live frame to the exact target header. This prevents a deterministic tick phase from permanently missing those loops. Threshold-zero mode waits for eight exact hits on those headers before capture so the first iteration does not over-specialize the recorded branch path.
 
-Loop lowering builds the normal native prologue, binds a back-edge label, lowers the loop body, commits loop-carried locals to VM stack homes, decrements `journalBudget`, and branches back while budget remains.
+Loop lowering builds the normal native prologue, binds a back-edge label, lowers the loop body, commits loop-carried locals to VM stack slots, decrements `journalBudget`, and branches back while budget remains.
 
 Loop-carried locals round-trip through the VM stack each iteration. This avoids a cross-back-edge register fixpoint.
 
@@ -388,24 +388,24 @@ If a release may free the object (`rc == 1`), native code deoptimizes before the
 
 ## Reference Ownership
 
-A ref `value` carries an `owner` that records where its reference count lives.
+A ref `value` carries an `backing` that records where its reference count lives.
 
-| Owner | Retain location |
+| Backing | Retain location |
 |---|---|
-| `ownerStack` | the operand-stack copy owns its own retain |
-| `ownerConst` | a compile-time constant marker; retain deferred |
-| `ownerLocal` / `ownerGlobal` / `ownerUpval` | deferred to the backing slot (`home`) |
+| `backingStack` | the operand-stack copy owns its own retain |
+| `backingConst` | a compile-time constant marker; retain deferred |
+| `backingLocal` / `backingGlobal` / `backingUpval` | deferred to the backing slot (`slot`) |
 
-Only an `ownerStack` ref carries a retain. Every other owner defers it to backing storage that already holds one, so the operand is a borrowed view until it transfers to interpreter-visible state.
+Only a `backingStack` ref carries a retain. Every other backing defers it to backing storage that already holds one, so the operand is a borrowed view until it transfers to interpreter-visible state.
 
-Producers push deferred. `LOCAL_GET`, `GLOBAL_GET`, and `UPVAL_GET` of a ref take no retain and record the slot as `home`; const markers push `ownerConst`; `DUP` of a deferred ref copies it deferred. Container consumers borrow the operand and elide their matching release when it is deferred: `ARRAY_GET`/`SET`, `STRUCT_GET`/`SET`, `ARRAY_LEN`, `REF_IS_NULL`, `DROP`, and the coroutine, error, and string reads all skip the container `guardRC`/release when the consumed operand is not `ownerStack`. A ref element or payload result is still retained; only the container's own release is elided. This removes the per-element retain/release pair from primitive container loops.
+Producers push deferred. `LOCAL_GET`, `GLOBAL_GET`, and `UPVAL_GET` of a ref take no retain and record its backing slot; const markers push `backingConst`; `DUP` of a deferred ref copies it deferred. Container consumers borrow the operand and elide their matching release when it is deferred: `ARRAY_GET`/`SET`, `STRUCT_GET`/`SET`, `ARRAY_LEN`, `REF_IS_NULL`, `DROP`, and the coroutine, error, and string reads all skip the container `guardRC`/release when the consumed operand is not `backingStack`. A ref element or payload result is still retained; only the container's own release is elided. This removes the per-element retain/release pair from primitive container loops.
 
 A retain materializes at every point that hands a deferred value to storage the interpreter can see:
 
 - `own` — storing into a local, global, or upval slot, transferring a ref into an array element or struct field, transferring a call argument through `locals()`, and boxing an entry-frame return in `ret`.
-- `settle` — before a backing slot is overwritten (`LOCAL_SET`/`GLOBAL_SET`/`UPVAL_SET`) or a frame dies (`stitch`, tail dispatch), every live operand deferred to that slot is owned first.
-- exit stubs — `materializeExits` reloads each deferred operand from its flushed VM stack home and retains it on the cold guard path.
-- `redeem` — a stub-less deopt that hands the flushed operand stack to the interpreter (a trap fallback, module completion) re-takes each deferred operand's retain from its home.
+- `detach` — before a backing slot is overwritten (`LOCAL_SET`/`GLOBAL_SET`/`UPVAL_SET`) or a frame dies (`stitch`, tail dispatch), every live operand deferred to that slot is owned first.
+- exit stubs — `emitExits` reloads each deferred operand from its flushed VM stack slot and retains it on the cold guard path.
+- `retainDeferred` — a stub-less deopt that hands the flushed operand stack to the interpreter (a trap fallback, module completion) re-takes each deferred operand's retain from its VM stack slot.
 - real calls — `directCall` and `selfCall` own every live deferred operand before the `BL`, because a callee trap adopts the caller's flushed stack.
 
 A committing (loop back-edge) flush rejects any live deferred ref: owning it would retain once per iteration with no matching release, so a loop-carried deferred ref keeps the whole trace threaded instead.
@@ -418,7 +418,7 @@ Native full-trace reads include observed shapes for scalar `REF_GET`, selected `
 
 Heap reads guard ref address, heap itab, array element kind, struct type pointer, struct field kind, index bounds, and release safety when needed.
 
-Ref reads retain the loaded element or payload. A container consumer releases its container handle only when that operand owns its retain, eliding the release for a deferred operand (see Reference Ownership): `CORO_VALUE` still retains the value and releases the handle when the handle is `ownerStack`. `CORO_DONE` keeps the handle.
+Ref reads retain the loaded element or payload. A container consumer releases its container handle only when that operand owns its retain, eliding the release for a deferred operand (see Reference Ownership): `CORO_VALUE` still retains the value and releases the handle when the handle is `backingStack`. `CORO_DONE` keeps the handle.
 
 Heap-promoted `i64` values fall back before boxing.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -402,7 +402,7 @@ Producers push deferred. `LOCAL_GET`, `GLOBAL_GET`, and `UPVAL_GET` of a ref tak
 
 A retain materializes at every point that hands a deferred value to storage the interpreter can see:
 
-- `own` — storing into a local, global, or upval slot, transferring a call argument through `locals()`, and boxing an entry-frame return in `ret`.
+- `own` — storing into a local, global, or upval slot, transferring a ref into an array element or struct field, transferring a call argument through `locals()`, and boxing an entry-frame return in `ret`.
 - `settle` — before a backing slot is overwritten (`LOCAL_SET`/`GLOBAL_SET`/`UPVAL_SET`) or a frame dies (`stitch`, tail dispatch), every live operand deferred to that slot is owned first.
 - exit stubs — `materializeExits` reloads each deferred operand from its flushed VM stack home and retains it on the cold guard path.
 - `redeem` — a stub-less deopt that hands the flushed operand stack to the interpreter (a trap fallback, module completion) re-takes each deferred operand's retain from its home.
@@ -424,7 +424,7 @@ Heap-promoted `i64` values fall back before boxing.
 
 A primitive typed-array `ARRAY_SET` may continue through native execution when it occurs in the anchor frame before any inlined call. Lowering first materializes one resumable pre-op snapshot, clears the local register cache, and lets shape, bounds, and release guards share that snapshot. Guard failure resumes at the original opcode; success performs the primitive store and continues to later operations or the loop back-edge.
 
-Ref-bearing `ARRAY_SET` and `STRUCT_SET` remain terminal mutations. Their hot path may perform the store and resume threaded execution at the next instruction, while recursive release or any failed guard remains interpreter-owned.
+Ref-bearing `ARRAY_SET` and `STRUCT_SET` remain terminal mutations. Before the store, lowering owns a deferred element or field value so the transferred container edge carries exactly one retain, matching threaded execution. Their hot path may perform the store and resume threaded execution at the next instruction, while recursive release or any failed guard remains interpreter-owned.
 
 Mutation plans are always no-spill. Leaf traces reuse pinned and dead registers for stack homes, heap cells, refcounts, and boxing scratch so primitive mutation loops fit the physical register bank. A mutation after inlined calls retains the terminal boundary; register exhaustion still rejects compilation cleanly instead of spilling across a back-edge (regression test: `interp.TestARM64_ArraySetAfterNestedCalls`).
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -311,7 +311,7 @@ Targets still deoptimize when they are unknown or unsupported.
 
 Branch lowering may skip hot-path flushes only when the branch state is clean. If locals or operands are dirty, flush first. Learned continuations and side exits must see the same stack image as threaded dispatch.
 
-A committing flush (`selfCall`, `tailLoop`) transfers operand ownership to the VM stack, so it accepts a live non-raw ref: that ref already carries the retain taken when it was pushed, and committing hands the same edge to the stack, exactly as the inlined call path does when it stores arguments and drops them from the operand stack. A raw ref marker instead retains inside `box()` for an interpreter frame to release, and a commit rebuilds no frame, so a raw ref stays rejected. This is what lets a self-recursive function forward a ref parameter to itself on the native self-call path.
+A committing flush (`selfCall`, `tailLoop`) transfers operand ownership to the VM stack, so it accepts a live `ownerStack` ref: that ref already carries the retain taken when it was pushed, and committing hands the same edge to the stack, exactly as the inlined call path does when it stores arguments and drops them from the operand stack. It rejects any live deferred ref (a const marker or a slot-backed operand): a deferred ref carries no retain of its own, and a loop back-edge has no cold stub to take one, so owning it each iteration would leak. A self-recursive function still forwards a ref parameter to itself because the argument is owned into the callee frame (through the call-argument path) before the commit. See Reference Ownership.
 
 ### Branch range validation
 
@@ -382,9 +382,33 @@ Result kinds must match the interpreter:
 
 Scalar slots load and store raw values directly.
 
-Ref-bearing slots use guarded retain/release through `journalRC`.
+A ref slot store releases the overwritten ref and transfers the stored ref, both guarded through `journalRC`. A ref `LOCAL_GET`/`GLOBAL_GET`/`UPVAL_GET` instead pushes a deferred operand and takes no retain (see Reference Ownership).
 
 If a release may free the object (`rc == 1`), native code deoptimizes before the release. The interpreter owns recursive release and cleanup.
+
+## Reference Ownership
+
+A ref `value` carries an `owner` that records where its reference count lives.
+
+| Owner | Retain location |
+|---|---|
+| `ownerStack` | the operand-stack copy owns its own retain |
+| `ownerConst` | a compile-time constant marker; retain deferred |
+| `ownerLocal` / `ownerGlobal` / `ownerUpval` | deferred to the backing slot (`home`) |
+
+Only an `ownerStack` ref carries a retain. Every other owner defers it to backing storage that already holds one, so the operand is a borrowed view until it transfers to interpreter-visible state.
+
+Producers push deferred. `LOCAL_GET`, `GLOBAL_GET`, and `UPVAL_GET` of a ref take no retain and record the slot as `home`; const markers push `ownerConst`; `DUP` of a deferred ref copies it deferred. Container consumers borrow the operand and elide their matching release when it is deferred: `ARRAY_GET`/`SET`, `STRUCT_GET`/`SET`, `ARRAY_LEN`, `REF_IS_NULL`, `DROP`, and the coroutine, error, and string reads all skip the container `guardRC`/release when the consumed operand is not `ownerStack`. A ref element or payload result is still retained; only the container's own release is elided. This removes the per-element retain/release pair from primitive container loops.
+
+A retain materializes at every point that hands a deferred value to storage the interpreter can see:
+
+- `own` — storing into a local, global, or upval slot, transferring a call argument through `locals()`, and boxing an entry-frame return in `ret`.
+- `settle` — before a backing slot is overwritten (`LOCAL_SET`/`GLOBAL_SET`/`UPVAL_SET`) or a frame dies (`stitch`, tail dispatch), every live operand deferred to that slot is owned first.
+- exit stubs — `materializeExits` reloads each deferred operand from its flushed VM stack home and retains it on the cold guard path.
+- `redeem` — a stub-less deopt that hands the flushed operand stack to the interpreter (a trap fallback, module completion) re-takes each deferred operand's retain from its home.
+- real calls — `directCall` and `selfCall` own every live deferred operand before the `BL`, because a callee trap adopts the caller's flushed stack.
+
+A committing (loop back-edge) flush rejects any live deferred ref: owning it would retain once per iteration with no matching release, so a loop-carried deferred ref keeps the whole trace threaded instead.
 
 ## Heap Reads and Mutations
 
@@ -394,7 +418,7 @@ Native full-trace reads include observed shapes for scalar `REF_GET`, selected `
 
 Heap reads guard ref address, heap itab, array element kind, struct type pointer, struct field kind, index bounds, and release safety when needed.
 
-Ref reads retain loaded refs. `CORO_VALUE` retains the value and releases the handle. `CORO_DONE` keeps the handle.
+Ref reads retain the loaded element or payload. A container consumer releases its container handle only when that operand owns its retain, eliding the release for a deferred operand (see Reference Ownership): `CORO_VALUE` still retains the value and releases the handle when the handle is `ownerStack`. `CORO_DONE` keeps the handle.
 
 Heap-promoted `i64` values fall back before boxing.
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -71,6 +71,15 @@ Counts include every ownership edge, whether it comes from another heap object,
 the VM stack and frames, a global or constant, temporary construction state, or
 the host. The cycle collector relies on this exactness.
 
+The ARM64 JIT may compile a stack copy of a ref as *deferred*: the operand
+borrows the retain already held by its backing storage (a local, global, upval,
+or constant) instead of taking its own, which removes the per-element
+retain/release pair from primitive container loops. The invariant is unchanged:
+every path that hands the value to interpreter-visible state — an ownership
+transfer, a guard exit stub, or a trap-fallback/module-completion redeem — takes
+exactly one retain first, so net counts stay exact and symmetric on every path,
+including deopts. See `docs/jit-internals.md` (Reference Ownership).
+
 ## Traceable Values
 
 Heap objects that can contain refs implement `types.Traceable`.

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -82,35 +82,34 @@ type lowering struct {
 // value is one typed operand: a register plus the runtime kind the trace
 // observed for it. raw scalars skip NaN-boxing between opcodes — an i32 keeps
 // its value in the low 32 bits, an f64 keeps its IEEE bits (identical to its
-// boxed form). For refs, owner records where the reference count lives: an
-// ownerStack ref carries its own retain on the operand stack, while every
-// other owner defers the retain to its backing storage until the value
-// transfers to interpreter state. An ownerConst ref is a compile-time function
-// or closure constant that was never materialized; fn holds the target
-// function and ref holds the callable heap ref. home locates a deferred ref's
-// backing storage: the VM stack home f.base+idx for ownerLocal, the global
-// slot index for ownerGlobal, or the upval index for ownerUpval.
+// boxed form). For refs, backing records where the reference count lives: an
+// backingStack ref carries its own retain on the operand stack, while every
+// other backing defers the retain to its backing storage until the value
+// transfers to interpreter state. Field validity depends on backing:
+// backingStack uses reg; backingConst uses ref and may also use fn for a direct
+// call target; backingLocal, backingGlobal, and backingUpval use reg plus slot.
+// slot identifies the VM stack local, global, or upval that carries the retain.
 type value struct {
-	reg   asm.VReg
-	kind  types.Kind
-	raw   bool
-	owner owner
-	home  int
-	known bool
-	imm   int64
-	fn    int
-	ref   int
+	reg     asm.VReg
+	kind    types.Kind
+	raw     bool
+	backing backing
+	slot    int
+	known   bool
+	imm     int64
+	fn      int
+	ref     int
 }
 
-// owner is the reference-count backer of a ref value.
-type owner uint8
+// backing identifies where a ref value derives its reference count.
+type backing uint8
 
 const (
-	ownerStack  owner = iota // retain lives on the operand stack copy
-	ownerConst               // compile-time constant, never retained
-	ownerLocal               // deferred to a VM stack local slot (home)
-	ownerGlobal              // deferred to a global slot (home)
-	ownerUpval               // deferred to a closure upval slot (home)
+	backingStack  backing = iota // retain lives on the operand stack copy
+	backingConst                 // compile-time constant, never retained
+	backingLocal                 // deferred to a VM stack local slot
+	backingGlobal                // deferred to a global slot
+	backingUpval                 // deferred to a closure upval slot
 )
 
 // activation mirrors one interpreter frame the trace inlined. Locals live in
@@ -132,7 +131,7 @@ type activation struct {
 }
 
 // work is a deferred block whose branch point produced its symbolic state:
-// stack homes are current, so the block re-enters at label with
+// VM stack slots are current, so the block re-enters at label with
 // every local unloaded and every operand awaiting reload. If the branch
 // returned from an inlined callee, tail keeps the caller path that must run
 // after the deferred block stitches back into the caller frame.
@@ -435,9 +434,6 @@ func (ctx *lowering) frame() *activation {
 	return &ctx.frames[len(ctx.frames)-1]
 }
 
-// snapshot deep-copies operand and frame state for a deferred branch. Callers
-// must flush VM stack homes before snapshot; re-entry reloads locals on demand,
-// so stale register/local loaded state must stay dropped.
 // queueExit records a cold fallback after the caller has materialized VM stack
 // state. values may be nil to snapshot the current symbolic stack; retains for
 // deferred refs in the snapshot are applied only on the cold path before
@@ -457,10 +453,13 @@ func (ctx *lowering) queueExit(values []value, resume int, reason prof.ExitReaso
 	return label
 }
 
+// snapshot deep-copies operand and frame state for a deferred branch. Callers
+// must flush VM stack slots first; re-entry reloads locals on demand, so stale
+// register and local-loaded state must stay dropped.
 func (ctx *lowering) snapshot() ([]value, []activation) {
 	values := make([]value, len(ctx.values))
 	for i, v := range ctx.values {
-		values[i] = value{kind: v.kind, raw: v.raw, owner: v.owner, home: v.home, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref}
+		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref}
 	}
 	frames := make([]activation, len(ctx.frames))
 	for i, f := range ctx.frames {
@@ -491,15 +490,6 @@ func (ctx *lowering) pinTo(pr asm.PReg) asm.VReg {
 	v := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	_ = ctx.assembler.Pin(v, pr)
 	return v
-}
-
-// constant returns the heap ref an ownerConst marker names: ref when set,
-// otherwise fn for a direct-call marker.
-func (v value) constant() int {
-	if v.ref != 0 {
-		return v.ref
-	}
-	return v.fn
 }
 
 func reasonPriority(reason prof.CompileReason) int {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -493,6 +493,15 @@ func (ctx *lowering) pinTo(pr asm.PReg) asm.VReg {
 	return v
 }
 
+// constant returns the heap ref an ownerConst marker names: ref when set,
+// otherwise fn for a direct-call marker.
+func (v value) constant() int {
+	if v.ref != 0 {
+		return v.ref
+	}
+	return v.fn
+}
+
 func reasonPriority(reason prof.CompileReason) int {
 	switch reason {
 	case prof.CompileReasonInvalidPlan:

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -82,18 +82,36 @@ type lowering struct {
 // value is one typed operand: a register plus the runtime kind the trace
 // observed for it. raw scalars skip NaN-boxing between opcodes — an i32 keeps
 // its value in the low 32 bits, an f64 keeps its IEEE bits (identical to its
-// boxed form). A raw ref is a compile-time function or closure constant that
-// was never materialized; fn holds the target function and ref holds the
-// callable heap ref.
+// boxed form). For refs, owner records where the reference count lives: an
+// ownerStack ref carries its own retain on the operand stack, while every
+// other owner defers the retain to its backing storage until the value
+// transfers to interpreter state. An ownerConst ref is a compile-time function
+// or closure constant that was never materialized; fn holds the target
+// function and ref holds the callable heap ref. home locates a deferred ref's
+// backing storage: the VM stack home f.base+idx for ownerLocal, the global
+// slot index for ownerGlobal, or the upval index for ownerUpval.
 type value struct {
 	reg   asm.VReg
 	kind  types.Kind
 	raw   bool
+	owner owner
+	home  int
 	known bool
 	imm   int64
 	fn    int
 	ref   int
 }
+
+// owner is the reference-count backer of a ref value.
+type owner uint8
+
+const (
+	ownerStack  owner = iota // retain lives on the operand stack copy
+	ownerConst               // compile-time constant, never retained
+	ownerLocal               // deferred to a VM stack local slot (home)
+	ownerGlobal              // deferred to a global slot (home)
+	ownerUpval               // deferred to a closure upval slot (home)
+)
 
 // activation mirrors one interpreter frame the trace inlined. Locals live in
 // registers; loaded marks which have been pulled from the VM stack and dirty
@@ -138,7 +156,6 @@ type sideExit struct {
 	values []value
 	frames []activation
 	resume int
-	retain int
 	id     int
 }
 
@@ -421,10 +438,11 @@ func (ctx *lowering) frame() *activation {
 // snapshot deep-copies operand and frame state for a deferred branch. Callers
 // must flush VM stack homes before snapshot; re-entry reloads locals on demand,
 // so stale register/local loaded state must stay dropped.
-// queueExit records a cold fallback after the caller has materialized VM stack state.
-// values may be nil to snapshot the current symbolic stack; retain is applied only
-// on the cold path before returning to threaded execution.
-func (ctx *lowering) queueExit(values []value, resume, retain int, reason prof.ExitReason, opcode int) asm.Label {
+// queueExit records a cold fallback after the caller has materialized VM stack
+// state. values may be nil to snapshot the current symbolic stack; retains for
+// deferred refs in the snapshot are applied only on the cold path before
+// returning to threaded execution.
+func (ctx *lowering) queueExit(values []value, resume int, reason prof.ExitReason, opcode int) asm.Label {
 	if values != nil {
 		ctx.values = append(ctx.values[:0], values...)
 	}
@@ -433,7 +451,7 @@ func (ctx *lowering) queueExit(values []value, resume, retain int, reason prof.E
 	id := len(ctx.descriptors)
 	ctx.descriptors = append(ctx.descriptors, exitDescriptor{reason: reason, opcode: opcode})
 	ctx.exits = append(ctx.exits, sideExit{
-		label: label, values: stack, frames: frames, resume: resume, retain: retain,
+		label: label, values: stack, frames: frames, resume: resume,
 		id: id,
 	})
 	return label
@@ -442,7 +460,7 @@ func (ctx *lowering) queueExit(values []value, resume, retain int, reason prof.E
 func (ctx *lowering) snapshot() ([]value, []activation) {
 	values := make([]value, len(ctx.values))
 	for i, v := range ctx.values {
-		values[i] = value{kind: v.kind, raw: v.raw, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref}
+		values[i] = value{kind: v.kind, raw: v.raw, owner: v.owner, home: v.home, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref}
 	}
 	frames := make([]activation, len(ctx.frames))
 	for i, f := range ctx.frames {

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -97,15 +97,65 @@ func (l arm64Lowerer) enter(ctx *lowering) {
 	a.Bind(ctx.head)
 }
 
+// materializeExits emits every queued cold stub. A deferred ref in the exit
+// snapshot was flushed to its VM stack home without a retain, and the
+// interpreter resuming there releases each stack ref it pops, so the stub
+// takes the retain here — on the cold path only.
 func (l arm64Lowerer) materializeExits(ctx *lowering) {
+	// Every exit's cold stub is a mutually exclusive, straight-line block
+	// (each ends in trapFlushed, an unconditional trap/return), so the
+	// registers used to reload-and-retain a deferred value are safe to reuse
+	// across every exit and every deferred value in this function: their live
+	// ranges never overlap at runtime. Allocating them once keeps this
+	// bookkeeping from competing with the hot path's own no-spill register
+	// budget (a function with several guarded ops and a live deferred operand
+	// can have many exits, each otherwise adding its own fresh registers).
+	var reg, refAddr, rcBase, rc asm.VReg
 	for _, exit := range ctx.exits {
 		ctx.reuseLocals = false
 		ctx.spare = asm.VReg{}
 		ctx.values = exit.values
 		ctx.frames = exit.frames
 		ctx.assembler.Bind(exit.label)
-		if exit.retain > 0 {
-			l.retain(ctx, exit.retain)
+		var addr asm.VReg
+		for j, v := range exit.values {
+			switch v.owner {
+			case ownerConst:
+				ref := v.ref
+				if ref == 0 {
+					ref = v.fn
+				}
+				if ref > 0 {
+					l.retain(ctx, ref)
+				}
+			case ownerLocal, ownerGlobal, ownerUpval:
+				// The stub owns no live registers, but flush wrote every
+				// operand to its VM stack home before the guard, so the home
+				// is authoritative: reload the boxed ref from there and take
+				// the retain the interpreter frame will release.
+				if addr.Width() == asm.WidthUndefined {
+					vStack := ctx.pin(scratchStack)
+					addr = l.base(ctx, vStack)
+				}
+				if reg.Width() == asm.WidthUndefined {
+					reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+				}
+				ctx.assembler.Emit(arm64.LDR(reg, addr, int16(ctx.slot(j)*8)))
+				if refAddr.Width() == asm.WidthUndefined {
+					refAddr = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+				}
+				ctx.assembler.Emit(arm64.ANDI(refAddr, reg, maskI32))
+				if rcBase.Width() == asm.WidthUndefined {
+					rcBase = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+				}
+				l.rcBaseTo(ctx, rcBase)
+				if rc.Width() == asm.WidthUndefined {
+					rc = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+				}
+				ctx.assembler.Emit(arm64.LDRR(rc, rcBase, refAddr))
+				ctx.assembler.Emit(arm64.ADDI(rc, rc, 1))
+				ctx.assembler.Emit(arm64.STRR(rc, rcBase, refAddr))
+			}
 		}
 		l.trapFlushed(ctx, trapFallback, exit.resume, exit.id)
 	}
@@ -400,7 +450,7 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 		case instr.F64_GE:
 			ok = l.f64Cmp(ctx, arm64.CondGE)
 		case instr.ARRAY_GET:
-			if ctx.count() >= 2 && ctx.values[len(ctx.values)-2].raw && ctx.values[len(ctx.values)-2].ref > 0 {
+			if ctx.count() >= 2 && ctx.values[len(ctx.values)-2].owner == ownerConst && ctx.values[len(ctx.values)-2].ref > 0 {
 				ok = l.arrayGetKnown(ctx, op)
 			} else {
 				ok = l.arrayGet(ctx, op)
@@ -690,7 +740,7 @@ func (l arm64Lowerer) fuse(ctx *lowering, ops []step, idx int) (int, bool) {
 	if l.target(ctx, source, consumer) {
 		return 1, true
 	}
-	return l.consume(ctx, ops, idx)
+	return 0, true
 }
 
 // target replaces a constant function load with a raw call marker. CALL and
@@ -718,100 +768,8 @@ func (l arm64Lowerer) target(ctx *lowering, source, consumer step) bool {
 	if callee != consumer.callee || resolve(ctx.module, ctx.heap, callee) == nil {
 		return false
 	}
-	ctx.push(value{fn: callee, kind: types.KindRef, raw: true, ref: ref})
+	ctx.push(value{fn: callee, kind: types.KindRef, owner: ownerConst, ref: ref})
 	return true
-}
-
-func (l arm64Lowerer) consume(ctx *lowering, ops []step, idx int) (int, bool) {
-	source := ops[idx]
-	consumer := ops[idx+1]
-	if consumer.op != instr.DROP && consumer.op != instr.REF_IS_NULL {
-		return 0, true
-	}
-	frame := ctx.frame()
-	const consumed = 2
-
-	var reg asm.VReg
-	drop := consumer.op == instr.DROP
-	switch source.op {
-	case instr.LOCAL_GET:
-		slot := int(source.args[0])
-		if slot >= len(frame.kinds) || frame.kinds[slot] != types.KindRef {
-			return 0, true
-		}
-		if drop {
-			return consumed, true
-		}
-		if !l.loadLocal(ctx, frame, slot, source.ip) {
-			return 0, false
-		}
-		reg = frame.locals[slot].reg
-	case instr.GLOBAL_GET:
-		slot := int(source.args[0])
-		if slot >= len(ctx.globals) || slot > 4095 || ctx.globals[slot] != types.KindRef {
-			return 0, true
-		}
-		if drop {
-			return consumed, true
-		}
-		reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDR(reg, ctx.pin(scratchGlobals), int16(slot*8)))
-	case instr.UPVAL_GET:
-		slot := int(source.args[0])
-		if slot >= len(frame.upvals) || frame.upvals[slot] != types.KindRef {
-			return 0, true
-		}
-		if drop {
-			return consumed, true
-		}
-		reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDR(reg, l.upvalBase(ctx), int16(slot*8)))
-	case instr.CONST_GET:
-		constant := int(source.args[0])
-		if constant >= len(ctx.constants) || ctx.constants[constant].Kind() != types.KindRef {
-			return 0, true
-		}
-		boxed := ctx.constants[constant]
-		ref := boxed.Ref()
-		if ref < 0 || ref >= len(ctx.heap) {
-			return 0, true
-		}
-		if _, ok := ctx.heap[ref].(types.String); ok {
-			return 0, true
-		}
-		if drop {
-			return consumed, true
-		}
-		reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDI(reg, uint64(boxed))...)
-	case instr.REF_NULL:
-		if drop {
-			return consumed, true
-		}
-		reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDI(reg, uint64(types.BoxedNull))...)
-	case instr.DUP:
-		if ctx.count() < 1 || ctx.values[len(ctx.values)-1].kind != types.KindRef {
-			return 0, true
-		}
-		if drop {
-			return consumed, true
-		}
-		var ok bool
-		reg, ok = l.box(ctx, ctx.values[len(ctx.values)-1])
-		if !ok {
-			return 0, false
-		}
-	default:
-		return 0, true
-	}
-
-	null := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	result := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	ctx.assembler.Emit(arm64.LDI(null, uint64(types.BoxedNull))...)
-	ctx.assembler.Emit(arm64.CMP(reg, null), arm64.CSET(result, arm64.CondEQ))
-	ctx.push(value{reg: result, kind: types.KindI1, raw: true})
-	return consumed, true
 }
 
 func (l arm64Lowerer) adjacent(a, b step) bool {
@@ -867,6 +825,12 @@ func (l arm64Lowerer) unreachable(ctx *lowering, op step) bool {
 	return l.exit(ctx, op.ip, prof.ExitTerminalOp, int(op.op))
 }
 
+// localGet loads local idx and, for a ref, pushes it deferred: owner ownerLocal
+// with home f.base+idx records that the slot itself still carries the retain,
+// so no retain is taken here. A container consumer that later reads this
+// operand elides its matching release to balance the missing retain; a
+// LOCAL_SET/tail/RETURN that would invalidate the slot settles this deferral
+// into a real retain first.
 func (l arm64Lowerer) localGet(ctx *lowering, op step) bool {
 	f := ctx.frame()
 	idx := int(op.args[0])
@@ -879,14 +843,12 @@ func (l arm64Lowerer) localGet(ctx *lowering, op step) bool {
 	if !l.loadLocal(ctx, f, idx, op.ip) {
 		return false
 	}
-	if f.locals[idx].kind == types.KindRef {
-		if ctx.leaf {
-			l.retainKnownBox(ctx, f.locals[idx].reg)
-		} else {
-			l.retainBox(ctx, f.locals[idx].reg)
-		}
+	v := f.locals[idx]
+	if v.kind == types.KindRef {
+		v.owner = ownerLocal
+		v.home = f.base + idx
 	}
-	ctx.push(f.locals[idx])
+	ctx.push(v)
 	return true
 }
 
@@ -896,13 +858,21 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 	if idx >= len(f.kinds) || ctx.count() < 1 {
 		return false
 	}
-	v := ctx.values[len(ctx.values)-1]
-	if v.kind.Repr() != f.kinds[idx].Repr() {
+	vp := &ctx.values[len(ctx.values)-1]
+	if vp.kind.Repr() != f.kinds[idx].Repr() {
 		return false
 	}
-	if v.kind == types.KindRef {
-		boxed, ok := l.box(ctx, v)
+	if vp.kind == types.KindRef {
+		// Own the incoming value before it is captured into a guard snapshot:
+		// pre() must observe ownerStack, or a deopt on this op would re-enter
+		// the interpreter expecting a retain the stub cannot see anymore.
+		// settle() then materializes every other deferred reader of the slot
+		// this SET is about to overwrite.
+		boxed, ok := l.own(ctx, vp)
 		if !ok {
+			return false
+		}
+		if !l.settle(ctx, ownerLocal, f.base+idx) {
 			return false
 		}
 		pre := ctx.pre()
@@ -927,10 +897,10 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 		}
 		return true
 	}
-	if !v.raw {
+	if !vp.raw {
 		return false
 	}
-	f.locals[idx] = v
+	f.locals[idx] = *vp
 	f.state[idx] |= localLoaded | localDirty
 	if pop {
 		ctx.pop()
@@ -939,7 +909,8 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 }
 
 // globalGet loads a global directly from the globals base. Scalars push
-// raw; refs stay boxed and retain the stack ownership created by the get.
+// raw; a ref pushes deferred (owner ownerGlobal, home idx): the slot itself
+// still carries the retain, so no retain is taken here (see localGet).
 func (l arm64Lowerer) globalGet(ctx *lowering, op step) bool {
 	idx, kind, ok := l.global(ctx, op)
 	if !ok {
@@ -955,8 +926,7 @@ func (l arm64Lowerer) globalGet(ctx *lowering, op step) bool {
 		dst = l.sign64(ctx, dst)
 	}
 	if kind == types.KindRef {
-		l.retainBox(ctx, dst)
-		ctx.push(value{reg: dst, kind: kind, raw: false})
+		ctx.push(value{reg: dst, kind: kind, owner: ownerGlobal, home: idx})
 		return true
 	}
 	ctx.push(value{reg: dst, kind: kind, raw: true})
@@ -973,15 +943,29 @@ func (l arm64Lowerer) globalSet(ctx *lowering, op step, pop bool) bool {
 	if ctx.count() < 1 {
 		return false
 	}
-	v := ctx.values[len(ctx.values)-1]
-	if v.kind != kind || !v.raw {
-		if v.kind != types.KindRef || kind != types.KindRef {
+	vp := &ctx.values[len(ctx.values)-1]
+	if vp.kind != kind || !vp.raw {
+		if vp.kind != types.KindRef || kind != types.KindRef {
 			return false
 		}
 	}
-	boxed, ok := l.box(ctx, v)
-	if !ok {
-		return false
+	var boxed asm.VReg
+	if kind == types.KindRef {
+		// Own the incoming value before it can be captured by a guard
+		// snapshot, then settle every other deferred reader of the slot this
+		// SET is about to overwrite (see localSet).
+		boxed, ok = l.own(ctx, vp)
+		if !ok {
+			return false
+		}
+		if !l.settle(ctx, ownerGlobal, idx) {
+			return false
+		}
+	} else {
+		boxed, ok = l.borrow(ctx, *vp)
+		if !ok {
+			return false
+		}
 	}
 	base := ctx.pin(scratchGlobals)
 	if kind == types.KindRef || kind == types.KindI64 {
@@ -1029,8 +1013,8 @@ func (l arm64Lowerer) drop(ctx *lowering, op step) bool {
 	}
 	pre := ctx.pre()
 	v := ctx.values[len(ctx.values)-1]
-	if v.kind == types.KindRef {
-		boxed, ok := l.box(ctx, v)
+	if v.kind == types.KindRef && v.owner == ownerStack {
+		boxed, ok := l.borrow(ctx, v)
 		if !ok {
 			return false
 		}
@@ -1040,13 +1024,16 @@ func (l arm64Lowerer) drop(ctx *lowering, op step) bool {
 	return true
 }
 
+// dup duplicates the top operand. A deferred ref (owner != ownerStack) is
+// still backed by its slot, so the duplicate stays deferred with the same
+// owner/home and no retain; an owned ref takes a fresh retain for the copy.
 func (l arm64Lowerer) dup(ctx *lowering) bool {
 	if ctx.count() < 1 {
 		return false
 	}
 	v := ctx.values[len(ctx.values)-1]
-	if v.kind == types.KindRef {
-		boxed, ok := l.box(ctx, v)
+	if v.kind == types.KindRef && v.owner == ownerStack {
+		boxed, ok := l.borrow(ctx, v)
 		if !ok {
 			return false
 		}
@@ -1116,7 +1103,7 @@ func (l arm64Lowerer) constGetKnown(ctx *lowering, op step) bool {
 	switch ctx.heap[ref].(type) {
 	case types.TypedArray[bool], types.TypedArray[int8], types.TypedArray[int32],
 		types.TypedArray[float32], types.TypedArray[float64]:
-		ctx.push(value{kind: types.KindRef, raw: true, ref: ref})
+		ctx.push(value{kind: types.KindRef, owner: ownerConst, ref: ref})
 		return true
 	default:
 		return l.constGet(ctx, op)
@@ -1168,7 +1155,7 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 	}
 	marker := ctx.values[len(ctx.values)-2]
 	constant := marker.ref
-	if !marker.raw || constant <= 0 || constant >= len(ctx.heap) {
+	if marker.owner != ownerConst || constant <= 0 || constant >= len(ctx.heap) {
 		return false
 	}
 
@@ -1191,14 +1178,11 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 	}
 
 	pre := append([]value(nil), ctx.values...)
-	boxed := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	ctx.assembler.Emit(arm64.LDI(boxed, uint64(types.BoxRef(constant)))...)
-	ctx.values[len(ctx.values)-2] = value{reg: boxed, kind: types.KindRef, raw: false, ref: constant}
 	if !l.flush(ctx, false) {
 		return false
 	}
 	clear(ctx.frame().state)
-	fail := ctx.queueExit(nil, op.ip, constant, prof.ExitGuardValue, int(op.op))
+	fail := ctx.queueExit(nil, op.ip, prof.ExitGuardValue, int(op.op))
 
 	a := ctx.assembler
 	heap := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -1250,7 +1234,11 @@ func (l arm64Lowerer) enterBlock(ctx *lowering, state []slot) {
 	ctx.spare = asm.VReg{}
 	ctx.values = ctx.values[:0]
 	for _, slot := range state {
-		ctx.values = append(ctx.values, value{kind: slot.kind, ref: slot.ref, raw: slot.refKnown})
+		o := ownerStack
+		if slot.refKnown {
+			o = ownerConst
+		}
+		ctx.values = append(ctx.values, value{kind: slot.kind, ref: slot.ref, owner: o})
 	}
 	frame := ctx.frame()
 	clear(frame.state)
@@ -1332,7 +1320,7 @@ func (l arm64Lowerer) label(ctx *lowering, target edge, tail []int, opcode int) 
 		if ctx.kind == entryLoop {
 			reason = prof.ExitLoop
 		}
-		return ctx.queueExit(nil, target.anchor.ip, 0, reason, opcode), true
+		return ctx.queueExit(nil, target.anchor.ip, reason, opcode), true
 	}
 	if target.block < 0 || target.block >= len(ctx.blocks) {
 		return 0, false
@@ -1342,7 +1330,7 @@ func (l arm64Lowerer) label(ctx *lowering, target edge, tail []int, opcode int) 
 		return ctx.labels[target.block], true
 	}
 	if l.marked(ctx) || ctx.scheduled >= continuationLimit {
-		return ctx.queueExit(nil, target.anchor.ip, 0, prof.ExitColdBranch, opcode), true
+		return ctx.queueExit(nil, target.anchor.ip, prof.ExitColdBranch, opcode), true
 	}
 	label := ctx.assembler.Label()
 	work := work{label: label, block: target.block, tail: tail}
@@ -1352,10 +1340,16 @@ func (l arm64Lowerer) label(ctx *lowering, target edge, tail []int, opcode int) 
 	return label, true
 }
 
-// marked reports whether a raw ref marker blocks deferred continuation reload.
+// marked reports whether a constant ref marker blocks deferred continuation
+// reload. reload() already reconstructs a slot-backed deferred value
+// correctly (flush wrote its boxed content to the operand's VM stack home
+// with no retain, and owner/home survive the round trip unchanged), so only
+// ownerConst — whose compile-time fn/ref identity a plain reload cannot
+// reconstruct — must force a branch to fall back to queueExit instead of a
+// learned continuation.
 func (l arm64Lowerer) marked(ctx *lowering) bool {
 	for _, v := range ctx.values {
-		if v.kind == types.KindRef && v.raw {
+		if v.owner == ownerConst {
 			return true
 		}
 	}
@@ -1398,6 +1392,21 @@ func (l arm64Lowerer) directCall(ctx *lowering, op step) bool {
 	marker := ctx.pop()
 	if marker.fn != op.callee || ctx.count() < params || !l.args(ctx, target, params) {
 		return false
+	}
+	// A real BLR hands this caller's flushed operand stack to the interpreter
+	// when the callee traps (the unwind adopts the caller frames), and passes
+	// each ref argument to the callee as an owned param it releases on RETURN.
+	// Either way a deferred ref must own its retain before the flush, or the
+	// interpreter/callee would release a reference this trace never took.
+	// Post-call consumers are emitted after this mutation, so they observe
+	// ownerStack and release normally.
+	for i := range ctx.values {
+		v := &ctx.values[i]
+		if v.kind == types.KindRef && v.owner != ownerStack {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
+		}
 	}
 	if !l.flush(ctx, false) {
 		return false
@@ -2226,7 +2235,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 	}
 	closureRef := 0
 	params := len(target.Typ.Params)
-	if v.raw {
+	if v.owner == ownerConst {
 		if v.fn != op.callee {
 			return false
 		}
@@ -2258,7 +2267,9 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 		ctx.assembler.Emit(arm64.LDI(want, uint64(types.BoxRef(wantRef)))...)
 		ctx.assembler.Emit(arm64.CMP(v.reg, want))
 		ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
-		l.releaseBox(ctx, v.reg, pre, op.ip)
+		if v.owner == ownerStack {
+			l.releaseBox(ctx, v.reg, pre, op.ip)
+		}
 	}
 	if len(target.Captures) > 0 {
 		if closureRef <= 0 || closureRef >= len(ctx.heap) {
@@ -2288,7 +2299,11 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 	vStack := ctx.pin(scratchStack)
 	addr := l.base(ctx, vStack)
 	for k := 0; k < params; k++ {
-		boxed, ok := l.box(ctx, ctx.values[len(ctx.values)-params+k])
+		// This inlines the callee's own activation directly onto the VM
+		// stack, so a deferred argument must own its retain here: its home
+		// slot is unrelated storage that may change independently of this
+		// new frame's local.
+		boxed, ok := l.own(ctx, &ctx.values[len(ctx.values)-params+k])
 		if !ok {
 			return false
 		}
@@ -2328,6 +2343,24 @@ func (l arm64Lowerer) selfCall(ctx *lowering, op step, target *types.Function, p
 		case types.KindI1, types.KindI8, types.KindI32, types.KindF32, types.KindF64, types.KindI64:
 		default:
 			return false
+		}
+	}
+	// This BL re-enters compiled code from the top; when the callee traps, the
+	// journal unwind adopts THIS caller's flushed operand stack and the
+	// interpreter releases each stack ref it later pops. Frame isolation once
+	// suggested a local-backed deferral was safe (recursion cannot address an
+	// ancestor's locals), but the callee-trap unwind adopts the caller's
+	// flushed stack regardless of which slot backs the deferral, and the
+	// recursion may also run arbitrary GLOBAL_SET/UPVAL_SET on shared storage
+	// this trace cannot see. So every deferred ref must own its retain before
+	// the call. (The committing flush below also rejects any deferred it still
+	// sees, so this sweep is what keeps such traces compiling.)
+	for i := range ctx.values {
+		v := &ctx.values[i]
+		if v.kind == types.KindRef && v.owner != ownerStack {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
 		}
 	}
 	if !l.flush(ctx, true) {
@@ -2448,6 +2481,18 @@ func (l arm64Lowerer) tailLoop(ctx *lowering, op step) bool {
 	if ctx.count() != 0 {
 		return false
 	}
+	// The whole frame chain is about to be replaced by a single fresh
+	// activation at the anchor, so every local- or upval-backed deferral in
+	// the trace — regardless of which now-discarded frame it names — must own
+	// its retain before that storage stops being tracked.
+	for i := range ctx.values {
+		v := &ctx.values[i]
+		if v.kind == types.KindRef && (v.owner == ownerLocal || v.owner == ownerUpval) {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
+		}
+	}
 	f := newActivation(ctx.addr, target, 0, 0)
 	if !l.locals(ctx, &f, args) {
 		return false
@@ -2479,6 +2524,21 @@ func (l arm64Lowerer) tailMorph(ctx *lowering, op step) bool {
 	if ctx.count() != 0 {
 		return false
 	}
+	// Only the innermost (current) frame is being replaced in place; a
+	// deferred local at or above its base names storage this morph is about
+	// to overwrite with the callee's own locals, and its closure's upvals may
+	// die with it, so both must own their retain first.
+	for i := range ctx.values {
+		v := &ctx.values[i]
+		if v.kind != types.KindRef {
+			continue
+		}
+		if (v.owner == ownerLocal && v.home >= base) || v.owner == ownerUpval {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
+		}
+	}
 	f := newActivation(op.callee, target, base, len(ctx.values))
 	f.resume = op.ip + 1
 	if !l.locals(ctx, &f, args) {
@@ -2506,7 +2566,7 @@ func (l arm64Lowerer) tailTarget(ctx *lowering, op step) (*types.Function, int, 
 		return nil, 0, false
 	}
 	params := len(target.Typ.Params)
-	if v.raw {
+	if v.owner == ownerConst {
 		if v.fn != op.callee || v.ref != op.callee {
 			return nil, 0, false
 		}
@@ -2531,7 +2591,9 @@ func (l arm64Lowerer) tailTarget(ctx *lowering, op step) (*types.Function, int, 
 		}
 		ctx.assembler.Bind(ok)
 		pre := ctx.pre()
-		l.releaseBox(ctx, v.reg, pre, op.ip)
+		if v.owner == ownerStack {
+			l.releaseBox(ctx, v.reg, pre, op.ip)
+		}
 	}
 	ctx.pop()
 	if ctx.count() < params || !l.args(ctx, target, params) {
@@ -2553,7 +2615,7 @@ func (l arm64Lowerer) args(ctx *lowering, target *types.Function, params int) bo
 			return false
 		}
 		if v.kind == types.KindRef {
-			if v.raw {
+			if v.owner == ownerConst {
 				return false
 			}
 			continue
@@ -2570,6 +2632,14 @@ func (l arm64Lowerer) args(ctx *lowering, target *types.Function, params int) bo
 // Each slot is loaded and dirty so the next flush commits it to the VM stack.
 func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
 	for k := range args {
+		// This becomes a new frame's own tracked local, so a deferred ref
+		// argument must own its retain: the new home is unrelated storage
+		// from the one it deferred to.
+		if args[k].kind == types.KindRef && args[k].owner != ownerStack {
+			if _, ok := l.own(ctx, &args[k]); !ok {
+				return false
+			}
+		}
 		f.locals[k] = args[k]
 		f.state[k] |= localLoaded | localDirty
 	}
@@ -2597,6 +2667,20 @@ func (l arm64Lowerer) stitch(ctx *lowering) bool {
 		return false
 	}
 	rets := append([]value(nil), ctx.values[len(ctx.values)-f.returns:]...)
+	// The frame that produced these values is retiring: a return backed by
+	// one of its own locals, or by its closure's upvals, would otherwise keep
+	// pointing at storage this stitch is about to stop tracking.
+	for i := range rets {
+		v := &rets[i]
+		if v.kind != types.KindRef {
+			continue
+		}
+		if (v.owner == ownerLocal && v.home >= f.base) || v.owner == ownerUpval {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
+		}
+	}
 	ctx.values = ctx.values[:f.opBase]
 	ctx.frames = ctx.frames[:len(ctx.frames)-1]
 	ctx.values = append(ctx.values, rets...)
@@ -2613,8 +2697,10 @@ func (l arm64Lowerer) ret(ctx *lowering) bool {
 	vStack := ctx.pin(scratchStack)
 	addr := l.base(ctx, vStack)
 	for idx := 0; idx < ctx.returns; idx++ {
-		v := ctx.values[len(ctx.values)-ctx.returns+idx]
-		boxed, ok := l.box(ctx, v)
+		// The entry frame is about to end, so a deferred return value must own
+		// its retain here: the Go wrapper reads these VM stack slots as
+		// ordinary owned values with no notion of a slot-backed deferral.
+		boxed, ok := l.own(ctx, &ctx.values[len(ctx.values)-ctx.returns+idx])
 		if !ok {
 			return false
 		}
@@ -2636,6 +2722,10 @@ func (l arm64Lowerer) complete(ctx *lowering) bool {
 	if !l.flush(ctx, false) {
 		return false
 	}
+	// The wrapper preserves this top-level operand stack on trapNone (see
+	// start()), and the interpreter adopts each stack ref as owned, so a
+	// deferred ref left on the stack at module end must re-take its retain.
+	l.redeem(ctx)
 	a := ctx.assembler
 	vCtrl := ctx.pin(scratchCtrl)
 	vBP := ctx.pin(scratchBP)
@@ -2699,7 +2789,7 @@ func (l arm64Lowerer) reload(ctx *lowering) {
 	addr := l.base(ctx, vStack)
 	for j := range ctx.values {
 		v := &ctx.values[j]
-		if v.kind == types.KindRef && v.raw {
+		if v.owner == ownerConst {
 			continue
 		}
 		reg := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -2771,8 +2861,7 @@ func (l arm64Lowerer) upvalGet(ctx *lowering, op step) bool {
 		dst = l.sign64(ctx, dst)
 	}
 	if kind == types.KindRef {
-		l.retainBox(ctx, dst)
-		ctx.push(value{reg: dst, kind: kind, raw: false})
+		ctx.push(value{reg: dst, kind: kind, owner: ownerUpval, home: idx})
 		return true
 	}
 	ctx.push(value{reg: dst, kind: kind, raw: true})
@@ -2786,13 +2875,25 @@ func (l arm64Lowerer) upvalSet(ctx *lowering, op step) bool {
 		return false
 	}
 	kind := f.upvals[idx]
-	v := ctx.values[len(ctx.values)-1]
-	if v.kind != kind {
+	vp := &ctx.values[len(ctx.values)-1]
+	if vp.kind != kind {
 		return false
 	}
-	boxed, ok := l.box(ctx, v)
-	if !ok {
-		return false
+	var boxed asm.VReg
+	var ok bool
+	if kind == types.KindRef {
+		boxed, ok = l.own(ctx, vp)
+		if !ok {
+			return false
+		}
+		if !l.settle(ctx, ownerUpval, idx) {
+			return false
+		}
+	} else {
+		boxed, ok = l.borrow(ctx, *vp)
+		if !ok {
+			return false
+		}
 	}
 	base := l.upvalBase(ctx)
 	if kind == types.KindRef || kind == types.KindI64 {
@@ -2839,8 +2940,9 @@ func (l arm64Lowerer) refIsNull(ctx *lowering, op step) bool {
 	if ctx.count() < 1 || ctx.values[len(ctx.values)-1].kind != types.KindRef {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -2848,10 +2950,13 @@ func (l arm64Lowerer) refIsNull(ctx *lowering, op step) bool {
 	ctx.assembler.Emit(arm64.LDI(vNull, uint64(types.BoxedNull))...)
 	ctx.assembler.Emit(arm64.CMP(ref, vNull))
 	// Capture the flags before release clobbers them, then release the consumed
-	// ref so the bool result leaves no leaked reference on the stack.
+	// ref (when it carries its own retain) so the bool result leaves no leaked
+	// reference on the stack. A deferred operand carries no retain to release.
 	flag := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.CSET(flag, arm64.CondEQ))
-	l.releaseBox(ctx, ref, pre, op.ip)
+	if owned {
+		l.releaseBox(ctx, ref, pre, op.ip)
+	}
 	ctx.pop()
 	ctx.push(value{reg: flag, kind: types.KindI1, raw: true})
 	return true
@@ -2878,8 +2983,9 @@ func (l arm64Lowerer) refGet(ctx *lowering, op step) bool {
 	default:
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -2896,7 +3002,9 @@ func (l arm64Lowerer) refGet(ctx *lowering, op step) bool {
 	} else {
 		ctx.assembler.Emit(arm64.LDRSW(result, data, 0))
 	}
-	l.releaseRef(ctx, addr, pre, op.ip)
+	if owned {
+		l.releaseRef(ctx, addr, pre, op.ip)
+	}
 	ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: result, kind: kind, raw: true})
 	return true
 }
@@ -2911,8 +3019,9 @@ func (l arm64Lowerer) stringLen(ctx *lowering, op step) bool {
 	if ctx.count() < 1 || ctx.values[len(ctx.values)-1].kind != types.KindRef {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -2927,7 +3036,9 @@ func (l arm64Lowerer) stringLen(ctx *lowering, op step) bool {
 	n := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.LDR(n, data, sliceLen))
 	ctx.assembler.Emit(arm64.MOV(result, n))
-	l.releaseRef(ctx, addr, pre, op.ip)
+	if owned {
+		l.releaseRef(ctx, addr, pre, op.ip)
+	}
 	ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: result, kind: types.KindI32, raw: true})
 	return true
 }
@@ -2944,8 +3055,9 @@ func (l arm64Lowerer) arrayLen(ctx *lowering, op step) bool {
 	default:
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -2960,7 +3072,9 @@ func (l arm64Lowerer) arrayLen(ctx *lowering, op step) bool {
 	n := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.LDR(n, data, base+sliceLen))
 	ctx.assembler.Emit(arm64.MOV(result, n))
-	l.releaseRef(ctx, addr, pre, op.ip)
+	if owned {
+		l.releaseRef(ctx, addr, pre, op.ip)
+	}
 	ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: result, kind: types.KindI32, raw: true})
 	return true
 }
@@ -3006,6 +3120,7 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-2].owner == ownerStack
 	pre := ctx.pre()
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-1].reg)
 	a := ctx.assembler
@@ -3021,7 +3136,7 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	if !ok {
 		return false
 	}
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-2])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-2])
 	if !ok {
 		return false
 	}
@@ -3063,10 +3178,12 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	if kind == types.KindI64 {
 		l.guardBoxable(ctx, result, valueFail)
 	}
-	rcBase := l.rcBase(ctx)
-	rc := l.guardRC(ctx, addr, rcBase, valueFail)
-	a.Emit(arm64.SUBI(rc, rc, 1))
-	a.Emit(arm64.STRR(rc, rcBase, addr))
+	if owned {
+		rcBase := l.rcBase(ctx)
+		rc := l.guardRC(ctx, addr, rcBase, valueFail)
+		a.Emit(arm64.SUBI(rc, rc, 1))
+		a.Emit(arm64.STRR(rc, rcBase, addr))
+	}
 	if kind == types.KindRef {
 		l.retainBox(ctx, result)
 	}
@@ -3108,10 +3225,11 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-3].owner == ownerStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-3])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-3])
 	if !ok {
 		return false
 	}
@@ -3143,9 +3261,9 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 			clear(ctx.frames[idx].state)
 		}
 		ctx.reuseLocals = len(ctx.values) == 3
-		fail = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardShape, int(op.op))
-		bounds = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardBounds, int(op.op))
-		valueFail = ctx.queueExit(nil, op.ip, 0, prof.ExitGuardValue, int(op.op))
+		fail = ctx.queueExit(nil, op.ip, prof.ExitGuardShape, int(op.op))
+		bounds = ctx.queueExit(nil, op.ip, prof.ExitGuardBounds, int(op.op))
+		valueFail = ctx.queueExit(nil, op.ip, prof.ExitGuardValue, int(op.op))
 	}
 	var addr, itab, data, scratch asm.VReg
 	remat := false
@@ -3180,17 +3298,19 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	l.guardIndex(ctx, idx, n, bounds)
 
 	var rcBase, rc, rcAddr asm.VReg
-	if continuable {
-		rcBase = scratch
-		l.rcBaseTo(ctx, rcBase)
-		ctx.assembler.Emit(arm64.MOV(n, addr))
-		rcAddr = addr
-		rc = n
-		l.guardRCTo(ctx, rc, rcAddr, rcBase, valueFail)
-	} else {
-		rcBase = l.rcBase(ctx)
-		rcAddr = addr
-		rc = l.guardRC(ctx, rcAddr, rcBase, valueFail)
+	if owned {
+		if continuable {
+			rcBase = scratch
+			l.rcBaseTo(ctx, rcBase)
+			ctx.assembler.Emit(arm64.MOV(n, addr))
+			rcAddr = addr
+			rc = n
+			l.guardRCTo(ctx, rc, rcAddr, rcBase, valueFail)
+		} else {
+			rcBase = l.rcBase(ctx)
+			rcAddr = addr
+			rc = l.guardRC(ctx, rcAddr, rcBase, valueFail)
+		}
 	}
 
 	if kind == types.KindRef {
@@ -3198,19 +3318,24 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		// overwritten element's release, which carries its own internal deopt
 		// (releaseBoxUnlessEqual -> releaseRef -> guardRC). Neither refcount is
 		// decremented until both checks pass, matching the release-old-ref-first
-		// idiom used by globalSet.
+		// idiom used by globalSet. A deferred container has no matching release
+		// to run at all.
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
 		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
-		a.Emit(arm64.SUBI(rc, rc, 1))
-		a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+		if owned {
+			a.Emit(arm64.SUBI(rc, rc, 1))
+			a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+		}
 		a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 	} else {
 		// All primitive-store guards have passed, so release the consumed array
 		// operand before address formation. This shortens addr/rc liveness and
 		// keeps mutation loops within the no-spill register budget.
-		a.Emit(arm64.SUBI(rc, rc, 1))
-		a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+		if owned {
+			a.Emit(arm64.SUBI(rc, rc, 1))
+			a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+		}
 		switch kind {
 		case types.KindI1, types.KindI8:
 			target := n
@@ -3239,7 +3364,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 			}
 			a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 		}
-		if continuable && remat {
+		if continuable && remat && owned {
 			ctx.spare = rc
 		}
 	}
@@ -3264,9 +3389,10 @@ func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != heapStruct {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-2].owner == ownerStack
 	pre := ctx.pre()
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-1].reg)
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-2])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-2])
 	if !ok {
 		return false
 	}
@@ -3317,13 +3443,17 @@ func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
 	if out == types.KindI64 {
 		l.guardBoxable(ctx, result, valueFail)
 	}
-	rcBase := l.rcBase(ctx)
-	rc := l.guardRC(ctx, addr, rcBase, valueFail)
-	if out == types.KindRef {
+	if owned {
+		rcBase := l.rcBase(ctx)
+		rc := l.guardRC(ctx, addr, rcBase, valueFail)
+		if out == types.KindRef {
+			l.retainBox(ctx, result)
+		}
+		a.Emit(arm64.SUBI(rc, rc, 1))
+		a.Emit(arm64.STRR(rc, rcBase, addr))
+	} else if out == types.KindRef {
 		l.retainBox(ctx, result)
 	}
-	a.Emit(arm64.SUBI(rc, rc, 1))
-	a.Emit(arm64.STRR(rc, rcBase, addr))
 	ctx.values = append(pre[:len(pre)-2:len(pre)-2], value{reg: result, kind: out, raw: out != types.KindRef})
 	return true
 }
@@ -3348,10 +3478,11 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != heapStruct {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-3].owner == ownerStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-3])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-3])
 	if !ok {
 		return false
 	}
@@ -3396,8 +3527,11 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 	a.Emit(arm64.CMPI(fieldKindReg, uint16(kind)))
 	a.Emit(arm64.BCondLabel(arm64.OpBNE, kindFail))
 
-	rcBase := l.rcBase(ctx)
-	rc := l.guardRC(ctx, addr, rcBase, valueFail)
+	var rcBase, rc asm.VReg
+	if owned {
+		rcBase = l.rcBase(ctx)
+		rc = l.guardRC(ctx, addr, rcBase, valueFail)
+	}
 
 	dataPtr, _ := l.sliceHeader(ctx, data, int16(structData))
 	if kind == types.KindRef {
@@ -3405,7 +3539,7 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 		// above is the deopt point for the container's own refcount, and the
 		// overwritten field's release (releaseBoxUnlessEqual) carries its own
 		// internal deopt. Neither refcount is decremented until both checks
-		// pass.
+		// pass. A deferred container has no matching release to run at all.
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
 		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
@@ -3420,8 +3554,10 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 		}
 		a.Emit(arm64.STRR(stored, dataPtr, idx))
 	}
-	a.Emit(arm64.SUBI(rc, rc, 1))
-	a.Emit(arm64.STRR(rc, rcBase, addr))
+	if owned {
+		a.Emit(arm64.SUBI(rc, rc, 1))
+		a.Emit(arm64.STRR(rc, rcBase, addr))
+	}
 	if kind == types.KindRef {
 		a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 	}
@@ -3447,8 +3583,9 @@ func (l arm64Lowerer) errorGet(ctx *lowering, op step) bool {
 	if op.shape.itab != heapError {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -3468,9 +3605,19 @@ func (l arm64Lowerer) errorGet(ctx *lowering, op step) bool {
 			return false
 		}
 		dst = l.sign64(ctx, dst)
-		l.releaseRef(ctx, addr, pre, op.ip)
+		if owned {
+			l.releaseRef(ctx, addr, pre, op.ip)
+		}
 		ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: true})
 	case types.KindRef:
+		if !owned {
+			// No release follows, so the container can never hit zero here:
+			// the exclusive-owner guard below exists only to protect a
+			// release-triggered free, and is moot without one.
+			l.retainBox(ctx, dst)
+			ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: false})
+			break
+		}
 		base := l.rcBase(ctx)
 		rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDRR(rc, base, addr))
@@ -3487,7 +3634,9 @@ func (l arm64Lowerer) errorGet(ctx *lowering, op step) bool {
 		l.releaseRef(ctx, addr, pre, op.ip)
 		ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: false})
 	case types.KindI32, types.KindF32, types.KindF64:
-		l.releaseRef(ctx, addr, pre, op.ip)
+		if owned {
+			l.releaseRef(ctx, addr, pre, op.ip)
+		}
 		ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: true})
 	default:
 		return false
@@ -3498,7 +3647,7 @@ func (l arm64Lowerer) errorGet(ctx *lowering, op step) bool {
 // coroDone reads a coroutine handle's done flag and pushes it as an i32 (0 or
 // 1). It mirrors the threaded handler: the handle ref stays owned by its stack
 // slot, so no refcount changes. A constant coroutine handle is impossible, so
-// a raw (unboxed constant) ref is rejected to avoid box's retain side effect.
+// a raw (unboxed constant) ref is rejected to avoid a retain side effect.
 func (l arm64Lowerer) coroDone(ctx *lowering, op step) bool {
 	if ctx.count() < 1 {
 		return false
@@ -3507,11 +3656,11 @@ func (l arm64Lowerer) coroDone(ctx *lowering, op step) bool {
 		return false
 	}
 	v := ctx.values[len(ctx.values)-1]
-	if v.kind != types.KindRef || v.raw {
+	if v.kind != types.KindRef || v.owner == ownerConst {
 		return false
 	}
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, v)
+	ref, ok := l.borrow(ctx, v)
 	if !ok {
 		return false
 	}
@@ -3539,8 +3688,9 @@ func (l arm64Lowerer) coroValue(ctx *lowering, op step) bool {
 	if op.shape.itab != heapCoroutine {
 		return false
 	}
+	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
 	pre := ctx.pre()
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -3560,9 +3710,16 @@ func (l arm64Lowerer) coroValue(ctx *lowering, op step) bool {
 			return false
 		}
 		dst = l.sign64(ctx, dst)
-		l.releaseRef(ctx, addr, pre, op.ip)
+		if owned {
+			l.releaseRef(ctx, addr, pre, op.ip)
+		}
 		ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: true})
 	case types.KindRef:
+		if !owned {
+			l.retainBox(ctx, dst)
+			ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: false})
+			break
+		}
 		base := l.rcBase(ctx)
 		rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDRR(rc, base, addr))
@@ -3579,7 +3736,9 @@ func (l arm64Lowerer) coroValue(ctx *lowering, op step) bool {
 		l.releaseRef(ctx, addr, pre, op.ip)
 		ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: false})
 	case types.KindI32, types.KindF32, types.KindF64:
-		l.releaseRef(ctx, addr, pre, op.ip)
+		if owned {
+			l.releaseRef(ctx, addr, pre, op.ip)
+		}
 		ctx.values = append(pre[:len(pre)-1:len(pre)-1], value{reg: dst, kind: kind, raw: true})
 	default:
 		return false
@@ -3626,6 +3785,12 @@ func (l arm64Lowerer) trap(ctx *lowering, kind, resume int, reason prof.ExitReas
 	}
 	id := -1
 	if kind == trapFallback {
+		// trapFallback hands the flushed operand stack to the threaded
+		// interpreter, which releases each stack ref it pops. Re-take every
+		// deferred ref's retain from its home first. trapYield never reaches
+		// here with a deferred live: its only caller commits first, and a
+		// committing flush rejects deferred refs (see flush).
+		l.redeem(ctx)
 		id = len(ctx.descriptors)
 		ctx.descriptors = append(ctx.descriptors, exitDescriptor{reason: reason, opcode: opcode})
 	}
@@ -3648,6 +3813,43 @@ func (l arm64Lowerer) trapFlushed(ctx *lowering, kind, resume, exitID int) {
 	a.Emit(
 		arm64.RET(),
 	)
+}
+
+// redeem re-takes the deferred retain for every operand in the current
+// snapshot whose ref was flushed to its VM stack home without one. A cold path
+// that hands the flushed operand stack to the threaded interpreter (a
+// trapFallback terminal exit, module completion) needs this: the interpreter
+// adopts each stack ref as owned and later releases it, so a deferred ref
+// flushed without a retain would be freed once too often. The caller must have
+// flushed the operands first — the home is authoritative — and must NOT change
+// any owner, because the surviving hot path keeps emitting with the same
+// symbolic state. Each call allocates fresh registers; the guard-exit stubs
+// need a register-reusing variant instead (see materializeExits) because they
+// emit this per exit rather than once per trace.
+func (l arm64Lowerer) redeem(ctx *lowering) {
+	var addr asm.VReg
+	for j, v := range ctx.values {
+		switch v.owner {
+		case ownerStack:
+		case ownerConst:
+			ref := v.ref
+			if ref == 0 {
+				ref = v.fn
+			}
+			if ref > 0 {
+				l.retain(ctx, ref)
+			}
+		default:
+			if addr.Width() == asm.WidthUndefined {
+				addr = l.base(ctx, ctx.pin(scratchStack))
+			}
+			reg := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+			ctx.assembler.Emit(arm64.LDR(reg, addr, int16(ctx.slot(j)*8)))
+			refAddr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+			ctx.assembler.Emit(arm64.ANDI(refAddr, reg, maskI32))
+			l.retainRef(ctx, refAddr)
+		}
+	}
 }
 
 // loadHeap loads a heap cell for a value already proven to have ref kind by the
@@ -3860,7 +4062,7 @@ func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason pr
 	if !l.flush(ctx, false) {
 		return 0, false
 	}
-	label := ctx.queueExit(nil, resume, 0, reason, opcode)
+	label := ctx.queueExit(nil, resume, reason, opcode)
 	ctx.values = append(ctx.values[:0], pre...)
 	return label, true
 }
@@ -3889,19 +4091,41 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 			}
 		}
 	}
-	// A non-raw ref carries the retain taken when it was pushed, so committing it
-	// transfers that edge to the stack. A raw marker instead retains inside box()
-	// for an interpreter frame to release; a commit rebuilds no frame, so nothing
-	// would balance it.
+	// An ownerStack ref carries the retain taken when it was pushed, so
+	// committing it transfers that edge to the stack. Every deferred ref (a
+	// const marker or a slot-backed value) is written boxed WITHOUT a retain,
+	// so it is only safe when a cold path re-takes the retain before the
+	// flushed copy reaches the interpreter (see redeem / materializeExits). A
+	// committing flush has no such cold path — the committed stack can reach
+	// the threaded interpreter through the loop-backedge yield with no stub to
+	// balance it — so every deferred owner rejects a commit, and the trace
+	// keeps a loop-carried deferred ref threaded. A non-commit flush writes the
+	// boxed ref for a following redeem (or exit stub) to retain.
 	for j, v := range ctx.values {
-		if v.kind == types.KindRef && commit && v.raw {
-			return false
+		switch v.owner {
+		case ownerStack:
+			boxed, ok := l.boxHome(ctx, v)
+			if !ok {
+				return false
+			}
+			a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
+		case ownerConst:
+			if commit {
+				return false
+			}
+			ref := v.ref
+			if ref == 0 {
+				ref = v.fn
+			}
+			boxed := a.Reg(asm.RegTypeInt, asm.Width64)
+			a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(ref)))...)
+			a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
+		default:
+			if commit {
+				return false
+			}
+			a.Emit(arm64.STR(v.reg, addr, int16(ctx.slot(j)*8)))
 		}
-		boxed, ok := l.boxHome(ctx, v)
-		if !ok {
-			return false
-		}
-		a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
 	}
 	return true
 }
@@ -3985,19 +4209,64 @@ func (l arm64Lowerer) boxHome(ctx *lowering, v value) (asm.VReg, bool) {
 		case types.KindI32:
 			tag = tagI32
 		default:
-			return l.box(ctx, v)
+			return l.borrow(ctx, v)
 		}
 		ctx.assembler.Emit(arm64.ANDI(ctx.spare, v.reg, maskI32))
 		ctx.assembler.Emit(arm64.MOVK(ctx.spare, uint16(tag>>48), 48))
 		return ctx.spare, true
 	}
-	return l.box(ctx, v)
+	return l.borrow(ctx, v)
 }
 
-// box produces the boxed form of v in a fresh register. A marker materializes
-// its function ref and retains it, because the interpreter state being rebuilt
-// will release it through the frame it pushes.
-func (l arm64Lowerer) box(ctx *lowering, v value) (asm.VReg, bool) {
+// settle owns every operand backed by the slot identified by (o, home) before
+// that slot's content changes underneath it — a LOCAL_SET/GLOBAL_SET/UPVAL_SET
+// write, or a frame dying at RETURN/tail dispatch. A deferred value left
+// unsettled would keep pointing at a home whose content (or existence) no
+// longer matches what it observed.
+func (l arm64Lowerer) settle(ctx *lowering, o owner, home int) bool {
+	for i := range ctx.values {
+		v := &ctx.values[i]
+		if v.kind == types.KindRef && v.owner == o && v.home == home {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// own borrows v and, when its reference count is deferred to backing storage
+// (owner != ownerStack), takes the retain that transfers ownership onto the
+// operand stack and marks v owned. Callers pass a pointer into ctx.values (or
+// other frame-owned storage) so a later exit snapshot never also stub-retains
+// the same transfer.
+func (l arm64Lowerer) own(ctx *lowering, v *value) (asm.VReg, bool) {
+	reg, ok := l.borrow(ctx, *v)
+	if !ok {
+		return asm.VReg{}, false
+	}
+	if v.kind != types.KindRef || v.owner == ownerStack {
+		return reg, true
+	}
+	if v.owner == ownerConst {
+		ref := v.ref
+		if ref == 0 {
+			ref = v.fn
+		}
+		l.retain(ctx, ref)
+		v.reg = reg
+	} else {
+		l.retainKnownBox(ctx, reg)
+	}
+	v.owner = ownerStack
+	return reg, true
+}
+
+// borrow produces the boxed form of v in a fresh register for read-only use.
+// It takes no reference-count action: an ownerConst ref materializes its
+// compile-time constant with no retain, and every other ref (ownerStack or
+// deferred to slot-backed storage) is already boxed in v.reg.
+func (l arm64Lowerer) borrow(ctx *lowering, v value) (asm.VReg, bool) {
 	a := ctx.assembler
 	switch v.kind {
 	case types.KindI32:
@@ -4043,7 +4312,7 @@ func (l arm64Lowerer) box(ctx *lowering, v value) (asm.VReg, bool) {
 	case types.KindF64:
 		return v.reg, true
 	case types.KindRef:
-		if !v.raw {
+		if v.owner != ownerConst {
 			return v.reg, true
 		}
 		ref := v.ref
@@ -4052,7 +4321,6 @@ func (l arm64Lowerer) box(ctx *lowering, v value) (asm.VReg, bool) {
 		}
 		boxed := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(ref)))...)
-		l.retain(ctx, ref)
 		return boxed, true
 	}
 	return asm.VReg{}, false

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -121,11 +121,7 @@ func (l arm64Lowerer) materializeExits(ctx *lowering) {
 		for j, v := range exit.values {
 			switch v.owner {
 			case ownerConst:
-				ref := v.ref
-				if ref == 0 {
-					ref = v.fn
-				}
-				if ref > 0 {
+				if ref := v.constant(); ref > 0 {
 					l.retain(ctx, ref)
 				}
 			case ownerLocal, ownerGlobal, ownerUpval:
@@ -295,15 +291,12 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 		if op.fn != f.addr {
 			return false, false
 		}
-		consumed, ok := l.fuse(ctx, ops, idx)
-		if !ok {
-			return false, false
-		}
+		consumed := l.fuse(ctx, ops, idx)
 		if consumed > 0 {
 			idx += consumed - 1
 			continue
 		}
-		ok = false
+		ok := false
 		switch op.op {
 		case instr.NOP:
 			ok = true
@@ -728,34 +721,36 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 	return false, true
 }
 
-// fuse lowers short sequences whose intermediate ref ownership can be
-// eliminated safely. It returns the number of steps lowered; a miss leaves
-// standalone lowering untouched, while false rejects native compilation.
-func (l arm64Lowerer) fuse(ctx *lowering, ops []step, idx int) (int, bool) {
-	if idx+1 >= len(ops) || !l.adjacent(ops[idx], ops[idx+1]) {
-		return 0, true
+// fuse lowers an adjacent constant function load and call as one marker.
+// It returns the number of source steps consumed; a miss leaves standalone
+// lowering untouched.
+func (l arm64Lowerer) fuse(ctx *lowering, ops []step, idx int) int {
+	if idx+1 >= len(ops) {
+		return 0
 	}
 	source := ops[idx]
 	consumer := ops[idx+1]
-	if l.target(ctx, source, consumer) {
-		return 1, true
+	if source.fn != consumer.fn || source.depth != consumer.depth {
+		return 0
 	}
-	return 0, true
-}
-
-// target replaces a constant function load with a raw call marker. CALL and
-// RETURN_CALL remain in steps, which owns frame-changing operations.
-func (l arm64Lowerer) target(ctx *lowering, source, consumer step) bool {
-	if source.op != instr.CONST_GET || (consumer.op != instr.CALL && consumer.op != instr.RETURN_CALL) {
-		return false
+	width := 1
+	for _, operand := range instr.TypeOf(source.op).Widths {
+		if operand < 0 {
+			return 0
+		}
+		width += operand
+	}
+	if consumer.ip != source.ip+width || source.op != instr.CONST_GET ||
+		(consumer.op != instr.CALL && consumer.op != instr.RETURN_CALL) {
+		return 0
 	}
 	constant := int(source.args[0])
 	if constant >= len(ctx.constants) || ctx.constants[constant].Kind() != types.KindRef {
-		return false
+		return 0
 	}
 	ref := ctx.constants[constant].Ref()
 	if ref < 0 || ref >= len(ctx.heap) {
-		return false
+		return 0
 	}
 	callee := ref
 	switch fn := ctx.heap[ref].(type) {
@@ -763,27 +758,13 @@ func (l arm64Lowerer) target(ctx *lowering, source, consumer step) bool {
 		callee = int(fn.Fn)
 	case *types.Function:
 	default:
-		return false
+		return 0
 	}
 	if callee != consumer.callee || resolve(ctx.module, ctx.heap, callee) == nil {
-		return false
+		return 0
 	}
 	ctx.push(value{fn: callee, kind: types.KindRef, owner: ownerConst, ref: ref})
-	return true
-}
-
-func (l arm64Lowerer) adjacent(a, b step) bool {
-	if a.fn != b.fn || a.depth != b.depth {
-		return false
-	}
-	width := 1
-	for _, operand := range instr.TypeOf(a.op).Widths {
-		if operand < 0 {
-			return false
-		}
-		width += operand
-	}
-	return b.ip == a.ip+width
+	return 1
 }
 
 func (l arm64Lowerer) i32Const(ctx *lowering, op step) bool {
@@ -890,7 +871,7 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 			l.retainBoxUnlessEqual(ctx, old, boxed)
 		}
 		ctx.assembler.Emit(arm64.STR(boxed, addr, int16((f.base+idx)*8)))
-		f.locals[idx] = value{reg: boxed, kind: types.KindRef, raw: false}
+		f.locals[idx] = value{reg: boxed, kind: types.KindRef}
 		f.state[idx] |= localLoaded
 		if pop {
 			ctx.pop()
@@ -1038,7 +1019,7 @@ func (l arm64Lowerer) dup(ctx *lowering) bool {
 			return false
 		}
 		l.retainBox(ctx, boxed)
-		v = value{reg: boxed, kind: types.KindRef, raw: false}
+		v = value{reg: boxed, kind: types.KindRef}
 	}
 	ctx.push(v)
 	return true
@@ -1143,7 +1124,7 @@ func (l arm64Lowerer) constGet(ctx *lowering, op step) bool {
 		boxed := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDI(boxed, uint64(v))...)
 		l.retain(ctx, ref)
-		ctx.push(value{reg: boxed, kind: types.KindRef, raw: false, ref: ref})
+		ctx.push(value{reg: boxed, kind: types.KindRef, ref: ref})
 		return true
 	}
 	return false
@@ -2477,21 +2458,11 @@ func (l arm64Lowerer) tailLoop(ctx *lowering, op step) bool {
 		args[k] = ctx.pop()
 	}
 	// A tail call stands in return position: no operands survive besides the
-	// arguments just consumed.
+	// arguments just consumed. The anchor frame has opBase 0, so ctx.count() == 0
+	// means ctx.values is empty here and no deferred operand needs owning; the
+	// arguments are owned into the new frame by locals() below.
 	if ctx.count() != 0 {
 		return false
-	}
-	// The whole frame chain is about to be replaced by a single fresh
-	// activation at the anchor, so every local- or upval-backed deferral in
-	// the trace — regardless of which now-discarded frame it names — must own
-	// its retain before that storage stops being tracked.
-	for i := range ctx.values {
-		v := &ctx.values[i]
-		if v.kind == types.KindRef && (v.owner == ownerLocal || v.owner == ownerUpval) {
-			if _, ok := l.own(ctx, v); !ok {
-				return false
-			}
-		}
 	}
 	f := newActivation(ctx.addr, target, 0, 0)
 	if !l.locals(ctx, &f, args) {
@@ -2524,21 +2495,11 @@ func (l arm64Lowerer) tailMorph(ctx *lowering, op step) bool {
 	if ctx.count() != 0 {
 		return false
 	}
-	// Only the innermost (current) frame is being replaced in place; a
-	// deferred local at or above its base names storage this morph is about
-	// to overwrite with the callee's own locals, and its closure's upvals may
-	// die with it, so both must own their retain first.
-	for i := range ctx.values {
-		v := &ctx.values[i]
-		if v.kind != types.KindRef {
-			continue
-		}
-		if (v.owner == ownerLocal && v.home >= base) || v.owner == ownerUpval {
-			if _, ok := l.own(ctx, v); !ok {
-				return false
-			}
-		}
-	}
+	// Only the innermost frame is replaced in place. Its own operands are gone
+	// (count() == 0), and any surviving operand belongs to an outer frame below
+	// this base: an ownerLocal home there is < base by construction, and an
+	// ownerUpval names a closure that does not die in this morph, so no sweep is
+	// needed. The arguments are owned into the new frame by locals() below.
 	f := newActivation(op.callee, target, base, len(ctx.values))
 	f.resume = op.ip + 1
 	if !l.locals(ctx, &f, args) {
@@ -2932,7 +2893,7 @@ func (l arm64Lowerer) refNull(ctx *lowering) bool {
 	boxed := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.LDI(boxed, uint64(types.BoxedNull))...)
 	l.retainBox(ctx, boxed)
-	ctx.push(value{reg: boxed, kind: types.KindRef, raw: false})
+	ctx.push(value{reg: boxed, kind: types.KindRef})
 	return true
 }
 
@@ -3225,6 +3186,16 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false
 	}
+	if kind == types.KindRef {
+		// The stored ref transfers into the element, so it must own its retain:
+		// threaded ARRAY_SET moves the popped operand's +1 into the container,
+		// and a deferred value has none. Own before pre() so the pre snapshot and
+		// every exit snapshot see ownerStack and no stub double-retains it
+		// (mirrors localSet).
+		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
+			return false
+		}
+	}
 	owned := ctx.values[len(ctx.values)-3].owner == ownerStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
@@ -3477,6 +3448,16 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 	}
 	if op.shape.itab != 0 && op.shape.itab != heapStruct {
 		return false
+	}
+	if kind == types.KindRef {
+		// The stored ref transfers into the field, so it must own its retain:
+		// threaded STRUCT_SET moves the popped operand's +1 into the container,
+		// and a deferred value has none. Own before pre() so the pre snapshot and
+		// every exit snapshot see ownerStack and no stub double-retains it
+		// (mirrors localSet).
+		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
+			return false
+		}
 	}
 	owned := ctx.values[len(ctx.values)-3].owner == ownerStack
 	pre := ctx.pre()
@@ -3832,11 +3813,7 @@ func (l arm64Lowerer) redeem(ctx *lowering) {
 		switch v.owner {
 		case ownerStack:
 		case ownerConst:
-			ref := v.ref
-			if ref == 0 {
-				ref = v.fn
-			}
-			if ref > 0 {
+			if ref := v.constant(); ref > 0 {
 				l.retain(ctx, ref)
 			}
 		default:
@@ -4020,20 +3997,6 @@ func (l arm64Lowerer) retainBox(ctx *lowering, v asm.VReg) {
 	})
 }
 
-// retainKnownBox retains a boxed value already proven to be a ref, avoiding a
-// tag guard and reusing the pinned spare register on leaf plans.
-func (l arm64Lowerer) retainKnownBox(ctx *lowering, v asm.VReg) {
-	a := ctx.assembler
-	addr := a.Reg(asm.RegTypeInt, asm.Width64)
-	a.Emit(arm64.ANDI(addr, v, maskI32))
-	base := ctx.pin(scratchSP)
-	l.rcBaseTo(ctx, base)
-	rc := a.Reg(asm.RegTypeInt, asm.Width64)
-	a.Emit(arm64.LDRR(rc, base, addr))
-	a.Emit(arm64.ADDI(rc, rc, 1))
-	a.Emit(arm64.STRR(rc, base, addr))
-}
-
 func (l arm64Lowerer) retainRef(ctx *lowering, addr asm.VReg) {
 	base := l.rcBase(ctx)
 	rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
@@ -4072,6 +4035,18 @@ func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason pr
 // a guard's cold path flushes a copy of the state and must leave the symbolic
 // state of the surviving hot path untouched.
 func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
+	// A committing flush transfers each ownerStack ref's retain to the VM
+	// stack, but it has no cold stub to re-take a deferred ref's retain: the
+	// loop-backedge yield can reach the threaded interpreter directly. Reject
+	// any live deferred ref up front, before emitting or mutating anything, so
+	// a loop-carried deferred ref keeps the trace threaded.
+	if commit {
+		for _, v := range ctx.values {
+			if v.owner != ownerStack {
+				return false
+			}
+		}
+	}
 	a := ctx.assembler
 	vStack := ctx.pin(scratchStack)
 	addr := l.base(ctx, vStack)
@@ -4092,15 +4067,11 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 		}
 	}
 	// An ownerStack ref carries the retain taken when it was pushed, so
-	// committing it transfers that edge to the stack. Every deferred ref (a
-	// const marker or a slot-backed value) is written boxed WITHOUT a retain,
-	// so it is only safe when a cold path re-takes the retain before the
-	// flushed copy reaches the interpreter (see redeem / materializeExits). A
-	// committing flush has no such cold path — the committed stack can reach
-	// the threaded interpreter through the loop-backedge yield with no stub to
-	// balance it — so every deferred owner rejects a commit, and the trace
-	// keeps a loop-carried deferred ref threaded. A non-commit flush writes the
-	// boxed ref for a following redeem (or exit stub) to retain.
+	// committing it transfers that edge to the stack. A non-commit flush writes
+	// each deferred ref boxed WITHOUT a retain; a following redeem or exit stub
+	// re-takes it before the flushed copy reaches the interpreter (see redeem /
+	// materializeExits). The commit pre-scan above already rejected any deferred
+	// owner, so those cases only run on a non-commit flush.
 	for j, v := range ctx.values {
 		switch v.owner {
 		case ownerStack:
@@ -4110,20 +4081,10 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 			}
 			a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
 		case ownerConst:
-			if commit {
-				return false
-			}
-			ref := v.ref
-			if ref == 0 {
-				ref = v.fn
-			}
 			boxed := a.Reg(asm.RegTypeInt, asm.Width64)
-			a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(ref)))...)
+			a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(v.constant())))...)
 			a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
 		default:
-			if commit {
-				return false
-			}
 			a.Emit(arm64.STR(v.reg, addr, int16(ctx.slot(j)*8)))
 		}
 	}
@@ -4249,14 +4210,12 @@ func (l arm64Lowerer) own(ctx *lowering, v *value) (asm.VReg, bool) {
 		return reg, true
 	}
 	if v.owner == ownerConst {
-		ref := v.ref
-		if ref == 0 {
-			ref = v.fn
-		}
-		l.retain(ctx, ref)
+		l.retain(ctx, v.constant())
 		v.reg = reg
 	} else {
-		l.retainKnownBox(ctx, reg)
+		addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+		ctx.assembler.Emit(arm64.ANDI(addr, reg, maskI32))
+		l.retainRef(ctx, addr)
 	}
 	v.owner = ownerStack
 	return reg, true
@@ -4315,12 +4274,8 @@ func (l arm64Lowerer) borrow(ctx *lowering, v value) (asm.VReg, bool) {
 		if v.owner != ownerConst {
 			return v.reg, true
 		}
-		ref := v.ref
-		if ref == 0 {
-			ref = v.fn
-		}
 		boxed := a.Reg(asm.RegTypeInt, asm.Width64)
-		a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(ref)))...)
+		a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(v.constant())))...)
 		return boxed, true
 	}
 	return asm.VReg{}, false

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -13,6 +13,13 @@ import (
 // arm64Lowerer is the AArch64 JIT lowerer.
 type arm64Lowerer struct{}
 
+type flushMode uint8
+
+const (
+	flushSnapshot flushMode = iota
+	flushCommit
+)
+
 // Boxing masks used by scalar lowering.
 const (
 	maskI32 = uint64(0xFFFFFFFF)
@@ -97,11 +104,11 @@ func (l arm64Lowerer) enter(ctx *lowering) {
 	a.Bind(ctx.head)
 }
 
-// materializeExits emits every queued cold stub. A deferred ref in the exit
-// snapshot was flushed to its VM stack home without a retain, and the
+// emitExits emits every queued cold stub. A deferred ref in the exit
+// snapshot was flushed to its VM stack slot without a retain, and the
 // interpreter resuming there releases each stack ref it pops, so the stub
 // takes the retain here — on the cold path only.
-func (l arm64Lowerer) materializeExits(ctx *lowering) {
+func (l arm64Lowerer) emitExits(ctx *lowering) {
 	// Every exit's cold stub is a mutually exclusive, straight-line block
 	// (each ends in trapFlushed, an unconditional trap/return), so the
 	// registers used to reload-and-retain a deferred value are safe to reuse
@@ -119,14 +126,14 @@ func (l arm64Lowerer) materializeExits(ctx *lowering) {
 		ctx.assembler.Bind(exit.label)
 		var addr asm.VReg
 		for j, v := range exit.values {
-			switch v.owner {
-			case ownerConst:
-				if ref := v.constant(); ref > 0 {
+			switch v.backing {
+			case backingConst:
+				if ref := v.ref; ref > 0 {
 					l.retain(ctx, ref)
 				}
-			case ownerLocal, ownerGlobal, ownerUpval:
+			case backingLocal, backingGlobal, backingUpval:
 				// The stub owns no live registers, but flush wrote every
-				// operand to its VM stack home before the guard, so the home
+				// operand to its VM stack slot before the guard, so the slot
 				// is authoritative: reload the boxed ref from there and take
 				// the retain the interpreter frame will release.
 				if addr.Width() == asm.WidthUndefined {
@@ -196,7 +203,7 @@ func (l arm64Lowerer) term(ctx *lowering, block block, tail []int) bool {
 		if block.term.hot == 0 {
 			return l.next(ctx, block.anchor, target, tail, int(instr.BR))
 		}
-		if !l.flush(ctx, false) {
+		if !l.flush(ctx, flushSnapshot) {
 			return false
 		}
 		return l.path(ctx, block.anchor, target, tail, int(instr.BR))
@@ -235,7 +242,7 @@ func (l arm64Lowerer) conditional(ctx *lowering, block block, tail []int) bool {
 	if block.term.hot >= 0 && block.term.hot < len(block.term.edges) {
 		cold := 1 - block.term.hot
 		clean := l.clean(ctx)
-		if !clean && !l.flush(ctx, false) {
+		if !clean && !l.flush(ctx, flushSnapshot) {
 			return false
 		}
 		target := block.term.edges[cold]
@@ -251,7 +258,7 @@ func (l arm64Lowerer) conditional(ctx *lowering, block block, tail []int) bool {
 		return l.next(ctx, block.anchor, block.term.edges[block.term.hot], tail, int(instr.BR_IF))
 	}
 
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 	taken := ctx.assembler.Label()
@@ -267,7 +274,7 @@ func (l arm64Lowerer) next(ctx *lowering, from anchor, target edge, tail []int, 
 	tail = appendTail(target.tail, tail)
 	target.tail = nil
 	if target.anchor.addr == from.addr && target.anchor.ip <= from.ip {
-		if !l.flush(ctx, false) {
+		if !l.flush(ctx, flushSnapshot) {
 			return false
 		}
 		return l.path(ctx, from, target, tail, opcode)
@@ -443,7 +450,7 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 		case instr.F64_GE:
 			ok = l.f64Cmp(ctx, arm64.CondGE)
 		case instr.ARRAY_GET:
-			if ctx.count() >= 2 && ctx.values[len(ctx.values)-2].owner == ownerConst && ctx.values[len(ctx.values)-2].ref > 0 {
+			if ctx.count() >= 2 && ctx.values[len(ctx.values)-2].backing == backingConst && ctx.values[len(ctx.values)-2].ref > 0 {
 				ok = l.arrayGetKnown(ctx, op)
 			} else {
 				ok = l.arrayGet(ctx, op)
@@ -763,7 +770,7 @@ func (l arm64Lowerer) fuse(ctx *lowering, ops []step, idx int) int {
 	if callee != consumer.callee || resolve(ctx.module, ctx.heap, callee) == nil {
 		return 0
 	}
-	ctx.push(value{fn: callee, kind: types.KindRef, owner: ownerConst, ref: ref})
+	ctx.push(value{fn: callee, kind: types.KindRef, backing: backingConst, ref: ref})
 	return 1
 }
 
@@ -806,11 +813,11 @@ func (l arm64Lowerer) unreachable(ctx *lowering, op step) bool {
 	return l.exit(ctx, op.ip, prof.ExitTerminalOp, int(op.op))
 }
 
-// localGet loads local idx and, for a ref, pushes it deferred: owner ownerLocal
-// with home f.base+idx records that the slot itself still carries the retain,
+// localGet loads local idx and, for a ref, pushes it deferred: backingLocal
+// with slot f.base+idx records that the slot itself still carries the retain,
 // so no retain is taken here. A container consumer that later reads this
 // operand elides its matching release to balance the missing retain; a
-// LOCAL_SET/tail/RETURN that would invalidate the slot settles this deferral
+// LOCAL_SET/tail/RETURN that would invalidate the slot detaches this deferral
 // into a real retain first.
 func (l arm64Lowerer) localGet(ctx *lowering, op step) bool {
 	f := ctx.frame()
@@ -826,8 +833,8 @@ func (l arm64Lowerer) localGet(ctx *lowering, op step) bool {
 	}
 	v := f.locals[idx]
 	if v.kind == types.KindRef {
-		v.owner = ownerLocal
-		v.home = f.base + idx
+		v.backing = backingLocal
+		v.slot = f.base + idx
 	}
 	ctx.push(v)
 	return true
@@ -845,15 +852,15 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 	}
 	if vp.kind == types.KindRef {
 		// Own the incoming value before it is captured into a guard snapshot:
-		// pre() must observe ownerStack, or a deopt on this op would re-enter
+		// pre() must observe backingStack, or a deopt on this op would re-enter
 		// the interpreter expecting a retain the stub cannot see anymore.
-		// settle() then materializes every other deferred reader of the slot
+		// detach() then materializes every other deferred reader of the slot
 		// this SET is about to overwrite.
 		boxed, ok := l.own(ctx, vp)
 		if !ok {
 			return false
 		}
-		if !l.settle(ctx, ownerLocal, f.base+idx) {
+		if !l.detach(ctx, backingLocal, f.base+idx) {
 			return false
 		}
 		pre := ctx.pre()
@@ -890,7 +897,7 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 }
 
 // globalGet loads a global directly from the globals base. Scalars push
-// raw; a ref pushes deferred (owner ownerGlobal, home idx): the slot itself
+// raw; a ref pushes deferred (backingGlobal, slot idx): the slot itself
 // still carries the retain, so no retain is taken here (see localGet).
 func (l arm64Lowerer) globalGet(ctx *lowering, op step) bool {
 	idx, kind, ok := l.global(ctx, op)
@@ -907,7 +914,7 @@ func (l arm64Lowerer) globalGet(ctx *lowering, op step) bool {
 		dst = l.sign64(ctx, dst)
 	}
 	if kind == types.KindRef {
-		ctx.push(value{reg: dst, kind: kind, owner: ownerGlobal, home: idx})
+		ctx.push(value{reg: dst, kind: kind, backing: backingGlobal, slot: idx})
 		return true
 	}
 	ctx.push(value{reg: dst, kind: kind, raw: true})
@@ -933,17 +940,17 @@ func (l arm64Lowerer) globalSet(ctx *lowering, op step, pop bool) bool {
 	var boxed asm.VReg
 	if kind == types.KindRef {
 		// Own the incoming value before it can be captured by a guard
-		// snapshot, then settle every other deferred reader of the slot this
+		// snapshot, then detach every other deferred reader of the slot this
 		// SET is about to overwrite (see localSet).
 		boxed, ok = l.own(ctx, vp)
 		if !ok {
 			return false
 		}
-		if !l.settle(ctx, ownerGlobal, idx) {
+		if !l.detach(ctx, backingGlobal, idx) {
 			return false
 		}
 	} else {
-		boxed, ok = l.borrow(ctx, *vp)
+		boxed, ok = l.box(ctx, *vp)
 		if !ok {
 			return false
 		}
@@ -994,8 +1001,8 @@ func (l arm64Lowerer) drop(ctx *lowering, op step) bool {
 	}
 	pre := ctx.pre()
 	v := ctx.values[len(ctx.values)-1]
-	if v.kind == types.KindRef && v.owner == ownerStack {
-		boxed, ok := l.borrow(ctx, v)
+	if v.kind == types.KindRef && v.backing == backingStack {
+		boxed, ok := l.box(ctx, v)
 		if !ok {
 			return false
 		}
@@ -1005,16 +1012,16 @@ func (l arm64Lowerer) drop(ctx *lowering, op step) bool {
 	return true
 }
 
-// dup duplicates the top operand. A deferred ref (owner != ownerStack) is
+// dup duplicates the top operand. A deferred ref (backing != backingStack) is
 // still backed by its slot, so the duplicate stays deferred with the same
-// owner/home and no retain; an owned ref takes a fresh retain for the copy.
+// backing/slot and no retain; an owned ref takes a fresh retain for the copy.
 func (l arm64Lowerer) dup(ctx *lowering) bool {
 	if ctx.count() < 1 {
 		return false
 	}
 	v := ctx.values[len(ctx.values)-1]
-	if v.kind == types.KindRef && v.owner == ownerStack {
-		boxed, ok := l.borrow(ctx, v)
+	if v.kind == types.KindRef && v.backing == backingStack {
+		boxed, ok := l.box(ctx, v)
 		if !ok {
 			return false
 		}
@@ -1052,7 +1059,7 @@ func (l arm64Lowerer) selectOp(ctx *lowering) bool {
 }
 
 // clean reports whether a branch can skip the hot-path flush: no live operand
-// or dirty local will be reloaded from VM stack homes later in the trace.
+// or dirty local will be reloaded from VM stack slots later in the trace.
 func (l arm64Lowerer) clean(ctx *lowering) bool {
 	if ctx.count() != 0 {
 		return false
@@ -1084,7 +1091,7 @@ func (l arm64Lowerer) constGetKnown(ctx *lowering, op step) bool {
 	switch ctx.heap[ref].(type) {
 	case types.TypedArray[bool], types.TypedArray[int8], types.TypedArray[int32],
 		types.TypedArray[float32], types.TypedArray[float64]:
-		ctx.push(value{kind: types.KindRef, owner: ownerConst, ref: ref})
+		ctx.push(value{kind: types.KindRef, backing: backingConst, ref: ref})
 		return true
 	default:
 		return l.constGet(ctx, op)
@@ -1136,7 +1143,7 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 	}
 	marker := ctx.values[len(ctx.values)-2]
 	constant := marker.ref
-	if marker.owner != ownerConst || constant <= 0 || constant >= len(ctx.heap) {
+	if marker.backing != backingConst || constant <= 0 || constant >= len(ctx.heap) {
 		return false
 	}
 
@@ -1159,7 +1166,7 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 	}
 
 	pre := append([]value(nil), ctx.values...)
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 	clear(ctx.frame().state)
@@ -1215,11 +1222,11 @@ func (l arm64Lowerer) enterBlock(ctx *lowering, state []slot) {
 	ctx.spare = asm.VReg{}
 	ctx.values = ctx.values[:0]
 	for _, slot := range state {
-		o := ownerStack
+		o := backingStack
 		if slot.refKnown {
-			o = ownerConst
+			o = backingConst
 		}
-		ctx.values = append(ctx.values, value{kind: slot.kind, ref: slot.ref, owner: o})
+		ctx.values = append(ctx.values, value{kind: slot.kind, ref: slot.ref, backing: o})
 	}
 	frame := ctx.frame()
 	clear(frame.state)
@@ -1233,7 +1240,7 @@ func (l arm64Lowerer) table(ctx *lowering, block block, tail []int) bool {
 	cond := ctx.pop()
 	value := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.ANDI(value, cond.reg, maskI32))
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 	labels := make([]asm.Label, len(block.term.edges))
@@ -1258,7 +1265,7 @@ func (l arm64Lowerer) follow(ctx *lowering, tail []int) bool {
 	if len(tail) == 0 {
 		return true
 	}
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 	id := tail[0]
@@ -1323,14 +1330,14 @@ func (l arm64Lowerer) label(ctx *lowering, target edge, tail []int, opcode int) 
 
 // marked reports whether a constant ref marker blocks deferred continuation
 // reload. reload() already reconstructs a slot-backed deferred value
-// correctly (flush wrote its boxed content to the operand's VM stack home
-// with no retain, and owner/home survive the round trip unchanged), so only
-// ownerConst — whose compile-time fn/ref identity a plain reload cannot
+// correctly (flush wrote its boxed content to the operand's VM stack slot
+// with no retain, and backing/slot survive the round trip unchanged), so only
+// backingConst — whose compile-time fn/ref identity a plain reload cannot
 // reconstruct — must force a branch to fall back to queueExit instead of a
 // learned continuation.
 func (l arm64Lowerer) marked(ctx *lowering) bool {
 	for _, v := range ctx.values {
-		if v.owner == ownerConst {
+		if v.backing == backingConst {
 			return true
 		}
 	}
@@ -1380,16 +1387,11 @@ func (l arm64Lowerer) directCall(ctx *lowering, op step) bool {
 	// Either way a deferred ref must own its retain before the flush, or the
 	// interpreter/callee would release a reference this trace never took.
 	// Post-call consumers are emitted after this mutation, so they observe
-	// ownerStack and release normally.
-	for i := range ctx.values {
-		v := &ctx.values[i]
-		if v.kind == types.KindRef && v.owner != ownerStack {
-			if _, ok := l.own(ctx, v); !ok {
-				return false
-			}
-		}
+	// backingStack and release normally.
+	if !l.ownRefs(ctx) {
+		return false
 	}
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 
@@ -2216,7 +2218,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 	}
 	closureRef := 0
 	params := len(target.Typ.Params)
-	if v.owner == ownerConst {
+	if v.backing == backingConst {
 		if v.fn != op.callee {
 			return false
 		}
@@ -2248,7 +2250,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 		ctx.assembler.Emit(arm64.LDI(want, uint64(types.BoxRef(wantRef)))...)
 		ctx.assembler.Emit(arm64.CMP(v.reg, want))
 		ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
-		if v.owner == ownerStack {
+		if v.backing == backingStack {
 			l.releaseBox(ctx, v.reg, pre, op.ip)
 		}
 	}
@@ -2281,7 +2283,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 	addr := l.base(ctx, vStack)
 	for k := 0; k < params; k++ {
 		// This inlines the callee's own activation directly onto the VM
-		// stack, so a deferred argument must own its retain here: its home
+		// stack, so a deferred argument must own its retain here: its backing slot
 		// slot is unrelated storage that may change independently of this
 		// new frame's local.
 		boxed, ok := l.own(ctx, &ctx.values[len(ctx.values)-params+k])
@@ -2336,15 +2338,10 @@ func (l arm64Lowerer) selfCall(ctx *lowering, op step, target *types.Function, p
 	// this trace cannot see. So every deferred ref must own its retain before
 	// the call. (The committing flush below also rejects any deferred it still
 	// sees, so this sweep is what keeps such traces compiling.)
-	for i := range ctx.values {
-		v := &ctx.values[i]
-		if v.kind == types.KindRef && v.owner != ownerStack {
-			if _, ok := l.own(ctx, v); !ok {
-				return false
-			}
-		}
+	if !l.ownRefs(ctx) {
+		return false
 	}
-	if !l.flush(ctx, true) {
+	if !l.flush(ctx, flushCommit) {
 		return false
 	}
 
@@ -2469,7 +2466,7 @@ func (l arm64Lowerer) tailLoop(ctx *lowering, op step) bool {
 		return false
 	}
 	ctx.frames = append(ctx.frames[:0], f)
-	if !l.flush(ctx, true) {
+	if !l.flush(ctx, flushCommit) {
 		return false
 	}
 	return l.iterate(ctx, 0)
@@ -2497,8 +2494,8 @@ func (l arm64Lowerer) tailMorph(ctx *lowering, op step) bool {
 	}
 	// Only the innermost frame is replaced in place. Its own operands are gone
 	// (count() == 0), and any surviving operand belongs to an outer frame below
-	// this base: an ownerLocal home there is < base by construction, and an
-	// ownerUpval names a closure that does not die in this morph, so no sweep is
+	// this base: a backingLocal slot there is < base by construction, and an
+	// backingUpval names a closure that does not die in this morph, so no sweep is
 	// needed. The arguments are owned into the new frame by locals() below.
 	f := newActivation(op.callee, target, base, len(ctx.values))
 	f.resume = op.ip + 1
@@ -2527,7 +2524,7 @@ func (l arm64Lowerer) tailTarget(ctx *lowering, op step) (*types.Function, int, 
 		return nil, 0, false
 	}
 	params := len(target.Typ.Params)
-	if v.owner == ownerConst {
+	if v.backing == backingConst {
 		if v.fn != op.callee || v.ref != op.callee {
 			return nil, 0, false
 		}
@@ -2552,7 +2549,7 @@ func (l arm64Lowerer) tailTarget(ctx *lowering, op step) (*types.Function, int, 
 		}
 		ctx.assembler.Bind(ok)
 		pre := ctx.pre()
-		if v.owner == ownerStack {
+		if v.backing == backingStack {
 			l.releaseBox(ctx, v.reg, pre, op.ip)
 		}
 	}
@@ -2576,7 +2573,7 @@ func (l arm64Lowerer) args(ctx *lowering, target *types.Function, params int) bo
 			return false
 		}
 		if v.kind == types.KindRef {
-			if v.owner == ownerConst {
+			if v.backing == backingConst {
 				return false
 			}
 			continue
@@ -2594,9 +2591,9 @@ func (l arm64Lowerer) args(ctx *lowering, target *types.Function, params int) bo
 func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
 	for k := range args {
 		// This becomes a new frame's own tracked local, so a deferred ref
-		// argument must own its retain: the new home is unrelated storage
+		// argument must own its retain: the new backing slot is unrelated storage
 		// from the one it deferred to.
-		if args[k].kind == types.KindRef && args[k].owner != ownerStack {
+		if args[k].kind == types.KindRef && args[k].backing != backingStack {
 			if _, ok := l.own(ctx, &args[k]); !ok {
 				return false
 			}
@@ -2636,7 +2633,7 @@ func (l arm64Lowerer) stitch(ctx *lowering) bool {
 		if v.kind != types.KindRef {
 			continue
 		}
-		if (v.owner == ownerLocal && v.home >= f.base) || v.owner == ownerUpval {
+		if (v.backing == backingLocal && v.slot >= f.base) || v.backing == backingUpval {
 			if _, ok := l.own(ctx, v); !ok {
 				return false
 			}
@@ -2680,13 +2677,13 @@ func (l arm64Lowerer) ret(ctx *lowering) bool {
 // complete finishes top-level module code: live locals and operands are boxed
 // back to the VM stack, SP is published, and the wrapper marks the frame done.
 func (l arm64Lowerer) complete(ctx *lowering) bool {
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 	// The wrapper preserves this top-level operand stack on trapNone (see
 	// start()), and the interpreter adopts each stack ref as owned, so a
 	// deferred ref left on the stack at module end must re-take its retain.
-	l.redeem(ctx)
+	l.retainDeferred(ctx)
 	a := ctx.assembler
 	vCtrl := ctx.pin(scratchCtrl)
 	vBP := ctx.pin(scratchBP)
@@ -2740,7 +2737,7 @@ func (l arm64Lowerer) overflow(ctx *lowering, op step) {
 	)
 }
 
-// reload pulls operands back from VM stack homes after a call or continuation.
+// reload pulls operands back from VM stack slots after a call or continuation.
 func (l arm64Lowerer) reload(ctx *lowering) {
 	a := ctx.assembler
 	if len(ctx.values) == 0 {
@@ -2750,7 +2747,7 @@ func (l arm64Lowerer) reload(ctx *lowering) {
 	addr := l.base(ctx, vStack)
 	for j := range ctx.values {
 		v := &ctx.values[j]
-		if v.owner == ownerConst {
+		if v.backing == backingConst {
 			continue
 		}
 		reg := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -2822,7 +2819,7 @@ func (l arm64Lowerer) upvalGet(ctx *lowering, op step) bool {
 		dst = l.sign64(ctx, dst)
 	}
 	if kind == types.KindRef {
-		ctx.push(value{reg: dst, kind: kind, owner: ownerUpval, home: idx})
+		ctx.push(value{reg: dst, kind: kind, backing: backingUpval, slot: idx})
 		return true
 	}
 	ctx.push(value{reg: dst, kind: kind, raw: true})
@@ -2847,11 +2844,11 @@ func (l arm64Lowerer) upvalSet(ctx *lowering, op step) bool {
 		if !ok {
 			return false
 		}
-		if !l.settle(ctx, ownerUpval, idx) {
+		if !l.detach(ctx, backingUpval, idx) {
 			return false
 		}
 	} else {
-		boxed, ok = l.borrow(ctx, *vp)
+		boxed, ok = l.box(ctx, *vp)
 		if !ok {
 			return false
 		}
@@ -2901,9 +2898,9 @@ func (l arm64Lowerer) refIsNull(ctx *lowering, op step) bool {
 	if ctx.count() < 1 || ctx.values[len(ctx.values)-1].kind != types.KindRef {
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -2944,9 +2941,9 @@ func (l arm64Lowerer) refGet(ctx *lowering, op step) bool {
 	default:
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -2980,9 +2977,9 @@ func (l arm64Lowerer) stringLen(ctx *lowering, op step) bool {
 	if ctx.count() < 1 || ctx.values[len(ctx.values)-1].kind != types.KindRef {
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -3016,9 +3013,9 @@ func (l arm64Lowerer) arrayLen(ctx *lowering, op step) bool {
 	default:
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -3081,7 +3078,7 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-2].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-2].backing == backingStack
 	pre := ctx.pre()
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-1].reg)
 	a := ctx.assembler
@@ -3097,7 +3094,7 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	if !ok {
 		return false
 	}
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-2])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-2])
 	if !ok {
 		return false
 	}
@@ -3190,17 +3187,17 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		// The stored ref transfers into the element, so it must own its retain:
 		// threaded ARRAY_SET moves the popped operand's +1 into the container,
 		// and a deferred value has none. Own before pre() so the pre snapshot and
-		// every exit snapshot see ownerStack and no stub double-retains it
+		// every exit snapshot see backingStack and no stub double-retains it
 		// (mirrors localSet).
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
 			return false
 		}
 	}
-	owned := ctx.values[len(ctx.values)-3].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-3].backing == backingStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-3])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-3])
 	if !ok {
 		return false
 	}
@@ -3224,8 +3221,8 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		// A continuable primitive store is a state barrier: materialize the
 		// pre-op frame once, then let all guards share that resumable snapshot.
 		// Clearing the local register cache bounds no-spill pressure and makes
-		// subsequent operations reload from the homes just written.
-		if !l.flush(ctx, false) {
+		// subsequent operations reload from the slots just written.
+		if !l.flush(ctx, flushSnapshot) {
 			return false
 		}
 		for idx := range ctx.frames {
@@ -3360,10 +3357,10 @@ func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
 	if op.shape.itab != 0 && op.shape.itab != heapStruct {
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-2].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-2].backing == backingStack
 	pre := ctx.pre()
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-1].reg)
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-2])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-2])
 	if !ok {
 		return false
 	}
@@ -3453,17 +3450,17 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 		// The stored ref transfers into the field, so it must own its retain:
 		// threaded STRUCT_SET moves the popped operand's +1 into the container,
 		// and a deferred value has none. Own before pre() so the pre snapshot and
-		// every exit snapshot see ownerStack and no stub double-retains it
+		// every exit snapshot see backingStack and no stub double-retains it
 		// (mirrors localSet).
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
 			return false
 		}
 	}
-	owned := ctx.values[len(ctx.values)-3].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-3].backing == backingStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-3])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-3])
 	if !ok {
 		return false
 	}
@@ -3564,9 +3561,9 @@ func (l arm64Lowerer) errorGet(ctx *lowering, op step) bool {
 	if op.shape.itab != heapError {
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -3637,11 +3634,11 @@ func (l arm64Lowerer) coroDone(ctx *lowering, op step) bool {
 		return false
 	}
 	v := ctx.values[len(ctx.values)-1]
-	if v.kind != types.KindRef || v.owner == ownerConst {
+	if v.kind != types.KindRef || v.backing == backingConst {
 		return false
 	}
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, v)
+	ref, ok := l.box(ctx, v)
 	if !ok {
 		return false
 	}
@@ -3669,9 +3666,9 @@ func (l arm64Lowerer) coroValue(ctx *lowering, op step) bool {
 	if op.shape.itab != heapCoroutine {
 		return false
 	}
-	owned := ctx.values[len(ctx.values)-1].owner == ownerStack
+	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
-	ref, ok := l.borrow(ctx, ctx.values[len(ctx.values)-1])
+	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
 	if !ok {
 		return false
 	}
@@ -3761,17 +3758,17 @@ func (l arm64Lowerer) exit(ctx *lowering, resume int, reason prof.ExitReason, op
 // is recorded resuming at resume, and the trap kind is reported. trapFallback
 // resumes threaded dispatch; trapYield re-enters native after a safepoint.
 func (l arm64Lowerer) trap(ctx *lowering, kind, resume int, reason prof.ExitReason, opcode int) bool {
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
 	id := -1
 	if kind == trapFallback {
 		// trapFallback hands the flushed operand stack to the threaded
 		// interpreter, which releases each stack ref it pops. Re-take every
-		// deferred ref's retain from its home first. trapYield never reaches
+		// deferred ref's retain from its backing slot first. trapYield never reaches
 		// here with a deferred live: its only caller commits first, and a
 		// committing flush rejects deferred refs (see flush).
-		l.redeem(ctx)
+		l.retainDeferred(ctx)
 		id = len(ctx.descriptors)
 		ctx.descriptors = append(ctx.descriptors, exitDescriptor{reason: reason, opcode: opcode})
 	}
@@ -3796,24 +3793,24 @@ func (l arm64Lowerer) trapFlushed(ctx *lowering, kind, resume, exitID int) {
 	)
 }
 
-// redeem re-takes the deferred retain for every operand in the current
-// snapshot whose ref was flushed to its VM stack home without one. A cold path
+// retainDeferred re-takes the deferred retain for every operand in the current
+// snapshot whose ref was flushed to its VM stack slot without one. A cold path
 // that hands the flushed operand stack to the threaded interpreter (a
 // trapFallback terminal exit, module completion) needs this: the interpreter
 // adopts each stack ref as owned and later releases it, so a deferred ref
 // flushed without a retain would be freed once too often. The caller must have
-// flushed the operands first — the home is authoritative — and must NOT change
-// any owner, because the surviving hot path keeps emitting with the same
+// flushed the operands first — the slot is authoritative — and must NOT change
+// any backing, because the surviving hot path keeps emitting with the same
 // symbolic state. Each call allocates fresh registers; the guard-exit stubs
-// need a register-reusing variant instead (see materializeExits) because they
+// need a register-reusing variant instead (see emitExits) because they
 // emit this per exit rather than once per trace.
-func (l arm64Lowerer) redeem(ctx *lowering) {
+func (l arm64Lowerer) retainDeferred(ctx *lowering) {
 	var addr asm.VReg
 	for j, v := range ctx.values {
-		switch v.owner {
-		case ownerStack:
-		case ownerConst:
-			if ref := v.constant(); ref > 0 {
+		switch v.backing {
+		case backingStack:
+		case backingConst:
+			if ref := v.ref; ref > 0 {
 				l.retain(ctx, ref)
 			}
 		default:
@@ -3831,7 +3828,7 @@ func (l arm64Lowerer) redeem(ctx *lowering) {
 
 // loadHeap loads a heap cell for a value already proven to have ref kind by the
 // symbolic stack. It reuses ref and off as outputs, so callers use it only after
-// a state barrier whose exits reload boxed operands from their stack homes.
+// a state barrier whose exits reload boxed operands from their VM stack slots.
 func (arm64Lowerer) loadHeap(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
 	addr := a.Reg(asm.RegTypeInt, asm.Width64)
@@ -4022,7 +4019,7 @@ func (l arm64Lowerer) releaseRef(ctx *lowering, addr asm.VReg, pre []value, ip i
 // wrapper can rebuild the same threaded resume shape.
 func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason prof.ExitReason, opcode int) (asm.Label, bool) {
 	ctx.values = append(ctx.values[:0], pre...)
-	if !l.flush(ctx, false) {
+	if !l.flush(ctx, flushSnapshot) {
 		return 0, false
 	}
 	label := ctx.queueExit(nil, resume, reason, opcode)
@@ -4030,19 +4027,19 @@ func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason pr
 	return label, true
 }
 
-// flush writes every dirty local and live operand to its VM stack home
+// flush writes every dirty local and live operand to its VM stack slot
 // in boxed form. commit clears dirty marks — only the hot path may do that;
 // a guard's cold path flushes a copy of the state and must leave the symbolic
 // state of the surviving hot path untouched.
-func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
-	// A committing flush transfers each ownerStack ref's retain to the VM
+func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
+	// A committing flush transfers each backingStack ref's retain to the VM
 	// stack, but it has no cold stub to re-take a deferred ref's retain: the
 	// loop-backedge yield can reach the threaded interpreter directly. Reject
 	// any live deferred ref up front, before emitting or mutating anything, so
 	// a loop-carried deferred ref keeps the trace threaded.
-	if commit {
+	if mode == flushCommit {
 		for _, v := range ctx.values {
-			if v.owner != ownerStack {
+			if v.kind == types.KindRef && v.backing != backingStack {
 				return false
 			}
 		}
@@ -4061,28 +4058,28 @@ func (l arm64Lowerer) flush(ctx *lowering, commit bool) bool {
 				return false
 			}
 			a.Emit(arm64.STR(boxed, addr, int16((f.base+idx)*8)))
-			if commit {
+			if mode == flushCommit {
 				f.state[idx] &^= localDirty
 			}
 		}
 	}
-	// An ownerStack ref carries the retain taken when it was pushed, so
+	// A backingStack ref carries the retain taken when it was pushed, so
 	// committing it transfers that edge to the stack. A non-commit flush writes
-	// each deferred ref boxed WITHOUT a retain; a following redeem or exit stub
-	// re-takes it before the flushed copy reaches the interpreter (see redeem /
-	// materializeExits). The commit pre-scan above already rejected any deferred
-	// owner, so those cases only run on a non-commit flush.
+	// each deferred ref boxed WITHOUT a retain; a following retainDeferred or exit stub
+	// re-takes it before the flushed copy reaches the interpreter (see retainDeferred /
+	// emitExits). The commit pre-scan above already rejected any deferred
+	// backing, so those cases only run on a non-commit flush.
 	for j, v := range ctx.values {
-		switch v.owner {
-		case ownerStack:
+		switch v.backing {
+		case backingStack:
 			boxed, ok := l.boxHome(ctx, v)
 			if !ok {
 				return false
 			}
 			a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
-		case ownerConst:
+		case backingConst:
 			boxed := a.Reg(asm.RegTypeInt, asm.Width64)
-			a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(v.constant())))...)
+			a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(v.ref)))...)
 			a.Emit(arm64.STR(boxed, addr, int16(ctx.slot(j)*8)))
 		default:
 			a.Emit(arm64.STR(v.reg, addr, int16(ctx.slot(j)*8)))
@@ -4170,24 +4167,24 @@ func (l arm64Lowerer) boxHome(ctx *lowering, v value) (asm.VReg, bool) {
 		case types.KindI32:
 			tag = tagI32
 		default:
-			return l.borrow(ctx, v)
+			return l.box(ctx, v)
 		}
 		ctx.assembler.Emit(arm64.ANDI(ctx.spare, v.reg, maskI32))
 		ctx.assembler.Emit(arm64.MOVK(ctx.spare, uint16(tag>>48), 48))
 		return ctx.spare, true
 	}
-	return l.borrow(ctx, v)
+	return l.box(ctx, v)
 }
 
-// settle owns every operand backed by the slot identified by (o, home) before
+// detach owns every operand backed by the slot identified by (backing, slot) before
 // that slot's content changes underneath it — a LOCAL_SET/GLOBAL_SET/UPVAL_SET
 // write, or a frame dying at RETURN/tail dispatch. A deferred value left
-// unsettled would keep pointing at a home whose content (or existence) no
+// undetached would keep pointing at a slot whose content (or existence) no
 // longer matches what it observed.
-func (l arm64Lowerer) settle(ctx *lowering, o owner, home int) bool {
+func (l arm64Lowerer) detach(ctx *lowering, b backing, slot int) bool {
 	for i := range ctx.values {
 		v := &ctx.values[i]
-		if v.kind == types.KindRef && v.owner == o && v.home == home {
+		if v.kind == types.KindRef && v.backing == b && v.slot == slot {
 			if _, ok := l.own(ctx, v); !ok {
 				return false
 			}
@@ -4196,36 +4193,51 @@ func (l arm64Lowerer) settle(ctx *lowering, o owner, home int) bool {
 	return true
 }
 
-// own borrows v and, when its reference count is deferred to backing storage
-// (owner != ownerStack), takes the retain that transfers ownership onto the
+// ownRefs transfers every live deferred ref onto the operand stack. Calls use
+// this ownership barrier before handing flushed state to another execution
+// context that may release or mutate the backing storage.
+func (l arm64Lowerer) ownRefs(ctx *lowering) bool {
+	for i := range ctx.values {
+		v := &ctx.values[i]
+		if v.kind == types.KindRef && v.backing != backingStack {
+			if _, ok := l.own(ctx, v); !ok {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// own boxes v and, when its reference count is deferred to backing storage
+// (backing != backingStack), takes the retain that transfers ownership onto the
 // operand stack and marks v owned. Callers pass a pointer into ctx.values (or
 // other frame-owned storage) so a later exit snapshot never also stub-retains
 // the same transfer.
 func (l arm64Lowerer) own(ctx *lowering, v *value) (asm.VReg, bool) {
-	reg, ok := l.borrow(ctx, *v)
+	reg, ok := l.box(ctx, *v)
 	if !ok {
 		return asm.VReg{}, false
 	}
-	if v.kind != types.KindRef || v.owner == ownerStack {
+	if v.kind != types.KindRef || v.backing == backingStack {
 		return reg, true
 	}
-	if v.owner == ownerConst {
-		l.retain(ctx, v.constant())
+	if v.backing == backingConst {
+		l.retain(ctx, v.ref)
 		v.reg = reg
 	} else {
 		addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.ANDI(addr, reg, maskI32))
 		l.retainRef(ctx, addr)
 	}
-	v.owner = ownerStack
+	v.backing = backingStack
 	return reg, true
 }
 
-// borrow produces the boxed form of v in a fresh register for read-only use.
-// It takes no reference-count action: an ownerConst ref materializes its
-// compile-time constant with no retain, and every other ref (ownerStack or
+// box produces the boxed form of v in a fresh register for read-only use.
+// It takes no reference-count action: a backingConst ref materializes its
+// compile-time constant with no retain, and every other ref (backingStack or
 // deferred to slot-backed storage) is already boxed in v.reg.
-func (l arm64Lowerer) borrow(ctx *lowering, v value) (asm.VReg, bool) {
+func (l arm64Lowerer) box(ctx *lowering, v value) (asm.VReg, bool) {
 	a := ctx.assembler
 	switch v.kind {
 	case types.KindI32:
@@ -4271,11 +4283,11 @@ func (l arm64Lowerer) borrow(ctx *lowering, v value) (asm.VReg, bool) {
 	case types.KindF64:
 		return v.reg, true
 	case types.KindRef:
-		if v.owner != ownerConst {
+		if v.backing != backingConst {
 			return v.reg, true
 		}
 		boxed := a.Reg(asm.RegTypeInt, asm.Width64)
-		a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(v.constant())))...)
+		a.Emit(arm64.LDI(boxed, uint64(types.BoxRef(v.ref)))...)
 		return boxed, true
 	}
 	return asm.VReg{}, false
@@ -4384,7 +4396,7 @@ func lower(ctx *lowering, plan plan) bool {
 			return false
 		}
 	}
-	l.materializeExits(ctx)
+	l.emitExits(ctx)
 	return true
 }
 

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1088,3 +1088,376 @@ func TestARM64_SelfCallWithRefArg(t *testing.T) {
 	}
 	require.Greater(t, entries, float64(0))
 }
+
+// DeferredRefElision protects Phase 3 of the JIT refcount-elision work:
+// LOCAL_GET/GLOBAL_GET/UPVAL_GET of a ref defers its retain to the backing
+// slot instead of taking one immediately, and ARRAY_GET/ARRAY_SET elide their
+// matching container release when the operand is still deferred. Every
+// sub-case asserts both the computed result and the exact heap refcount
+// survive repeated JIT warmup, so a missed retain (use-after-free) or a
+// missed release (leak) would show up as a wrong value or a wrong count.
+// Coverage of a deferred value staying live across a learned exit/continuation
+// boundary — the other half of materializeExits' retain-on-reload path — is
+// exercised separately by "jits learned br_if continuation over a live ref
+// value" in interp_test.go, which already keeps a LOCAL_GET-deferred array
+// live across a BR_IF and asserts both the result and stable exit counts.
+func TestARM64_DeferredRefElision(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+
+	t.Run("sieve-shaped kernel keeps the local-backed array refcount exact", func(t *testing.T) {
+		const size = int32(24)
+		b := program.NewBuilder()
+		arrayTyp := b.Type(types.TypeI32Array)
+		b.Locals(types.TypeI32Array, types.TypeI32, types.TypeI32)
+		fill := b.Label()
+		scan := b.Label()
+		done := b.Label()
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Bind(fill)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(scan)
+		// arr[i] = 1 — LOCAL_GET 0 pushes the array deferred (owner ownerLocal);
+		// ARRAY_SET must elide the container release to match.
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_SET)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(fill)
+		b.Bind(scan)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 2)
+		loop := b.Label()
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+		// sum += arr[i] — the same deferred array feeds ARRAY_GET.
+		b.Emit(instr.LOCAL_GET, 2).Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).Emit(instr.ARRAY_GET).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 2)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 2)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+		var ref int
+		for n := 0; n < 32; n++ {
+			require.NoError(t, i.Run(context.Background()))
+			v, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(size), v)
+
+			l, err := i.Local(0)
+			require.NoError(t, err)
+			ref = l.Ref()
+			require.Equal(t, 1, i.rc[ref]) // the local slot's own retain, never doubled or dropped
+			i.Reset()
+		}
+	})
+
+	t.Run("global-backed variant elides the container release", func(t *testing.T) {
+		const size = int32(8)
+		b := program.NewBuilder()
+		arrayTyp := b.Type(types.TypeI32Array)
+		b.Globals(types.TypeI32Array)
+		b.Locals(types.TypeI32, types.TypeI32)
+		fill := b.Label()
+		scan := b.Label()
+		done := b.Label()
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.GLOBAL_SET, 0)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 0)
+		b.Bind(fill)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(scan)
+		// GLOBAL_GET pushes the array deferred (owner ownerGlobal).
+		b.Emit(instr.GLOBAL_GET, 0).Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 2).Emit(instr.ARRAY_SET)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 0)
+		b.Br(fill)
+		b.Bind(scan)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		loop := b.Label()
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.GLOBAL_GET, 0).Emit(instr.LOCAL_GET, 0).Emit(instr.ARRAY_GET).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 0)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 1)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+		for n := 0; n < 32; n++ {
+			require.NoError(t, i.Run(context.Background()))
+			v, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(2*size), v)
+
+			g, err := i.Global(0)
+			require.NoError(t, err)
+			require.Equal(t, 1, i.rc[g.Ref()]) // the global slot's own retain, never doubled or dropped
+			i.Reset()
+		}
+	})
+
+	t.Run("upval-backed variant elides the container release", func(t *testing.T) {
+		const size = int32(8)
+		body := types.NewFunctionBuilder(nil).Captures(types.TypeI32Array).Returns(types.TypeI32)
+		body.Locals(types.TypeI32, types.TypeI32)
+		fill := body.Label()
+		scan := body.Label()
+		done := body.Label()
+		body.Emit(instr.New(instr.I32_CONST, 0)).Emit(instr.New(instr.LOCAL_SET, 0))
+		body.Bind(fill)
+		body.Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, uint64(uint32(size)))).Emit(instr.New(instr.I32_GE_S)).BrIf(scan)
+		// UPVAL_GET pushes the captured array deferred (owner ownerUpval).
+		body.Emit(instr.New(instr.UPVAL_GET, 0)).Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, 3)).Emit(instr.New(instr.ARRAY_SET))
+		body.Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, 1)).Emit(instr.New(instr.I32_ADD)).Emit(instr.New(instr.LOCAL_SET, 0))
+		body.Br(fill)
+		body.Bind(scan)
+		body.Emit(instr.New(instr.I32_CONST, 0)).Emit(instr.New(instr.LOCAL_SET, 0))
+		body.Emit(instr.New(instr.I32_CONST, 0)).Emit(instr.New(instr.LOCAL_SET, 1))
+		loop := body.Label()
+		body.Bind(loop)
+		body.Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, uint64(uint32(size)))).Emit(instr.New(instr.I32_GE_S)).BrIf(done)
+		body.Emit(instr.New(instr.LOCAL_GET, 1)).Emit(instr.New(instr.UPVAL_GET, 0)).Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.ARRAY_GET)).Emit(instr.New(instr.I32_ADD)).Emit(instr.New(instr.LOCAL_SET, 1))
+		body.Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, 1)).Emit(instr.New(instr.I32_ADD)).Emit(instr.New(instr.LOCAL_SET, 0))
+		body.Br(loop)
+		body.Bind(done)
+		body.Emit(instr.New(instr.LOCAL_GET, 1)).Emit(instr.New(instr.RETURN))
+		fn, err := body.Build()
+		require.NoError(t, err)
+
+		arrayTyp := 0
+		b := program.NewBuilder()
+		arrayTyp = b.Type(types.TypeI32Array)
+		b.Const(fn)
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp))
+		b.ConstGet(fn).Emit(instr.CLOSURE_NEW).Emit(instr.CALL)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+		for n := 0; n < 32; n++ {
+			require.NoError(t, i.Run(context.Background()))
+			v, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(3*size), v)
+			i.Reset()
+		}
+	})
+
+	t.Run("dup of a deferred ref consumed twice keeps both container releases elided", func(t *testing.T) {
+		const size = int32(4)
+		b := program.NewBuilder()
+		arrayTyp := b.Type(types.TypeI32Array)
+		b.Locals(types.TypeI32Array)
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
+		// Two deferred reads of the same slot, each duplicated and consumed by
+		// its own ARRAY_SET: dup of a deferred value must stay deferred (no
+		// retain), so every ARRAY_SET below still elides its release.
+		for idx := int32(0); idx < size; idx++ {
+			b.Emit(instr.LOCAL_GET, 0).Emit(instr.DUP).
+				Emit(instr.I32_CONST, uint64(uint32(idx))).Emit(instr.I32_CONST, 5).Emit(instr.ARRAY_SET).
+				Emit(instr.I32_CONST, uint64(uint32(idx))).Emit(instr.I32_CONST, 7).Emit(instr.ARRAY_SET)
+		}
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).Emit(instr.ARRAY_GET)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+		for n := 0; n < 32; n++ {
+			require.NoError(t, i.Run(context.Background()))
+			v, err := i.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, types.BoxI32(7), v) // second ARRAY_SET's value wins per index
+
+			l, err := i.Local(0)
+			require.NoError(t, err)
+			require.Equal(t, 1, i.rc[l.Ref()])
+			i.Reset()
+		}
+	})
+
+	t.Run("backer overwrite settles the deferred reader before LOCAL_SET replaces the slot", func(t *testing.T) {
+		b := program.NewBuilder()
+		arrayTyp := b.Type(types.TypeI32Array)
+		b.Locals(types.TypeI32Array)
+		// LOCAL_GET 0 pushes the first array deferred; overwriting local 0 via
+		// LOCAL_SET must settle() that deferred copy into an owned retain
+		// before the slot's content changes, or the first array would end up
+		// unretained once its only backer is gone.
+		b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.LOCAL_GET, 0)
+		b.Emit(instr.I32_CONST, 2).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
+		// The stale LOCAL_GET 0 copy (now settled/owned) is still consumed here.
+		b.Emit(instr.I32_CONST, 0).Emit(instr.I32_CONST, 9).Emit(instr.ARRAY_SET)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		i := New(prog, WithTick(1), WithThreshold(0))
+		defer i.Close()
+		for n := 0; n < 32; n++ {
+			require.NoError(t, i.Run(context.Background()))
+
+			l, err := i.Local(0)
+			require.NoError(t, err)
+			require.Equal(t, 1, i.rc[l.Ref()]) // second array, still owned by the local slot
+			i.Reset()
+		}
+	})
+
+	// balanced runs prog under the JIT and the pure interpreter in lockstep and
+	// asserts, on every iteration, that the popped result and every heap
+	// refcount agree with the threaded reference. A missed retain leaves an rc
+	// below threaded (and corrupts under -race via premature reuse); a missed
+	// release leaves one above threaded. It is path-agnostic: whichever cold path
+	// (terminal trap, direct call, module completion, or a threaded fallback)
+	// the trace takes, the interpreter's own bookkeeping is the oracle. Heap
+	// index 0 is the permanent Null cell whose count never gates a free, so its
+	// bookkeeping is excluded.
+	balanced := func(t *testing.T, prog *program.Program) {
+		t.Helper()
+		jit := New(prog, WithTick(1), WithThreshold(0))
+		defer jit.Close()
+		ref := New(prog, WithTick(1), WithThreshold(-1))
+		defer ref.Close()
+		for n := 0; n < 48; n++ {
+			require.NoError(t, jit.Run(context.Background()))
+			require.NoError(t, ref.Run(context.Background()))
+			got, err := jit.PopBoxed()
+			require.NoError(t, err)
+			want, err := ref.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, want, got, "result diverged from threaded on iteration %d", n)
+			require.Equal(t, ref.rc[1:], jit.rc[1:], "refcount diverged from threaded on iteration %d", n)
+			jit.Reset()
+			ref.Reset()
+		}
+	}
+
+	t.Run("terminal-op trap redeems a deferred ref left live below it", func(t *testing.T) {
+		const size = int32(6)
+		// A ref-element ARRAY_SET lowers as an unconditional terminal trap. Put it
+		// in a compiled leaf function so the trap fires on every call, with an
+		// extra deferred copy of the array live below the store: trap() must
+		// redeem that copy's retain before the threaded resume (ARRAY_LEN) reads
+		// and then releases it. Without redeem the copy is flushed unretained and
+		// the interpreter frees the array one reference early.
+		store := types.NewFunctionBuilder(nil).Params(types.NewArrayType(types.TypeRef), types.TypeI32).Returns(types.TypeI32)
+		store.Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.LOCAL_GET, 1), instr.New(instr.REF_NULL), instr.New(instr.ARRAY_SET),
+			instr.New(instr.ARRAY_LEN),
+			instr.New(instr.RETURN),
+		)
+		fn, err := store.Build()
+		require.NoError(t, err)
+
+		b := program.NewBuilder()
+		refArrTyp := b.Type(types.NewArrayType(types.TypeRef))
+		b.Const(fn)
+		b.Locals(types.NewArrayType(types.TypeRef), types.TypeI32, types.TypeI32)
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(refArrTyp)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 2)
+		loop := b.Label()
+		done := b.Label()
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).ConstGet(fn).Emit(instr.CALL) // store(arr, i) -> size
+		b.Emit(instr.LOCAL_GET, 2).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 2)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 2)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		balanced(t, prog)
+	})
+
+	t.Run("deferred ref passed as a call argument stays balanced", func(t *testing.T) {
+		const size = int32(6)
+		sink := types.NewFunctionBuilder(nil).Params(types.TypeI32Array).Returns(types.TypeI32)
+		sink.Emit(instr.New(instr.LOCAL_GET, 0), instr.New(instr.ARRAY_LEN), instr.New(instr.RETURN))
+		fn, err := sink.Build()
+		require.NoError(t, err)
+
+		b := program.NewBuilder()
+		arrayTyp := b.Type(types.TypeI32Array)
+		b.Const(fn)
+		b.Locals(types.TypeI32Array, types.TypeI32, types.TypeI32)
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 2)
+		loop := b.Label()
+		done := b.Label()
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+		// Pass the array as a deferred (ownerLocal) ref argument: the call must
+		// own it before handing it to the callee, which releases it on RETURN.
+		b.Emit(instr.LOCAL_GET, 0).ConstGet(fn).Emit(instr.CALL)
+		b.Emit(instr.LOCAL_GET, 2).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 2) // acc += sink(arr)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 2)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		balanced(t, prog)
+	})
+
+	t.Run("deferred ref forwarded through a self tail call stays balanced", func(t *testing.T) {
+		const size = int32(6)
+		// fill(arr, i, self): arr[i] = 7; i < 0 ? 0 : self(arr, i-1, self). Each
+		// LOCAL_GET of arr defers, and the tail call commits its frame; the tail
+		// dispatch must own every deferred ref before the committing flush (which
+		// now rejects any deferred it still sees).
+		fill := types.NewFunctionBuilder(nil).Params(types.TypeI32Array, types.TypeI32, types.TypeRef).Returns(types.TypeI32)
+		base := fill.Label()
+		fill.Emit(instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, 0), instr.New(instr.I32_LT_S)).
+			BrIf(base).
+			Emit(
+				instr.New(instr.LOCAL_GET, 0), instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, 7), instr.New(instr.ARRAY_SET),
+				instr.New(instr.LOCAL_GET, 0),
+				instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_SUB),
+				instr.New(instr.LOCAL_GET, 2),
+				instr.New(instr.LOCAL_GET, 2),
+				instr.New(instr.RETURN_CALL),
+			).
+			Bind(base).
+			Emit(instr.New(instr.I32_CONST, 0), instr.New(instr.RETURN))
+		fn, err := fill.Build()
+		require.NoError(t, err)
+
+		b := program.NewBuilder()
+		arrayTyp := b.Type(types.TypeI32Array)
+		b.Const(fn)
+		b.Locals(types.TypeI32Array)
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, uint64(uint32(size-1)))
+		b.ConstGet(fn).ConstGet(fn).Emit(instr.CALL) // fill(arr, size-1, fill)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		balanced(t, prog)
+	})
+
+	t.Run("module completion redeems a deferred ref left on the top-level stack", func(t *testing.T) {
+		tarr := types.TypedArray[int32]{3, 5, 7}
+		b := program.NewBuilder()
+		b.Const(tarr)
+		// A typed-array constant used as an ARRAY_GET container is a deferred
+		// (ownerConst) marker. Leave one live on the operand stack at module end:
+		// complete() flushes it to the top-level stack the wrapper preserves, so
+		// redeem must re-take its retain the way the threaded CONST_GET would.
+		b.ConstGet(tarr)
+		b.ConstGet(tarr).Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_GET).Emit(instr.DROP)
+		// [A] is left live on the stack; the module returns it at completion.
+		prog, err := b.Build()
+		require.NoError(t, err)
+		balanced(t, prog)
+	})
+}

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1138,21 +1138,37 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		prog, err := b.Build()
 		require.NoError(t, err)
 
-		i := New(prog, WithTick(1), WithThreshold(0))
-		defer i.Close()
+		profile := prof.New()
+		i := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
+		threaded := New(prog, WithTick(1), WithThreshold(-1))
 		var ref int
 		for n := 0; n < 32; n++ {
 			require.NoError(t, i.Run(context.Background()))
+			require.NoError(t, threaded.Run(context.Background()))
 			v, err := i.PopBoxed()
 			require.NoError(t, err)
+			want, err := threaded.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, want, v, "result diverged from threaded on iteration %d", n)
 			require.Equal(t, types.BoxI32(size), v)
 
 			l, err := i.Local(0)
 			require.NoError(t, err)
 			ref = l.Ref()
 			require.Equal(t, 1, i.rc[ref]) // the local slot's own retain, never doubled or dropped
+			require.Equal(t, threaded.rc[1:], i.rc[1:], "refcount diverged from threaded on iteration %d", n)
 			i.Reset()
+			threaded.Reset()
 		}
+		require.NoError(t, i.Close())
+		require.NoError(t, threaded.Close())
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		require.Greater(t, entries, float64(0))
 	})
 
 	t.Run("global-backed variant elides the container release", func(t *testing.T) {
@@ -1186,19 +1202,35 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		prog, err := b.Build()
 		require.NoError(t, err)
 
-		i := New(prog, WithTick(1), WithThreshold(0))
-		defer i.Close()
+		profile := prof.New()
+		i := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
+		threaded := New(prog, WithTick(1), WithThreshold(-1))
 		for n := 0; n < 32; n++ {
 			require.NoError(t, i.Run(context.Background()))
+			require.NoError(t, threaded.Run(context.Background()))
 			v, err := i.PopBoxed()
 			require.NoError(t, err)
+			want, err := threaded.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, want, v, "result diverged from threaded on iteration %d", n)
 			require.Equal(t, types.BoxI32(2*size), v)
 
 			g, err := i.Global(0)
 			require.NoError(t, err)
 			require.Equal(t, 1, i.rc[g.Ref()]) // the global slot's own retain, never doubled or dropped
+			require.Equal(t, threaded.rc[1:], i.rc[1:], "refcount diverged from threaded on iteration %d", n)
 			i.Reset()
+			threaded.Reset()
 		}
+		require.NoError(t, i.Close())
+		require.NoError(t, threaded.Close())
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		require.Greater(t, entries, float64(0))
 	})
 
 	t.Run("upval-backed variant elides the container release", func(t *testing.T) {
@@ -1238,76 +1270,154 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		prog, err := b.Build()
 		require.NoError(t, err)
 
-		i := New(prog, WithTick(1), WithThreshold(0))
-		defer i.Close()
+		profile := prof.New()
+		i := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
+		threaded := New(prog, WithTick(1), WithThreshold(-1))
 		for n := 0; n < 32; n++ {
 			require.NoError(t, i.Run(context.Background()))
+			require.NoError(t, threaded.Run(context.Background()))
 			v, err := i.PopBoxed()
 			require.NoError(t, err)
+			want, err := threaded.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, want, v, "result diverged from threaded on iteration %d", n)
 			require.Equal(t, types.BoxI32(3*size), v)
+			require.Equal(t, threaded.rc[1:], i.rc[1:], "refcount diverged from threaded on iteration %d", n)
 			i.Reset()
+			threaded.Reset()
 		}
+		require.NoError(t, i.Close())
+		require.NoError(t, threaded.Close())
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		require.Greater(t, entries, float64(0))
 	})
 
 	t.Run("dup of a deferred ref consumed twice keeps both container releases elided", func(t *testing.T) {
 		const size = int32(4)
+		use := types.NewFunctionBuilder(nil).
+			Params(types.TypeI32Array).
+			Returns(types.TypeI32)
+		// DUP of a deferred LOCAL_GET must stay deferred. Both ARRAY_LEN
+		// consumers borrow their copies without retain/release churn.
+		fn, err := use.Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.DUP),
+			instr.New(instr.ARRAY_LEN),
+			instr.New(instr.SWAP),
+			instr.New(instr.ARRAY_LEN),
+			instr.New(instr.I32_ADD),
+			instr.New(instr.RETURN),
+		).Build()
+		require.NoError(t, err)
+
 		b := program.NewBuilder()
-		arrayTyp := b.Type(types.TypeI32Array)
+		arrayType := b.Type(types.TypeI32Array)
+		b.Const(fn)
 		b.Locals(types.TypeI32Array)
-		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
-		// Two deferred reads of the same slot, each duplicated and consumed by
-		// its own ARRAY_SET: dup of a deferred value must stay deferred (no
-		// retain), so every ARRAY_SET below still elides its release.
-		for idx := int32(0); idx < size; idx++ {
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.DUP).
-				Emit(instr.I32_CONST, uint64(uint32(idx))).Emit(instr.I32_CONST, 5).Emit(instr.ARRAY_SET).
-				Emit(instr.I32_CONST, uint64(uint32(idx))).Emit(instr.I32_CONST, 7).Emit(instr.ARRAY_SET)
-		}
-		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).Emit(instr.ARRAY_GET)
+		b.Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayType)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.LOCAL_GET, 0).ConstGet(fn).Emit(instr.CALL)
 		prog, err := b.Build()
 		require.NoError(t, err)
 
-		i := New(prog, WithTick(1), WithThreshold(0))
-		defer i.Close()
+		profile := prof.New()
+		i := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
+		threaded := New(prog, WithTick(1), WithThreshold(-1))
 		for n := 0; n < 32; n++ {
 			require.NoError(t, i.Run(context.Background()))
+			require.NoError(t, threaded.Run(context.Background()))
 			v, err := i.PopBoxed()
 			require.NoError(t, err)
-			require.Equal(t, types.BoxI32(7), v) // second ARRAY_SET's value wins per index
+			want, err := threaded.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, want, v, "result diverged from threaded on iteration %d", n)
+			require.Equal(t, types.BoxI32(2*size), v)
 
 			l, err := i.Local(0)
 			require.NoError(t, err)
-			require.Equal(t, 1, i.rc[l.Ref()])
+			wantLocal, err := threaded.Local(0)
+			require.NoError(t, err)
+			require.Equal(t, threaded.rc[wantLocal.Ref()], i.rc[l.Ref()])
+			require.Equal(t, threaded.rc[1:], i.rc[1:], "refcount diverged from threaded on iteration %d", n)
 			i.Reset()
+			threaded.Reset()
 		}
+		require.NoError(t, i.Close())
+		require.NoError(t, threaded.Close())
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		require.Greater(t, entries, float64(0))
 	})
 
 	t.Run("backer overwrite settles the deferred reader before LOCAL_SET replaces the slot", func(t *testing.T) {
+		replace := types.NewFunctionBuilder(nil).
+			Params(types.TypeI32Array, types.TypeI32Array).
+			Returns(types.TypeI32)
+		// LOCAL_GET 0 pushes the first array deferred. LOCAL_SET 0 then replaces
+		// that backing slot with parameter 1, so settle must own the stale reader
+		// before its original home changes.
+		fn, err := replace.Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.LOCAL_GET, 1),
+			instr.New(instr.LOCAL_SET, 0),
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.I32_CONST, 9),
+			instr.New(instr.ARRAY_SET),
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.ARRAY_LEN),
+			instr.New(instr.RETURN),
+		).Build()
+		require.NoError(t, err)
+
 		b := program.NewBuilder()
-		arrayTyp := b.Type(types.TypeI32Array)
-		b.Locals(types.TypeI32Array)
-		// LOCAL_GET 0 pushes the first array deferred; overwriting local 0 via
-		// LOCAL_SET must settle() that deferred copy into an owned retain
-		// before the slot's content changes, or the first array would end up
-		// unretained once its only backer is gone.
-		b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
-		b.Emit(instr.LOCAL_GET, 0)
-		b.Emit(instr.I32_CONST, 2).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayTyp)).Emit(instr.LOCAL_SET, 0)
-		// The stale LOCAL_GET 0 copy (now settled/owned) is still consumed here.
-		b.Emit(instr.I32_CONST, 0).Emit(instr.I32_CONST, 9).Emit(instr.ARRAY_SET)
+		arrayType := b.Type(types.TypeI32Array)
+		b.Const(fn)
+		b.Locals(types.TypeI32Array, types.TypeI32Array)
+		b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayType)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 2).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrayType)).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).ConstGet(fn).Emit(instr.CALL)
 		prog, err := b.Build()
 		require.NoError(t, err)
 
-		i := New(prog, WithTick(1), WithThreshold(0))
-		defer i.Close()
+		profile := prof.New()
+		i := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
+		threaded := New(prog, WithTick(1), WithThreshold(-1))
 		for n := 0; n < 32; n++ {
 			require.NoError(t, i.Run(context.Background()))
-
-			l, err := i.Local(0)
+			require.NoError(t, threaded.Run(context.Background()))
+			v, err := i.PopBoxed()
 			require.NoError(t, err)
-			require.Equal(t, 1, i.rc[l.Ref()]) // second array, still owned by the local slot
+			want, err := threaded.PopBoxed()
+			require.NoError(t, err)
+			require.Equal(t, want, v, "result diverged from threaded on iteration %d", n)
+			require.Equal(t, types.BoxI32(2), v)
+
+			l, err := i.Local(1)
+			require.NoError(t, err)
+			wantLocal, err := threaded.Local(1)
+			require.NoError(t, err)
+			require.Equal(t, threaded.rc[wantLocal.Ref()], i.rc[l.Ref()])
+			require.Equal(t, threaded.rc[1:], i.rc[1:], "refcount diverged from threaded on iteration %d", n)
 			i.Reset()
+			threaded.Reset()
 		}
+		require.NoError(t, i.Close())
+		require.NoError(t, threaded.Close())
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		require.Greater(t, entries, float64(0))
 	})
 
 	// balanced runs prog under the JIT and the pure interpreter in lockstep and
@@ -1321,10 +1431,9 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 	// bookkeeping is excluded.
 	balanced := func(t *testing.T, prog *program.Program) {
 		t.Helper()
-		jit := New(prog, WithTick(1), WithThreshold(0))
-		defer jit.Close()
+		profile := prof.New()
+		jit := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
 		ref := New(prog, WithTick(1), WithThreshold(-1))
-		defer ref.Close()
 		for n := 0; n < 48; n++ {
 			require.NoError(t, jit.Run(context.Background()))
 			require.NoError(t, ref.Run(context.Background()))
@@ -1337,6 +1446,15 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 			jit.Reset()
 			ref.Reset()
 		}
+		require.NoError(t, jit.Close())
+		require.NoError(t, ref.Close())
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		require.Greater(t, entries, float64(0))
 	}
 
 	t.Run("terminal-op trap redeems a deferred ref left live below it", func(t *testing.T) {
@@ -1374,6 +1492,64 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Br(loop)
 		b.Bind(done)
 		b.Emit(instr.LOCAL_GET, 2)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		balanced(t, prog)
+	})
+
+	t.Run("ref array store owns a deferred element before transfer", func(t *testing.T) {
+		refArray := types.NewArrayType(types.TypeRef)
+		store := types.NewFunctionBuilder(nil).
+			Params(refArray, types.TypeI32Array).
+			Returns(types.TypeI32)
+		store.Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.LOCAL_GET, 1),
+			instr.New(instr.ARRAY_SET),
+			instr.New(instr.I32_CONST, 1),
+			instr.New(instr.RETURN),
+		)
+		fn, err := store.Build()
+		require.NoError(t, err)
+
+		b := program.NewBuilder()
+		refArrayType := b.Type(refArray)
+		valueArrayType := b.Type(types.TypeI32Array)
+		b.Const(fn)
+		b.Locals(refArray, types.TypeI32Array)
+		b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(refArrayType)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(valueArrayType)).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).ConstGet(fn).Emit(instr.CALL)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		balanced(t, prog)
+	})
+
+	t.Run("ref struct store owns a deferred field before transfer", func(t *testing.T) {
+		structure := types.NewStructType(types.NewStructField(types.TypeI32Array))
+		store := types.NewFunctionBuilder(nil).
+			Params(structure, types.TypeI32Array).
+			Returns(types.TypeI32)
+		store.Emit(
+			instr.New(instr.LOCAL_GET, 0),
+			instr.New(instr.I32_CONST, 0),
+			instr.New(instr.LOCAL_GET, 1),
+			instr.New(instr.STRUCT_SET),
+			instr.New(instr.I32_CONST, 1),
+			instr.New(instr.RETURN),
+		)
+		fn, err := store.Build()
+		require.NoError(t, err)
+
+		b := program.NewBuilder()
+		structType := b.Type(structure)
+		valueArrayType := b.Type(types.TypeI32Array)
+		b.Const(fn)
+		b.Locals(structure, types.TypeI32Array)
+		b.Emit(instr.STRUCT_NEW_DEFAULT, uint64(structType)).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(valueArrayType)).Emit(instr.LOCAL_SET, 1)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).ConstGet(fn).Emit(instr.CALL)
 		prog, err := b.Build()
 		require.NoError(t, err)
 		balanced(t, prog)

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1097,7 +1097,7 @@ func TestARM64_SelfCallWithRefArg(t *testing.T) {
 // survive repeated JIT warmup, so a missed retain (use-after-free) or a
 // missed release (leak) would show up as a wrong value or a wrong count.
 // Coverage of a deferred value staying live across a learned exit/continuation
-// boundary — the other half of materializeExits' retain-on-reload path — is
+// boundary — the other half of emitExits' retain-on-reload path — is
 // exercised separately by "jits learned br_if continuation over a live ref
 // value" in interp_test.go, which already keeps a LOCAL_GET-deferred array
 // live across a BR_IF and asserts both the result and stable exit counts.
@@ -1118,7 +1118,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
 		b.Bind(fill)
 		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(scan)
-		// arr[i] = 1 — LOCAL_GET 0 pushes the array deferred (owner ownerLocal);
+		// arr[i] = 1 — LOCAL_GET 0 pushes the array deferred (backingLocal);
 		// ARRAY_SET must elide the container release to match.
 		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_SET)
 		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
@@ -1184,7 +1184,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 0)
 		b.Bind(fill)
 		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(scan)
-		// GLOBAL_GET pushes the array deferred (owner ownerGlobal).
+		// GLOBAL_GET pushes the array deferred (backingGlobal).
 		b.Emit(instr.GLOBAL_GET, 0).Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 2).Emit(instr.ARRAY_SET)
 		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 0)
 		b.Br(fill)
@@ -1243,7 +1243,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		body.Emit(instr.New(instr.I32_CONST, 0)).Emit(instr.New(instr.LOCAL_SET, 0))
 		body.Bind(fill)
 		body.Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, uint64(uint32(size)))).Emit(instr.New(instr.I32_GE_S)).BrIf(scan)
-		// UPVAL_GET pushes the captured array deferred (owner ownerUpval).
+		// UPVAL_GET pushes the captured array deferred (backingUpval).
 		body.Emit(instr.New(instr.UPVAL_GET, 0)).Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, 3)).Emit(instr.New(instr.ARRAY_SET))
 		body.Emit(instr.New(instr.LOCAL_GET, 0)).Emit(instr.New(instr.I32_CONST, 1)).Emit(instr.New(instr.I32_ADD)).Emit(instr.New(instr.LOCAL_SET, 0))
 		body.Br(fill)
@@ -1303,7 +1303,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 			Params(types.TypeI32Array).
 			Returns(types.TypeI32)
 		// DUP of a deferred LOCAL_GET must stay deferred. Both ARRAY_LEN
-		// consumers borrow their copies without retain/release churn.
+		// consumers box their copies without retain/release churn.
 		fn, err := use.Emit(
 			instr.New(instr.LOCAL_GET, 0),
 			instr.New(instr.DUP),
@@ -1357,13 +1357,13 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		require.Greater(t, entries, float64(0))
 	})
 
-	t.Run("backer overwrite settles the deferred reader before LOCAL_SET replaces the slot", func(t *testing.T) {
+	t.Run("backing slot overwrite preserves a live deferred reader", func(t *testing.T) {
 		replace := types.NewFunctionBuilder(nil).
 			Params(types.TypeI32Array, types.TypeI32Array).
 			Returns(types.TypeI32)
 		// LOCAL_GET 0 pushes the first array deferred. LOCAL_SET 0 then replaces
-		// that backing slot with parameter 1, so settle must own the stale reader
-		// before its original home changes.
+		// that backing slot with parameter 1, so detach must own the stale reader
+		// before its original backing slot changes.
 		fn, err := replace.Emit(
 			instr.New(instr.LOCAL_GET, 0),
 			instr.New(instr.LOCAL_GET, 1),
@@ -1429,7 +1429,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 	// the trace takes, the interpreter's own bookkeeping is the oracle. Heap
 	// index 0 is the permanent Null cell whose count never gates a free, so its
 	// bookkeeping is excluded.
-	balanced := func(t *testing.T, prog *program.Program) {
+	requireRefParity := func(t *testing.T, prog *program.Program) {
 		t.Helper()
 		profile := prof.New()
 		jit := New(prog, WithTick(1), WithThreshold(0), WithProfiler(profile))
@@ -1457,13 +1457,13 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		require.Greater(t, entries, float64(0))
 	}
 
-	t.Run("terminal-op trap redeems a deferred ref left live below it", func(t *testing.T) {
+	t.Run("terminal fallback preserves a live deferred ref", func(t *testing.T) {
 		const size = int32(6)
 		// A ref-element ARRAY_SET lowers as an unconditional terminal trap. Put it
 		// in a compiled leaf function so the trap fires on every call, with an
 		// extra deferred copy of the array live below the store: trap() must
-		// redeem that copy's retain before the threaded resume (ARRAY_LEN) reads
-		// and then releases it. Without redeem the copy is flushed unretained and
+		// retainDeferred that copy's retain before the threaded resume (ARRAY_LEN) reads
+		// and then releases it. Without retainDeferred the copy is flushed unretained and
 		// the interpreter frees the array one reference early.
 		store := types.NewFunctionBuilder(nil).Params(types.NewArrayType(types.TypeRef), types.TypeI32).Returns(types.TypeI32)
 		store.Emit(
@@ -1494,7 +1494,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Emit(instr.LOCAL_GET, 2)
 		prog, err := b.Build()
 		require.NoError(t, err)
-		balanced(t, prog)
+		requireRefParity(t, prog)
 	})
 
 	t.Run("ref array store owns a deferred element before transfer", func(t *testing.T) {
@@ -1523,7 +1523,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).ConstGet(fn).Emit(instr.CALL)
 		prog, err := b.Build()
 		require.NoError(t, err)
-		balanced(t, prog)
+		requireRefParity(t, prog)
 	})
 
 	t.Run("ref struct store owns a deferred field before transfer", func(t *testing.T) {
@@ -1552,7 +1552,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Emit(instr.LOCAL_GET, 0).Emit(instr.LOCAL_GET, 1).ConstGet(fn).Emit(instr.CALL)
 		prog, err := b.Build()
 		require.NoError(t, err)
-		balanced(t, prog)
+		requireRefParity(t, prog)
 	})
 
 	t.Run("deferred ref passed as a call argument stays balanced", func(t *testing.T) {
@@ -1573,7 +1573,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		done := b.Label()
 		b.Bind(loop)
 		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
-		// Pass the array as a deferred (ownerLocal) ref argument: the call must
+		// Pass the array as a deferred (backingLocal) ref argument: the call must
 		// own it before handing it to the callee, which releases it on RETURN.
 		b.Emit(instr.LOCAL_GET, 0).ConstGet(fn).Emit(instr.CALL)
 		b.Emit(instr.LOCAL_GET, 2).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 2) // acc += sink(arr)
@@ -1583,7 +1583,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.Emit(instr.LOCAL_GET, 2)
 		prog, err := b.Build()
 		require.NoError(t, err)
-		balanced(t, prog)
+		requireRefParity(t, prog)
 	})
 
 	t.Run("deferred ref forwarded through a self tail call stays balanced", func(t *testing.T) {
@@ -1618,22 +1618,22 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 		b.ConstGet(fn).ConstGet(fn).Emit(instr.CALL) // fill(arr, size-1, fill)
 		prog, err := b.Build()
 		require.NoError(t, err)
-		balanced(t, prog)
+		requireRefParity(t, prog)
 	})
 
-	t.Run("module completion redeems a deferred ref left on the top-level stack", func(t *testing.T) {
+	t.Run("module completion preserves a live deferred ref", func(t *testing.T) {
 		tarr := types.TypedArray[int32]{3, 5, 7}
 		b := program.NewBuilder()
 		b.Const(tarr)
 		// A typed-array constant used as an ARRAY_GET container is a deferred
-		// (ownerConst) marker. Leave one live on the operand stack at module end:
+		// (backingConst) marker. Leave one live on the operand stack at module end:
 		// complete() flushes it to the top-level stack the wrapper preserves, so
-		// redeem must re-take its retain the way the threaded CONST_GET would.
+		// retainDeferred must re-take its retain the way the threaded CONST_GET would.
 		b.ConstGet(tarr)
 		b.ConstGet(tarr).Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_GET).Emit(instr.DROP)
 		// [A] is left live on the stack; the module returns it at completion.
 		prog, err := b.Build()
 		require.NoError(t, err)
-		balanced(t, prog)
+		requireRefParity(t, prog)
 	})
 }


### PR DESCRIPTION
## Problem

`docs/benchmarks.md`'s worst competitive row was `Sieve(256)`: 5,052 ns adaptive vs wazero 645 ns (7.8x) — the representative pattern of a runtime-allocated array held in a local. A control experiment isolated the cause: per array access, `TypedArraySum(256)` (constant array) costs 2.28 ns while Sieve costs 6.89 ns — 3x for the same element type and JIT. The delta is pure refcount churn: every ref `LOCAL_GET` emitted a retain and the consuming `ARRAY_GET`/`ARRAY_SET` emitted a matching `guardRC` + release — two serialized read-modify-writes on the same `rc` cell, per element, net zero.

## Change

The JIT fusion layer already had a deferral concept for compile-time constant ref markers (`raw` refs: no retain at push, `box()` materializes it, `sideExit.retain` balances exits). This PR unifies that into a single ownership model and extends it to every slot-backed producer:

- `value` gains `owner` (`ownerStack`/`ownerConst`/`ownerLocal`/`ownerGlobal`/`ownerUpval`) and `home`. Only `ownerStack` carries its own retain; every other owner borrows from backing storage.
- **Producers** — `LOCAL_GET`/`GLOBAL_GET`/`UPVAL_GET` of a ref, const markers, and `DUP` of a deferred ref push deferred with no retain.
- **Consumers** — `ARRAY_GET`/`SET`, `STRUCT_GET`/`SET`, `ARRAY_LEN`, `REF_IS_NULL`, `DROP`, and coroutine/error/string reads borrow the container and elide its `guardRC`/release when deferred (element/payload retains are unchanged).
- **Materialization points** take exactly one retain wherever the value reaches interpreter-visible state:
  - `own` — slot stores, call-argument transfer, entry-frame returns
  - `settle` — backing slot overwritten (`*_SET`) or frame dying (`stitch`, tail dispatch)
  - `materializeExits` — guard exit stubs reload each deferred operand from its flushed VM stack home and retain on the cold path only
  - `redeem` — stub-less deopts (trap fallback, module completion)
  - `directCall`/`selfCall` own every live deferred operand before the `BL` (a callee trap adopts the caller's flushed stack)
- A committing (loop back-edge) flush rejects live deferred refs — a loop-carried deferral keeps the trace threaded rather than leaking one retain per iteration.
- The `consume()` peephole and `sideExit.retain` scalar field are subsumed and removed.

## Results (Apple M4 Pro, darwin/arm64, Go 1.26.2, median of 3 × 300ms, serial)

| Workload | before | after |
|---|---:|---:|
| Sieve(256) default | 5,052 ns | **4,722 ns** |
| Sieve(256) jit | 5,017 ns | **4,719 ns** |

Other rows moved within noise or from earlier branch commits; `docs/benchmarks.md` refreshed as one consistent measurement set (July 16, 2026).

## Safety

The RC invariant (exact and symmetric on every path, including deopts) is preserved by construction: each deferred value is retained exactly once on any path that hands it to the interpreter. `TestARM64_DeferredRefElision` adds a JIT-vs-threaded oracle asserting popped results and every heap refcount agree across 48 lockstep runs, covering: local/global/upval backers, `DUP` fan-out, backer overwrite (`settle`), terminal-op trap (`redeem`), module completion, call-argument transfer, and self tail-call forwarding. Each regression test was verified to fail with its fix reverted.

## Test plan

- [x] `go test -race ./...` — all 16 packages green
- [x] `benchmarks` correctness suite across default/threaded/jit modes
- [x] `go vet`, `make lint` clean
- [x] Full `-tags=compare` external comparison re-measured serially; `docs/benchmarks.md`, `docs/jit-internals.md` (new Reference Ownership section), `docs/memory-model.md`, `AGENTS.md`, `docs/architecture.md` updated

## Known follow-ups (out of scope)

- Loop-invariant hoisting of heap-cell/itab/slice-header reloads — the remaining Sieve gap to wazero.
- A pre-existing (baseline-reproducible) JIT miscompile when a ref lingers on the operand stack across a loop header — unrelated to this change, found while writing coverage; deserves its own investigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ARM64 JIT correctness for deferred `ref` operands, ensuring retains are properly owned/redeemed across calls, branches, exits, trap fallback, and module completion, and preventing deferred refs from persisting across committing loop back-edges.
- **Tests**
  - Added an ARM64 regression test covering deferred `ref` elision scenarios and verifying exact JIT vs threaded interpreter parity, including heap refcount stability.
- **Documentation**
  - Updated JIT, architecture, and memory-model docs to clarify deferred `ref` ownership/flush rules; refreshed benchmark results with new measurement data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->