### PR TITLE
perf(interp): cut trace loop iteration overhead

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,7 +176,7 @@ Violations cause silent corruption or invalid execution.
 - `tree.branchIPs()` excludes `aborted` branches from continuation-inlining eligibility; a fragment that recorded a partial, unsupported prefix must never be inlined into a parent trace.
 - `interp/jit.go`'s `spillSafe` must scan the whole trace tree (root plus every branch it may inline), not just the root's last op, before deciding a trace is safe to spill.
 - A deferred (slot-backed or const) ref operand carries no retain of its own; it must be owned or redeemed before any path that hands the flushed operand stack to the interpreter (ownership transfer, guard exit stub, trap-fallback/module-completion redeem, or a real call), and a committing (loop back-edge) flush rejects any live deferred ref.
-- Hoisted container registers are valid only within one native loop entry: the prologue re-guards tag and itab on every entry, hoist eligibility requires a call-free loop plan with no store to the container local, and a loop fallback that resumes at the header must run the shadowed threaded handler once (the header slot holds the native stub, so redispatching it would livelock).
+- Hoisted container registers are valid only within one native loop entry: the prologue re-guards tag and itab on every entry, hoist eligibility requires a call-free loop plan with no store to the container local, `asm.OpPseudoUse` keeps the derived registers live across the native back-edge, and a loop fallback that resumes at the header must run the shadowed threaded handler once (the header slot holds the native stub, so redispatching it would livelock).
 
 ## Tests
 

--- a/asm/assembler.go
+++ b/asm/assembler.go
@@ -217,7 +217,7 @@ func (a *Assembler) draft(insts []Instruction) ([][]byte, []int, error) {
 	offsets := make([]int, len(insts)+1)
 
 	for i, inst := range insts {
-		if inst.Op == OpPseudoLabel {
+		if inst.Op == OpPseudoLabel || inst.Op == OpPseudoUse {
 			offsets[i+1] = offsets[i]
 			continue
 		}
@@ -247,7 +247,7 @@ func (a *Assembler) final(
 	out := make([]byte, 0, offsets[len(insts)])
 	var relocs []Relocation
 	for i, inst := range insts {
-		if inst.Op == OpPseudoLabel {
+		if inst.Op == OpPseudoLabel || inst.Op == OpPseudoUse {
 			continue
 		}
 		lbl, isLabel := inst.Src2.(LabelOperand)

--- a/asm/assembler_test.go
+++ b/asm/assembler_test.go
@@ -54,6 +54,25 @@ func TestAssembler_Emit(t *testing.T) {
 	require.NotEmpty(t, code.Bytes)
 }
 
+func TestAssembler_PseudoUse(t *testing.T) {
+	assembler := asm.New(arm64.New())
+	v := assembler.Reg(asm.RegTypeInt, asm.Width64)
+	assembler.Emit(arm64.LDI(v, 1)...)
+	assembler.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(v)})
+	assembler.Emit(arm64.RET())
+
+	code, err := assembler.Build()
+	require.NoError(t, err)
+
+	without := asm.New(arm64.New())
+	v = without.Reg(asm.RegTypeInt, asm.Width64)
+	without.Emit(arm64.LDI(v, 1)...)
+	without.Emit(arm64.RET())
+	want, err := without.Build()
+	require.NoError(t, err)
+	require.Equal(t, want.Bytes, code.Bytes)
+}
+
 func TestAssembler_Pin(t *testing.T) {
 	arch := arm64.New()
 

--- a/asm/assembler_test.go
+++ b/asm/assembler_test.go
@@ -55,22 +55,50 @@ func TestAssembler_Emit(t *testing.T) {
 }
 
 func TestAssembler_PseudoUse(t *testing.T) {
-	assembler := asm.New(arm64.New())
-	v := assembler.Reg(asm.RegTypeInt, asm.Width64)
-	assembler.Emit(arm64.LDI(v, 1)...)
-	assembler.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(v)})
-	assembler.Emit(arm64.RET())
+	t.Run("emits no bytes", func(t *testing.T) {
+		assembler := asm.New(arm64.New())
+		v := assembler.Reg(asm.RegTypeInt, asm.Width64)
+		assembler.Emit(arm64.LDI(v, 1)...)
+		assembler.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(v)})
+		assembler.Emit(arm64.RET())
 
-	code, err := assembler.Build()
-	require.NoError(t, err)
+		code, err := assembler.Build()
+		require.NoError(t, err)
 
-	without := asm.New(arm64.New())
-	v = without.Reg(asm.RegTypeInt, asm.Width64)
-	without.Emit(arm64.LDI(v, 1)...)
-	without.Emit(arm64.RET())
-	want, err := without.Build()
-	require.NoError(t, err)
-	require.Equal(t, want.Bytes, code.Bytes)
+		without := asm.New(arm64.New())
+		v = without.Reg(asm.RegTypeInt, asm.Width64)
+		without.Emit(arm64.LDI(v, 1)...)
+		without.Emit(arm64.RET())
+		want, err := without.Build()
+		require.NoError(t, err)
+		require.Equal(t, want.Bytes, code.Bytes)
+	})
+
+	t.Run("extends live ranges", func(t *testing.T) {
+		const n = 64
+		without := asm.New(noFrameArch{arm64.New()})
+		for i := 0; i < n; i++ {
+			v := without.Reg(asm.RegTypeInt, asm.Width64)
+			without.Emit(arm64.LDI(v, uint64(i))...)
+		}
+		without.Emit(arm64.RET())
+		_, err := without.Build()
+		require.NoError(t, err)
+
+		assembler := asm.New(noFrameArch{arm64.New()})
+		values := make([]asm.VReg, n)
+		for i := range values {
+			values[i] = assembler.Reg(asm.RegTypeInt, asm.Width64)
+			assembler.Emit(arm64.LDI(values[i], uint64(i))...)
+		}
+		for _, v := range values {
+			assembler.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(v)})
+		}
+		assembler.Emit(arm64.RET())
+
+		_, err = assembler.Build()
+		require.ErrorIs(t, err, asm.ErrNoRegistersAvailable)
+	})
 }
 
 func TestAssembler_Pin(t *testing.T) {

--- a/asm/instr.go
+++ b/asm/instr.go
@@ -14,6 +14,10 @@ type Instruction struct {
 	Src3 Operand
 }
 
+// OpPseudoUse is a zero-byte pseudo-instruction that extends the live range
+// of virtual-register source operands through its position.
+const OpPseudoUse uint16 = 0xFFFE
+
 // OpPseudoLabel is a pseudo-instruction that marks a label position. It
 // emits zero bytes and is stripped before register allocation.
 const OpPseudoLabel uint16 = 0xFFFF

--- a/asm/instr.go
+++ b/asm/instr.go
@@ -18,8 +18,8 @@ type Instruction struct {
 // of virtual-register source operands through its position.
 const OpPseudoUse uint16 = 0xFFFE
 
-// OpPseudoLabel is a pseudo-instruction that marks a label position. It
-// emits zero bytes and is stripped before register allocation.
+// OpPseudoLabel is a pseudo-instruction that marks a label position and
+// emits zero bytes during encoding.
 const OpPseudoLabel uint16 = 0xFFFF
 
 // Def returns the destination vreg if Dst is a virtual-register operand.

--- a/asm/instr_test.go
+++ b/asm/instr_test.go
@@ -31,6 +31,7 @@ func TestInstruction_Uses(t *testing.T) {
 	}
 
 	require.Equal(t, []VReg{a, b, c}, inst.Uses())
+	require.Equal(t, []VReg{a, b}, (Instruction{Op: OpPseudoUse, Src1: V(a), Src2: V(b)}).Uses())
 }
 
 func TestInstruction_String(t *testing.T) {

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -325,9 +325,9 @@ A loop root is anchored at a loop header: the target of a backward branch.
 
 The tracer discovers headers statically. Periodic samples still drive normal hotness, while JIT-enabled unconditional backward `BR` handlers also notify the interpreter after moving the live frame to the exact target header. This prevents a deterministic tick phase from permanently missing those loops. Threshold-zero mode waits for eight exact hits on those headers before capture so the first iteration does not over-specialize the recorded branch path.
 
-Loop lowering builds the normal native prologue, binds a back-edge label, lowers the loop body, commits loop-carried locals to VM stack slots, decrements `journalBudget`, and branches back while budget remains.
+Loop lowering builds the normal native prologue, binds a back-edge label, emits the loop body once, commits loop-carried locals to VM stack slots, decrements the safepoint budget, and branches back while budget remains. Eligible trace loops use a true backward branch; when the allocator cannot satisfy the resulting no-spill live ranges, compilation retries with bounded forward chaining.
 
-Loop-carried locals round-trip through the VM stack each iteration. This avoids a cross-back-edge register fixpoint.
+Loop-carried locals round-trip through the VM stack each iteration. This avoids a cross-back-edge register fixpoint. Call-free backward loops cache `journalBudget` in a register and write it back only on yield or another cold exit; other loops retain the memory-backed check.
 
 Module loops at `addr == 0` are valid when their header IP is positive. Only loops whose header is the module or function entry (`ip == 0`) remain threaded.
 
@@ -345,7 +345,7 @@ On yield trap, the wrapper deoptimizes to the header and runs one safepoint befo
 
 A trace loop plan may hoist one container: `hoistable` (`interp/jit_plan.go`) picks the most-accessed ref local whose recorded `ARRAY_GET`/non-terminal `ARRAY_SET` steps agree on one primitive typed-array itab, provided its root-frame slot fits the ARM64 load immediate, no block writes that local, and the plan contains no `CALL`/`RETURN_CALL` (a `BL` would clobber the hoisted registers). The backend prologue (`arm64Lowerer.hoist`) then derives the heap cell, guards the tag and itab, and loads the slice header once per native entry, before the header label. Matching accesses keep only their bounds side exit, `guardIndex`, and element load/store; I64 loads also retain their value/boxability side exit. A non-terminal hoisted primitive `ARRAY_SET` is no longer a state barrier (no snapshot flush plus local-cache clear), while terminal stores continue through the existing path.
 
-The hoisted registers are pure derived state: flush, snapshots, and reload never see them, and they stay valid for the whole entry because all flow inside a call-free loop callable is forward. The prologue takes no retain — the local slot keeps carrying the container's refcount — and its shape-guard exit resumes at the header with an empty operand stack. Accesses whose operand does not match the hoisted slot and itab use the per-access derivation unchanged.
+The hoisted registers are pure derived state: flush, snapshots, and reload never see them. A zero-byte `asm.OpPseudoUse` keeps them allocated through the backward branch, so the prologue-derived values remain valid across every native iteration. The prologue takes no retain — the local slot keeps carrying the container's refcount — and its shape-guard exit resumes at the header with an empty operand stack. Accesses whose operand does not match the hoisted slot and itab use the per-access derivation unchanged.
 
 ## Coroutine Suspension
 

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -114,7 +114,6 @@ type value struct {
 	imm     int64
 	fn      int
 	ref     int
-	stored  bool
 }
 
 // backing identifies where a ref value derives its reference count.
@@ -486,7 +485,7 @@ func (ctx *lowering) queueExit(values []value, resume int, reason prof.ExitReaso
 func (ctx *lowering) snapshot() ([]value, []activation) {
 	values := make([]value, len(ctx.values))
 	for i, v := range ctx.values {
-		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref, stored: v.stored}
+		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref}
 	}
 	frames := make([]activation, len(ctx.frames))
 	for i, f := range ctx.frames {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -71,12 +71,12 @@ type lowering struct {
 	descriptors []exitDescriptor
 	saved       []value
 
-	addr     int
-	root     int
-	returns  int
-	kind     entryKind
-	leaf     bool
-	backEdge bool
+	addr       int
+	loopRoot   int
+	returns    int
+	kind       entryKind
+	leaf       bool
+	nativeLoop bool
 
 	reuseLocals bool
 	spare       asm.VReg
@@ -114,7 +114,7 @@ type value struct {
 	imm     int64
 	fn      int
 	ref     int
-	flushed bool
+	stored  bool
 }
 
 // backing identifies where a ref value derives its reference count.
@@ -156,7 +156,7 @@ type localState uint8
 const (
 	localLoaded localState = 1 << iota
 	localDirty
-	localFlushed
+	localStored
 )
 
 type work struct {
@@ -327,24 +327,22 @@ func (c *compiler) compile(input *compileInput, plan plan, mod *module, frontend
 	if plan.noSpill {
 		arch = noSpillArch{c.arch}
 	}
-	attempts := []bool{false}
-	if plan.kind == entryLoop {
-		attempts = []bool{true, false}
-	}
-	for _, backEdge := range attempts {
-		ctx := c.newLowering(input, arch)
-		ctx.backEdge = backEdge
-		if !lower(ctx, plan) {
-			return prof.CompileReasonLoweringRejected, nil
-		}
-		exits := append([]exitDescriptor(nil), ctx.descriptors...)
-		reason, err := c.publish(mod, plan.anchor, ctx, c.arch, native{kind: plan.kind, frontend: frontend, exits: exits})
-		if reason == prof.CompileReasonRegisterPressure && backEdge {
-			continue
-		}
+	nativeLoop := plan.kind == entryLoop
+	reason, err := c.emit(input, plan, mod, frontend, arch, nativeLoop)
+	if reason != prof.CompileReasonRegisterPressure || !nativeLoop {
 		return reason, err
 	}
-	return prof.CompileReasonRegisterPressure, nil
+	return c.emit(input, plan, mod, frontend, arch, false)
+}
+
+func (c *compiler) emit(input *compileInput, plan plan, mod *module, frontend prof.Frontend, arch asm.Arch, nativeLoop bool) (prof.CompileReason, error) {
+	ctx := c.newLowering(input, arch)
+	ctx.nativeLoop = nativeLoop
+	if !lower(ctx, plan) {
+		return prof.CompileReasonLoweringRejected, nil
+	}
+	exits := append([]exitDescriptor(nil), ctx.descriptors...)
+	return c.publish(mod, plan.anchor, ctx, c.arch, native{kind: plan.kind, frontend: frontend, exits: exits})
 }
 
 func (c *compiler) newLowering(input *compileInput, arch asm.Arch) *lowering {
@@ -488,7 +486,7 @@ func (ctx *lowering) queueExit(values []value, resume int, reason prof.ExitReaso
 func (ctx *lowering) snapshot() ([]value, []activation) {
 	values := make([]value, len(ctx.values))
 	for i, v := range ctx.values {
-		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref, flushed: v.flushed}
+		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref, stored: v.stored}
 	}
 	frames := make([]activation, len(ctx.frames))
 	for i, f := range ctx.frames {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -61,6 +61,7 @@ type lowering struct {
 	entry     asm.Label
 	head      asm.Label
 	back      asm.Label
+	budget    asm.VReg
 
 	values      []value
 	frames      []activation
@@ -70,10 +71,12 @@ type lowering struct {
 	descriptors []exitDescriptor
 	saved       []value
 
-	addr    int
-	returns int
-	kind    entryKind
-	leaf    bool
+	addr     int
+	root     int
+	returns  int
+	kind     entryKind
+	leaf     bool
+	backEdge bool
 
 	reuseLocals bool
 	spare       asm.VReg
@@ -111,6 +114,7 @@ type value struct {
 	imm     int64
 	fn      int
 	ref     int
+	flushed bool
 }
 
 // backing identifies where a ref value derives its reference count.
@@ -152,6 +156,7 @@ type localState uint8
 const (
 	localLoaded localState = 1 << iota
 	localDirty
+	localFlushed
 )
 
 type work struct {
@@ -322,12 +327,24 @@ func (c *compiler) compile(input *compileInput, plan plan, mod *module, frontend
 	if plan.noSpill {
 		arch = noSpillArch{c.arch}
 	}
-	ctx := c.newLowering(input, arch)
-	if !lower(ctx, plan) {
-		return prof.CompileReasonLoweringRejected, nil
+	attempts := []bool{false}
+	if plan.kind == entryLoop {
+		attempts = []bool{true, false}
 	}
-	exits := append([]exitDescriptor(nil), ctx.descriptors...)
-	return c.publish(mod, plan.anchor, ctx, c.arch, native{kind: plan.kind, frontend: frontend, exits: exits})
+	for _, backEdge := range attempts {
+		ctx := c.newLowering(input, arch)
+		ctx.backEdge = backEdge
+		if !lower(ctx, plan) {
+			return prof.CompileReasonLoweringRejected, nil
+		}
+		exits := append([]exitDescriptor(nil), ctx.descriptors...)
+		reason, err := c.publish(mod, plan.anchor, ctx, c.arch, native{kind: plan.kind, frontend: frontend, exits: exits})
+		if reason == prof.CompileReasonRegisterPressure && backEdge {
+			continue
+		}
+		return reason, err
+	}
+	return prof.CompileReasonRegisterPressure, nil
 }
 
 func (c *compiler) newLowering(input *compileInput, arch asm.Arch) *lowering {
@@ -471,7 +488,7 @@ func (ctx *lowering) queueExit(values []value, resume int, reason prof.ExitReaso
 func (ctx *lowering) snapshot() ([]value, []activation) {
 	values := make([]value, len(ctx.values))
 	for i, v := range ctx.values {
-		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref}
+		values[i] = value{kind: v.kind, raw: v.raw, backing: v.backing, slot: v.slot, known: v.known, imm: v.imm, fn: v.fn, ref: v.ref, flushed: v.flushed}
 	}
 	frames := make([]activation, len(ctx.frames))
 	for i, f := range ctx.frames {

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -4231,9 +4231,9 @@ func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason pr
 }
 
 // flush writes dirty locals and live operands to their VM stack slots in
-// boxed form. Snapshot flushes remember stored homes so later guards do
-// not repeat unchanged stores; definitions clear that mark. A commit clears
-// both dirty and stored marks after transferring state to the VM stack.
+// boxed form. Snapshot flushes remember fixed local homes so later guards do
+// not repeat unchanged local stores; definitions clear that mark. Operands are
+// always stored because stack operations may move them to a different home.
 func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 	// A committing flush transfers each backingStack ref's retain to the VM
 	// stack, but it has no cold stub to re-take a deferred ref's retain: the
@@ -4275,14 +4275,10 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 	// re-takes it before the flushed copy reaches the interpreter (see retainDeferred /
 	// emitExits). The commit pre-scan above already rejected any deferred
 	// backing, so those cases only run on a non-commit flush.
-	for j := range ctx.values {
-		v := &ctx.values[j]
-		if v.stored {
-			continue
-		}
+	for j, v := range ctx.values {
 		switch v.backing {
 		case backingStack:
-			boxed, ok := l.boxHome(ctx, *v)
+			boxed, ok := l.boxHome(ctx, v)
 			if !ok {
 				return false
 			}
@@ -4294,7 +4290,6 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 		default:
 			a.Emit(arm64.STR(v.reg, addr, int16(ctx.slot(j)*8)))
 		}
-		v.stored = true
 	}
 	return true
 }

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -124,6 +124,9 @@ func (l arm64Lowerer) emitExits(ctx *lowering) {
 		ctx.values = exit.values
 		ctx.frames = exit.frames
 		ctx.assembler.Bind(exit.label)
+		if ctx.budget.Width() != asm.WidthUndefined {
+			ctx.assembler.Emit(arm64.STR(ctx.budget, ctx.pin(scratchCtrl), int16(journalBudget*8)))
+		}
 		var addr asm.VReg
 		for j, v := range exit.values {
 			switch v.backing {
@@ -276,6 +279,26 @@ func (l arm64Lowerer) next(ctx *lowering, from anchor, target edge, tail []int, 
 	if target.anchor.addr == from.addr && target.anchor.ip <= from.ip {
 		if !l.flush(ctx, flushCommit) {
 			return false
+		}
+		if ctx.backEdge && ctx.kind == entryLoop && target.block == ctx.root && len(ctx.frames) == 1 && ctx.count() == 0 {
+			a := ctx.assembler
+			if ctx.hoist.live {
+				a.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(ctx.hoist.dataPtr), Src2: asm.V(ctx.hoist.n)})
+			}
+			vCtrl := ctx.pin(scratchCtrl)
+			if ctx.budget.Width() != asm.WidthUndefined {
+				a.Emit(arm64.SUBI(ctx.budget, ctx.budget, 1))
+				a.Emit(arm64.CBNZLabel(ctx.budget, ctx.back))
+				a.Emit(arm64.STR(ctx.budget, vCtrl, int16(journalBudget*8)))
+			} else {
+				budget := a.Reg(asm.RegTypeInt, asm.Width64)
+				a.Emit(arm64.LDR(budget, vCtrl, int16(journalBudget*8)))
+				a.Emit(arm64.SUBI(budget, budget, 1))
+				a.Emit(arm64.STR(budget, vCtrl, int16(journalBudget*8)))
+				a.Emit(arm64.CBNZLabel(budget, ctx.back))
+			}
+			l.trapFlushed(ctx, trapYield, target.anchor.ip, -1)
+			return true
 		}
 		return l.path(ctx, from, target, tail, opcode)
 	}
@@ -909,7 +932,7 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 		return false
 	}
 	f.locals[idx] = *vp
-	f.state[idx] |= localLoaded | localDirty
+	f.state[idx] = f.state[idx]&^localFlushed | localLoaded | localDirty
 	if pop {
 		ctx.pop()
 	}
@@ -2324,7 +2347,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 				return false
 			}
 			frame.locals[k] = value{reg: zero, kind: frame.kinds[k], raw: true}
-			frame.state[k] |= localLoaded | localDirty
+			frame.state[k] = frame.state[k]&^localFlushed | localLoaded | localDirty
 		}
 	}
 	ctx.frames = append(ctx.frames, frame)
@@ -2615,7 +2638,7 @@ func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
 			}
 		}
 		f.locals[k] = args[k]
-		f.state[k] |= localLoaded | localDirty
+		f.state[k] = f.state[k]&^localFlushed | localLoaded | localDirty
 	}
 	if len(f.kinds) > len(args) {
 		zero := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
@@ -2627,7 +2650,7 @@ func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
 				return false
 			}
 			f.locals[k] = value{reg: zero, kind: f.kinds[k], raw: true}
-			f.state[k] |= localLoaded | localDirty
+			f.state[k] = f.state[k]&^localFlushed | localLoaded | localDirty
 		}
 	}
 	return true
@@ -4206,10 +4229,10 @@ func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason pr
 	return label, true
 }
 
-// flush writes every dirty local and live operand to its VM stack slot
-// in boxed form. commit clears dirty marks — only the hot path may do that;
-// a guard's cold path flushes a copy of the state and must leave the symbolic
-// state of the surviving hot path untouched.
+// flush writes dirty locals and live operands to their VM stack slots in
+// boxed form. Snapshot flushes memoize materialized homes so later guards do
+// not repeat unchanged stores; definitions clear that memo. A commit clears
+// both dirty and memoized marks after transferring state to the VM stack.
 func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 	// A committing flush transfers each backingStack ref's retain to the VM
 	// stack, but it has no cold stub to re-take a deferred ref's retain: the
@@ -4232,13 +4255,16 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 			if f.state[idx]&localDirty == 0 {
 				continue
 			}
-			boxed, ok := l.boxHome(ctx, f.locals[idx])
-			if !ok {
-				return false
+			if f.state[idx]&localFlushed == 0 {
+				boxed, ok := l.boxHome(ctx, f.locals[idx])
+				if !ok {
+					return false
+				}
+				a.Emit(arm64.STR(boxed, addr, int16((f.base+idx)*8)))
+				f.state[idx] |= localFlushed
 			}
-			a.Emit(arm64.STR(boxed, addr, int16((f.base+idx)*8)))
 			if mode == flushCommit {
-				f.state[idx] &^= localDirty
+				f.state[idx] &^= localDirty | localFlushed
 			}
 		}
 	}
@@ -4248,10 +4274,14 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 	// re-takes it before the flushed copy reaches the interpreter (see retainDeferred /
 	// emitExits). The commit pre-scan above already rejected any deferred
 	// backing, so those cases only run on a non-commit flush.
-	for j, v := range ctx.values {
+	for j := range ctx.values {
+		v := &ctx.values[j]
+		if v.flushed {
+			continue
+		}
 		switch v.backing {
 		case backingStack:
-			boxed, ok := l.boxHome(ctx, v)
+			boxed, ok := l.boxHome(ctx, *v)
 			if !ok {
 				return false
 			}
@@ -4263,6 +4293,7 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 		default:
 			a.Emit(arm64.STR(v.reg, addr, int16(ctx.slot(j)*8)))
 		}
+		v.flushed = true
 	}
 	return true
 }
@@ -4546,10 +4577,15 @@ func lower(ctx *lowering, plan plan) bool {
 		}
 	}
 	root := plan.root
+	ctx.root = root
 	if _, ok := ctx.labels[root]; !ok {
 		ctx.labels[root] = ctx.assembler.Label()
 	}
 	ctx.back = ctx.labels[root]
+	if ctx.backEdge && plan.kind == entryLoop && ctx.leaf {
+		ctx.budget = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+		ctx.assembler.Emit(arm64.LDR(ctx.budget, ctx.pin(scratchCtrl), int16(journalBudget*8)))
+	}
 	if plan.kind == entryLoop && plan.hoist != nil && !l.hoist(ctx, *plan.hoist, plan.anchor.ip) {
 		return false
 	}
@@ -4585,8 +4621,8 @@ func lower(ctx *lowering, plan plan) bool {
 // hoist derives the plan's loop-invariant container once per native entry:
 // the container local is loaded, tag- and itab-guarded against an empty-stack
 // exit resuming at the loop header, and its slice header lands in registers
-// that stay live for the whole body — hoistable rejected every call, so all
-// flow is forward and nothing clobbers them or re-enters ctx.back. The
+// that stay live across the loop back-edge. hoistable rejects every call, and
+// OpPseudoUse extends both live ranges through the backward branch. The
 // prologue takes no retain: the local slot keeps carrying the container's
 // refcount, and the exit snapshot is empty. Unsupported layouts decline
 // silently and every access keeps its per-op derivation.

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -280,7 +280,7 @@ func (l arm64Lowerer) next(ctx *lowering, from anchor, target edge, tail []int, 
 		if !l.flush(ctx, flushCommit) {
 			return false
 		}
-		if ctx.backEdge && ctx.kind == entryLoop && target.block == ctx.root && len(ctx.frames) == 1 && ctx.count() == 0 {
+		if ctx.nativeLoop && ctx.kind == entryLoop && target.block == ctx.loopRoot && len(ctx.frames) == 1 && ctx.count() == 0 {
 			a := ctx.assembler
 			if ctx.hoist.live {
 				a.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(ctx.hoist.dataPtr), Src2: asm.V(ctx.hoist.n)})
@@ -932,7 +932,7 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 		return false
 	}
 	f.locals[idx] = *vp
-	f.state[idx] = f.state[idx]&^localFlushed | localLoaded | localDirty
+	f.state[idx] = f.state[idx]&^localStored | localLoaded | localDirty
 	if pop {
 		ctx.pop()
 	}
@@ -2347,7 +2347,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 				return false
 			}
 			frame.locals[k] = value{reg: zero, kind: frame.kinds[k], raw: true}
-			frame.state[k] = frame.state[k]&^localFlushed | localLoaded | localDirty
+			frame.state[k] = frame.state[k]&^localStored | localLoaded | localDirty
 		}
 	}
 	ctx.frames = append(ctx.frames, frame)
@@ -2638,7 +2638,7 @@ func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
 			}
 		}
 		f.locals[k] = args[k]
-		f.state[k] = f.state[k]&^localFlushed | localLoaded | localDirty
+		f.state[k] = f.state[k]&^localStored | localLoaded | localDirty
 	}
 	if len(f.kinds) > len(args) {
 		zero := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
@@ -2650,7 +2650,7 @@ func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
 				return false
 			}
 			f.locals[k] = value{reg: zero, kind: f.kinds[k], raw: true}
-			f.state[k] = f.state[k]&^localFlushed | localLoaded | localDirty
+			f.state[k] = f.state[k]&^localStored | localLoaded | localDirty
 		}
 	}
 	return true
@@ -4230,9 +4230,9 @@ func (l arm64Lowerer) sideExit(ctx *lowering, pre []value, resume int, reason pr
 }
 
 // flush writes dirty locals and live operands to their VM stack slots in
-// boxed form. Snapshot flushes memoize materialized homes so later guards do
-// not repeat unchanged stores; definitions clear that memo. A commit clears
-// both dirty and memoized marks after transferring state to the VM stack.
+// boxed form. Snapshot flushes remember stored homes so later guards do
+// not repeat unchanged stores; definitions clear that mark. A commit clears
+// both dirty and stored marks after transferring state to the VM stack.
 func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 	// A committing flush transfers each backingStack ref's retain to the VM
 	// stack, but it has no cold stub to re-take a deferred ref's retain: the
@@ -4255,16 +4255,16 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 			if f.state[idx]&localDirty == 0 {
 				continue
 			}
-			if f.state[idx]&localFlushed == 0 {
+			if f.state[idx]&localStored == 0 {
 				boxed, ok := l.boxHome(ctx, f.locals[idx])
 				if !ok {
 					return false
 				}
 				a.Emit(arm64.STR(boxed, addr, int16((f.base+idx)*8)))
-				f.state[idx] |= localFlushed
+				f.state[idx] |= localStored
 			}
 			if mode == flushCommit {
-				f.state[idx] &^= localDirty | localFlushed
+				f.state[idx] &^= localDirty | localStored
 			}
 		}
 	}
@@ -4276,7 +4276,7 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 	// backing, so those cases only run on a non-commit flush.
 	for j := range ctx.values {
 		v := &ctx.values[j]
-		if v.flushed {
+		if v.stored {
 			continue
 		}
 		switch v.backing {
@@ -4293,7 +4293,7 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 		default:
 			a.Emit(arm64.STR(v.reg, addr, int16(ctx.slot(j)*8)))
 		}
-		v.flushed = true
+		v.stored = true
 	}
 	return true
 }
@@ -4577,12 +4577,12 @@ func lower(ctx *lowering, plan plan) bool {
 		}
 	}
 	root := plan.root
-	ctx.root = root
+	ctx.loopRoot = root
 	if _, ok := ctx.labels[root]; !ok {
 		ctx.labels[root] = ctx.assembler.Label()
 	}
 	ctx.back = ctx.labels[root]
-	if ctx.backEdge && plan.kind == entryLoop && ctx.leaf {
+	if ctx.nativeLoop && plan.kind == entryLoop && ctx.leaf {
 		ctx.budget = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(ctx.budget, ctx.pin(scratchCtrl), int16(journalBudget*8)))
 	}

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -280,24 +280,11 @@ func (l arm64Lowerer) next(ctx *lowering, from anchor, target edge, tail []int, 
 		if !l.flush(ctx, flushCommit) {
 			return false
 		}
-		if ctx.nativeLoop && ctx.kind == entryLoop && target.block == ctx.loopRoot && len(ctx.frames) == 1 && ctx.count() == 0 {
-			a := ctx.assembler
+		if ctx.nativeLoop && target.block == ctx.loopRoot && len(ctx.frames) == 1 && ctx.count() == 0 {
 			if ctx.hoist.live {
-				a.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(ctx.hoist.dataPtr), Src2: asm.V(ctx.hoist.n)})
+				ctx.assembler.Emit(asm.Instruction{Op: asm.OpPseudoUse, Src1: asm.V(ctx.hoist.dataPtr), Src2: asm.V(ctx.hoist.n)})
 			}
-			vCtrl := ctx.pin(scratchCtrl)
-			if ctx.budget.Width() != asm.WidthUndefined {
-				a.Emit(arm64.SUBI(ctx.budget, ctx.budget, 1))
-				a.Emit(arm64.CBNZLabel(ctx.budget, ctx.back))
-				a.Emit(arm64.STR(ctx.budget, vCtrl, int16(journalBudget*8)))
-			} else {
-				budget := a.Reg(asm.RegTypeInt, asm.Width64)
-				a.Emit(arm64.LDR(budget, vCtrl, int16(journalBudget*8)))
-				a.Emit(arm64.SUBI(budget, budget, 1))
-				a.Emit(arm64.STR(budget, vCtrl, int16(journalBudget*8)))
-				a.Emit(arm64.CBNZLabel(budget, ctx.back))
-			}
-			l.trapFlushed(ctx, trapYield, target.anchor.ip, -1)
+			l.back(ctx, ctx.back, target.anchor.ip)
 			return true
 		}
 		return l.path(ctx, from, target, tail, opcode)
@@ -1327,18 +1314,32 @@ func (l arm64Lowerer) path(ctx *lowering, from anchor, target edge, tail []int, 
 		return false
 	}
 	if target.anchor.addr == from.addr && target.anchor.ip <= from.ip {
-		a := ctx.assembler
-		vCtrl := ctx.pin(scratchCtrl)
-		budget := a.Reg(asm.RegTypeInt, asm.Width64)
-		a.Emit(arm64.LDR(budget, vCtrl, int16(journalBudget*8)))
-		a.Emit(arm64.SUBI(budget, budget, 1))
-		a.Emit(arm64.STR(budget, vCtrl, int16(journalBudget*8)))
-		a.Emit(arm64.CBNZLabel(budget, label))
-		l.trapFlushed(ctx, trapYield, target.anchor.ip, -1)
+		l.back(ctx, label, target.anchor.ip)
 		return true
 	}
 	ctx.assembler.Emit(arm64.BLabel(label))
 	return true
+}
+
+// back decrements the safepoint budget and continues at label while work remains.
+// Native loops keep the budget in a register; chained loops update its VM slot.
+func (l arm64Lowerer) back(ctx *lowering, label asm.Label, resume int) {
+	a := ctx.assembler
+	vCtrl := ctx.pin(scratchCtrl)
+	budget := ctx.budget
+	if budget.Width() == asm.WidthUndefined {
+		budget = a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.LDR(budget, vCtrl, int16(journalBudget*8)))
+	}
+	a.Emit(arm64.SUBI(budget, budget, 1))
+	if ctx.budget.Width() == asm.WidthUndefined {
+		a.Emit(arm64.STR(budget, vCtrl, int16(journalBudget*8)))
+	}
+	a.Emit(arm64.CBNZLabel(budget, label))
+	if ctx.budget.Width() != asm.WidthUndefined {
+		a.Emit(arm64.STR(budget, vCtrl, int16(journalBudget*8)))
+	}
+	l.trapFlushed(ctx, trapYield, resume, -1)
 }
 
 func (l arm64Lowerer) label(ctx *lowering, target edge, tail []int, opcode int) (asm.Label, bool) {
@@ -4582,7 +4583,7 @@ func lower(ctx *lowering, plan plan) bool {
 		ctx.labels[root] = ctx.assembler.Label()
 	}
 	ctx.back = ctx.labels[root]
-	if ctx.nativeLoop && plan.kind == entryLoop && ctx.leaf {
+	if ctx.nativeLoop && ctx.leaf {
 		ctx.budget = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(ctx.budget, ctx.pin(scratchCtrl), int16(journalBudget*8)))
 	}

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1136,7 +1136,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 	})
 
 	t.Run("sieve-shaped kernel keeps the local-backed array refcount exact", func(t *testing.T) {
-		const size = int32(24)
+		const size = int32(10_000)
 		b := program.NewBuilder()
 		arrayTyp := b.Type(types.TypeI32Array)
 		b.Locals(types.TypeI32Array, types.TypeI32, types.TypeI32)
@@ -1732,6 +1732,12 @@ func TestARM64_HoistedContainerLoop(t *testing.T) {
 			switch metric.Name {
 			case "vm_jit_native_entries_total":
 				entries += metric.Value
+			case "vm_jit_entry_bytes_total":
+				for _, label := range metric.Labels {
+					if label.Key == "kind" && label.Value == "loop" {
+						require.Less(t, metric.Value, float64(16<<10), "loop body was duplicated instead of using a back-edge")
+					}
+				}
 			case "vm_jit_native_exits_total":
 				for _, label := range metric.Labels {
 					if label.Key == "reason" {

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1728,6 +1728,7 @@ func TestARM64_HoistedContainerLoop(t *testing.T) {
 		// Hoisted loops must not pay per-access deopts: the only native exits
 		// are the loops' own cold branches.
 		var entries float64
+		var loopBytes bool
 		for _, metric := range profile.Metrics() {
 			switch metric.Name {
 			case "vm_jit_native_entries_total":
@@ -1735,6 +1736,7 @@ func TestARM64_HoistedContainerLoop(t *testing.T) {
 			case "vm_jit_entry_bytes_total":
 				for _, label := range metric.Labels {
 					if label.Key == "kind" && label.Value == "loop" {
+						loopBytes = true
 						require.Less(t, metric.Value, float64(16<<10), "loop body was duplicated instead of using a back-edge")
 					}
 				}
@@ -1747,6 +1749,7 @@ func TestARM64_HoistedContainerLoop(t *testing.T) {
 			}
 		}
 		require.Greater(t, entries, float64(0))
+		require.True(t, loopBytes, "expected a loop entry byte metric")
 	})
 
 	t.Run("the prologue shape guard deopts to the header", func(t *testing.T) {

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -1136,7 +1136,7 @@ func TestARM64_DeferredRefElision(t *testing.T) {
 	})
 
 	t.Run("sieve-shaped kernel keeps the local-backed array refcount exact", func(t *testing.T) {
-		const size = int32(10_000)
+		const size = int32(24)
 		b := program.NewBuilder()
 		arrayTyp := b.Type(types.TypeI32Array)
 		b.Locals(types.TypeI32Array, types.TypeI32, types.TypeI32)


### PR DESCRIPTION
## Summary

- lower eligible ARM64 trace loops as one native body with a real backward branch
- cache the safepoint budget in a register for native loops and write it back only on cold exits
- avoid repeated unchanged local stores across snapshot flushes
- add a zero-byte pseudo-use instruction to keep hoisted registers live across the backedge
- fall back to bounded forward chaining when native backedge allocation hits register pressure
- unify native and chained backedge budget emission

Closes #156.

## Verification

- `go test ./asm/... ./interp -count=1`
- `make check`
- `go test -race ./...`
- `git diff --check`

## Benchmarks

Focused ARM64 results from the branch:

- `BenchmarkControl_Sieve/jit`: 4.17-4.26 us/op
- `BenchmarkControl_Sieve/threaded`: 15.82-15.91 us/op
- `BenchmarkMemory_TypedArraySum/jit`: 611-625 ns/op
- `BenchmarkMemory_TypedArraySum/threaded`: 6.15-6.21 us/op


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved ARM64 JIT native-loop handling with more precise safepoint budgeting and back-edge control, including smarter retry behavior under register pressure.
  * Added a new zero-byte pseudo-instruction to extend derived register live ranges across native loop backward branches (enabling container hoisting).
* **Bug Fixes**
  * Ensured pseudo-instructions are never emitted as machine code or relocations during assembly.
  * Refined local state tracking so dirty locals are only stored when needed, reducing redundant updates.
* **Documentation**
  * Updated JIT loop and loop-invariant container hoisting documentation to reflect the new backward-branch live-range behavior.
* **Tests**
  * Added coverage for pseudo-instruction behavior and enhanced validation of loop-entry code metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->