### PR TITLE
fix(interp): stop host allocation scanning the heap and leaking frame slots

### DIFF
--- a/benchmarks/memory_test.go
+++ b/benchmarks/memory_test.go
@@ -101,6 +101,206 @@ func typedArraySum(size int32) *program.Program {
 	return prog
 }
 
+func BenchmarkMemory_PermutationFlips(b *testing.B) {
+	const size int32 = 24
+	const depth int32 = 64
+	want := permutationFlipsReference(size, depth)
+	prog := permutationFlips(size, depth)
+	require.NoError(b, program.Verify(prog))
+
+	benchmarkVM(b, prog, types.BoxI32(want))
+	benchmarkCompare(b, benchmarkComparison{
+		native: func() int32 {
+			var walk func(d int32) int32
+			walk = func(d int32) int32 {
+				if d == 0 {
+					return 0
+				}
+				arr := make([]int32, size)
+				for index := range arr {
+					arr[index] = size - 1 - int32(index)
+				}
+				lo, hi := int32(0), size-1
+				for lo < hi {
+					arr[lo], arr[hi] = arr[hi], arr[lo]
+					lo++
+					hi--
+				}
+				return arr[size-1] + walk(d-1)
+			}
+			return walk(depth)
+		},
+		scripts: benchmarkScripts{
+			tengo: fmt.Sprintf(`walk := func(d) {
+    if d == 0 { return 0 }
+    arr := []
+    for i := 0; i < %d; i++ { arr = append(arr, %d - 1 - i) }
+    lo := 0
+    hi := %d - 1
+    for lo < hi {
+        t := arr[lo]
+        arr[lo] = arr[hi]
+        arr[hi] = t
+        lo++
+        hi--
+    }
+    return arr[%d - 1] + walk(d - 1)
+}
+result := walk(%d)`, size, size, size, size, depth),
+			gopherLua: fmt.Sprintf(`function walk(d)
+    if d == 0 then return 0 end
+    local arr = {}
+    for i = 0, %d - 1 do arr[i] = %d - 1 - i end
+    local lo, hi = 0, %d - 1
+    while lo < hi do
+        local t = arr[lo]
+        arr[lo] = arr[hi]
+        arr[hi] = t
+        lo = lo + 1
+        hi = hi - 1
+    end
+    return arr[%d - 1] + walk(d - 1)
+end
+function run() return walk(%d) end`, size, size, size, size, depth),
+			goja: fmt.Sprintf(`function walk(d) {
+    if (d === 0) return 0;
+    let arr = [];
+    for (let i = 0; i < %d; i++) arr[i] = %d - 1 - i;
+    let lo = 0, hi = %d - 1;
+    while (lo < hi) {
+        let t = arr[lo]; arr[lo] = arr[hi]; arr[hi] = t;
+        lo++; hi--;
+    }
+    return arr[%d - 1] + walk(d - 1);
+}
+function run() { return walk(%d); }`, size, size, size, size, depth),
+			gpython: fmt.Sprintf(`def walk(d):
+    if d == 0: return 0
+    arr = [0] * %d
+    for i in range(%d): arr[i] = %d - 1 - i
+    lo, hi = 0, %d - 1
+    while lo < hi:
+        arr[lo], arr[hi] = arr[hi], arr[lo]
+        lo += 1
+        hi -= 1
+    return arr[%d - 1] + walk(d - 1)
+def run(): return walk(%d)`, size, size, size, size, size, depth),
+			yaegi: fmt.Sprintf(`package bench
+func walk(d int32) int32 {
+    if d == 0 { return 0 }
+    arr := make([]int32, %d)
+    for i := range arr { arr[i] = int32(%d) - 1 - int32(i) }
+    lo, hi := 0, %d - 1
+    for lo < hi {
+        arr[lo], arr[hi] = arr[hi], arr[lo]
+        lo++
+        hi--
+    }
+    return arr[%d - 1] + walk(d - 1)
+}
+func Run() int32 { return walk(%d) }`, size, size, size, size, depth),
+		},
+	}, want)
+}
+
+func BenchmarkMemory_StructTreeWalk(b *testing.B) {
+	const depth int32 = 9
+	want := structTreeWalkReference(depth)
+	prog := structTreeWalk(depth)
+	require.NoError(b, program.Verify(prog))
+
+	benchmarkVM(b, prog, types.BoxI32(want))
+	benchmarkCompare(b, benchmarkComparison{
+		native: func() int32 {
+			type node struct{ left, right *node }
+			var build func(d int32) *node
+			build = func(d int32) *node {
+				n := &node{}
+				if d > 0 {
+					n.left = build(d - 1)
+					n.right = build(d - 1)
+				}
+				return n
+			}
+			var check func(n *node) int32
+			check = func(n *node) int32 {
+				if n == nil {
+					return 0
+				}
+				return 1 + check(n.left) + check(n.right)
+			}
+			return check(build(depth))
+		},
+		scripts: benchmarkScripts{
+			tengo: fmt.Sprintf(`build := func(d) {
+    n := {left: undefined, right: undefined}
+    if d > 0 {
+        n.left = build(d - 1)
+        n.right = build(d - 1)
+    }
+    return n
+}
+check := func(n) {
+    if n == undefined { return 0 }
+    return 1 + check(n.left) + check(n.right)
+}
+result := check(build(%d))`, depth),
+			gopherLua: fmt.Sprintf(`function build(d)
+    local n = {left=false, right=false}
+    if d > 0 then
+        n.left = build(d - 1)
+        n.right = build(d - 1)
+    end
+    return n
+end
+function check(n)
+    if not n then return 0 end
+    return 1 + check(n.left) + check(n.right)
+end
+function run() return check(build(%d)) end`, depth),
+			goja: fmt.Sprintf(`function build(d) {
+    let n = { left: null, right: null };
+    if (d > 0) { n.left = build(d - 1); n.right = build(d - 1); }
+    return n;
+}
+function check(n) {
+    if (n === null) return 0;
+    return 1 + check(n.left) + check(n.right);
+}
+function run() { return check(build(%d)); }`, depth),
+			gpython: fmt.Sprintf(`class Node:
+    def __init__(self):
+        self.left = None
+        self.right = None
+def build(d):
+    n = Node()
+    if d > 0:
+        n.left = build(d - 1)
+        n.right = build(d - 1)
+    return n
+def check(n):
+    if n is None: return 0
+    return 1 + check(n.left) + check(n.right)
+def run(): return check(build(%d))`, depth),
+			yaegi: fmt.Sprintf(`package bench
+type node struct { left, right *node }
+func build(d int32) *node {
+    n := &node{}
+    if d > 0 {
+        n.left = build(d - 1)
+        n.right = build(d - 1)
+    }
+    return n
+}
+func check(n *node) int32 {
+    if n == nil { return 0 }
+    return 1 + check(n.left) + check(n.right)
+}
+func Run() int32 { return check(build(%d)) }`, depth),
+		},
+	}, want)
+}
+
 func allocationGraph(depth int32) *program.Program {
 	b := program.NewBuilder()
 	array := b.Type(types.NewArrayType(types.TypeRef))
@@ -123,6 +323,160 @@ func allocationGraph(depth int32) *program.Program {
 	return prog
 }
 
+func permutationFlips(size, depth int32) *program.Program {
+	arrayType := types.NewArrayType(types.TypeRef)
+
+	// locals: 0=depth (param), 1=arr, 2=i, 3=lo, 4=hi, 5=t
+	fb := types.NewFunctionBuilder(&types.FunctionType{Returns: []types.Type{types.TypeI32}}).
+		Params(types.TypeI32).
+		Locals(types.TypeRef, types.TypeI32, types.TypeI32, types.TypeI32, types.TypeI32)
+	base := fb.Label()
+	fillLoop := fb.Label()
+	fillDone := fb.Label()
+	swapLoop := fb.Label()
+	swapDone := fb.Label()
+
+	fn := fb.
+		Emit(instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_CONST, 0), instr.New(instr.I32_EQ)).
+		BrIf(base).
+		Emit(
+			instr.New(instr.I32_CONST, uint64(uint32(size))), instr.New(instr.ARRAY_NEW_DEFAULT, 0), instr.New(instr.LOCAL_SET, 1),
+			instr.New(instr.I32_CONST, 0), instr.New(instr.LOCAL_SET, 2),
+		).
+		Bind(fillLoop).
+		Emit(instr.New(instr.LOCAL_GET, 2), instr.New(instr.I32_CONST, uint64(uint32(size))), instr.New(instr.I32_GE_S)).
+		BrIf(fillDone).
+		Emit(
+			// arr[i] = size-1-i
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.LOCAL_GET, 2),
+			instr.New(instr.I32_CONST, uint64(uint32(size-1))), instr.New(instr.LOCAL_GET, 2), instr.New(instr.I32_SUB),
+			instr.New(instr.ARRAY_SET),
+			instr.New(instr.LOCAL_GET, 2), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_ADD), instr.New(instr.LOCAL_SET, 2),
+		).
+		Br(fillLoop).
+		Bind(fillDone).
+		Emit(
+			instr.New(instr.I32_CONST, 0), instr.New(instr.LOCAL_SET, 3),
+			instr.New(instr.I32_CONST, uint64(uint32(size-1))), instr.New(instr.LOCAL_SET, 4),
+		).
+		Bind(swapLoop).
+		Emit(instr.New(instr.LOCAL_GET, 3), instr.New(instr.LOCAL_GET, 4), instr.New(instr.I32_GE_S)).
+		BrIf(swapDone).
+		Emit(
+			// t = arr[lo]
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.LOCAL_GET, 3), instr.New(instr.ARRAY_GET), instr.New(instr.LOCAL_SET, 5),
+			// arr[lo] = arr[hi]
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.LOCAL_GET, 3),
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.LOCAL_GET, 4), instr.New(instr.ARRAY_GET),
+			instr.New(instr.ARRAY_SET),
+			// arr[hi] = t
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.LOCAL_GET, 4), instr.New(instr.LOCAL_GET, 5), instr.New(instr.ARRAY_SET),
+			// lo++; hi--
+			instr.New(instr.LOCAL_GET, 3), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_ADD), instr.New(instr.LOCAL_SET, 3),
+			instr.New(instr.LOCAL_GET, 4), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_SUB), instr.New(instr.LOCAL_SET, 4),
+		).
+		Br(swapLoop).
+		Bind(swapDone).
+		Emit(
+			// arr[size-1] + walk(depth-1)
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, uint64(uint32(size-1))), instr.New(instr.ARRAY_GET),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_SUB),
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CALL),
+			instr.New(instr.I32_ADD), instr.New(instr.RETURN),
+		).
+		Bind(base).
+		Emit(instr.New(instr.I32_CONST, 0), instr.New(instr.RETURN)).
+		MustBuild()
+
+	return program.New(
+		[]instr.Instruction{instr.New(instr.I32_CONST, uint64(uint32(depth))), instr.New(instr.CONST_GET, 0), instr.New(instr.CALL)},
+		program.WithConstants(fn),
+		program.WithTypes(arrayType),
+	)
+}
+
+func structTreeWalk(depth int32) *program.Program {
+	nodeType := types.NewStructType(
+		types.NewStructField(types.TypeI64, types.FieldWithName("value")),
+		types.NewStructField(types.TypeRef, types.FieldWithName("left")),
+		types.NewStructField(types.TypeRef, types.FieldWithName("right")),
+	)
+
+	// build locals: 0=d (param), 1=n
+	buildBuilder := types.NewFunctionBuilder(&types.FunctionType{Returns: []types.Type{types.TypeRef}}).
+		Params(types.TypeI32).
+		Locals(types.TypeRef)
+	buildDone := buildBuilder.Label()
+	buildFn := buildBuilder.
+		Emit(
+			instr.New(instr.STRUCT_NEW_DEFAULT, 0), instr.New(instr.LOCAL_SET, 1),
+			// n.value = i64(d)
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, 0),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_TO_I64_S),
+			instr.New(instr.STRUCT_SET),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_CONST, 0), instr.New(instr.I32_LE_S),
+		).
+		BrIf(buildDone).
+		Emit(
+			// n.left = build(d-1)
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, 1),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_SUB),
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CALL),
+			instr.New(instr.STRUCT_SET),
+			// n.right = build(d-1)
+			instr.New(instr.LOCAL_GET, 1), instr.New(instr.I32_CONST, 2),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_SUB),
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CALL),
+			instr.New(instr.STRUCT_SET),
+		).
+		Bind(buildDone).
+		Emit(
+			instr.New(instr.LOCAL_GET, 1),
+			instr.New(instr.RETURN),
+		).
+		MustBuild()
+
+	// check locals: 0=node (param)
+	checkBuilder := types.NewFunctionBuilder(&types.FunctionType{Returns: []types.Type{types.TypeI32}}).
+		Params(types.TypeRef)
+	nullCase := checkBuilder.Label()
+	checkFn := checkBuilder.
+		Emit(instr.New(instr.LOCAL_GET, 0), instr.New(instr.REF_IS_NULL)).
+		BrIf(nullCase).
+		Emit(
+			// m := ref.cast[Node](node); left := m.left; check(left)
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.REF_CAST, 0),
+			instr.New(instr.I32_CONST, 1), instr.New(instr.STRUCT_GET),
+			instr.New(instr.CONST_GET, 1), instr.New(instr.CALL),
+			// right := m.right; check(right)
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.I32_CONST, 2), instr.New(instr.STRUCT_GET),
+			instr.New(instr.CONST_GET, 1), instr.New(instr.CALL),
+			instr.New(instr.I32_ADD), instr.New(instr.I32_CONST, 1), instr.New(instr.I32_ADD),
+			instr.New(instr.RETURN),
+		).
+		Bind(nullCase).
+		Emit(instr.New(instr.I32_CONST, 0), instr.New(instr.RETURN)).
+		MustBuild()
+
+	return program.New(
+		[]instr.Instruction{
+			instr.New(instr.I32_CONST, uint64(uint32(depth))),
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CALL),
+			instr.New(instr.CONST_GET, 1), instr.New(instr.CALL),
+		},
+		program.WithConstants(buildFn, checkFn),
+		program.WithTypes(nodeType),
+	)
+}
+
 func typedArraySumReference(size int32) int32 {
 	return size * (size + 1) / 2
+}
+
+func permutationFlipsReference(size, depth int32) int32 {
+	return depth * (size - 1)
+}
+
+func structTreeWalkReference(depth int32) int32 {
+	return int32(1<<uint(depth+1)) - 1
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -46,7 +46,7 @@ go test -tags=compare -run='^$' -bench='.' -benchmem -benchtime=300ms -count=3 .
 # Issue #164 A/B: alternate this command between commit 10d6adf and the
 # current checkout five times, then take each side's median.
 go test -run='^$' \
-  -bench='^(BenchmarkControl_IterativeFib|BenchmarkControl_Sieve|BenchmarkCall_RecursiveFib|BenchmarkCall_IndirectRecursiveFib|BenchmarkCall_ClosureCounter|BenchmarkMemory_TypedArraySum|BenchmarkMemory_AllocationGraph|BenchmarkNumeric_BranchTree)$' \
+  -bench='^(BenchmarkControl_IterativeFib|BenchmarkControl_Sieve|BenchmarkCall_RecursiveFib|BenchmarkCall_IndirectRecursiveFib|BenchmarkCall_ClosureCounter|BenchmarkMemory_TypedArraySum|BenchmarkMemory_AllocationGraph|BenchmarkMemory_PermutationFlips|BenchmarkMemory_StructTreeWalk|BenchmarkNumeric_BranchTree)$' \
   -benchmem -benchtime=300ms -count=1 .
 
 # Public interpreter and pool API costs
@@ -83,6 +83,25 @@ go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
 - Threshold-zero `jit` is not a warmed-JIT guarantee. It matches `default` on Sieve and BranchTree, but is slower on IterativeFib, TypedArraySum, and recursive Fibonacci because it can compile before representative traces are learned.
 - Allocation-heavy workloads remain interpreter-bound. `AllocationGraph(128)` is fastest in minivm's threaded mode at **4.816 us**; adaptive and eager modes add profiling cost without native coverage.
 - Indirect recursion reaches the native self-call path in adaptive mode: `IndirectRecursiveFib(20)` is **53.56 us** in `default`, versus **478 us** threaded and **43.3 us** in wazero. Eager `jit` stays at **584 us**, consistent with the threshold-zero note above.
+
+- Host-boundary ownership checking is no longer proportional to the heap
+  (issues #169, #170). `Alloc`, `Store`, and `Push` used to scan every live slot
+  with reflection to reject an already-owned pointer, so an embedder that
+  allocates per operation ran quadratically. The check is now one index lookup.
+- `RETURN` releases the frame slots it discards, which reference counting
+  previously leaked. On `linux/amd64` (4 cores, Go 1.26.2, min of eight
+  300 ms samples) the sweep costs `RecursiveFib(20)/threaded`
+  **604 -> 672 ns/op**; skipping it for frames whose every slot is a plain
+  scalar recovers most of that at **625 ns/op**. Frames with `ref`- or
+  `i64`-shaped slots pay the sweep, which is the price of counts exact enough
+  for trial deletion to collect at all.
+- `PermutationFlips` and `StructTreeWalk` cover recursion with per-call boxed
+  array allocation and in-place `ARRAY_GET`/`ARRAY_SET`, and recursive
+  `STRUCT_NEW_DEFAULT`/`STRUCT_SET` construction with `REF_CAST` traversal.
+  They are workload coverage for the shapes those issues reported; neither
+  reproduces the regressions on its own, because the host-boundary scan needs
+  an embedder and a per-call leak does not compound inside one benchmark
+  operation.
 
 These results are workload measurements, not general language rankings. The runtimes use different value models, safety boundaries, host-call conventions, and compilation strategies.
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -125,7 +125,9 @@ Ownership rules:
   `Alloc(existingRef)` to create another ownership of one object
 - concrete pointer values passed to `Alloc`, `Store`, or `Push` transfer unique
   ownership and must not already be owned by the interpreter; use an existing
-  ref when sharing one object
+  ref when sharing one object. The interpreter answers this from an index of the
+  pointers that have crossed `Alloc`, `Store`, `Push`, `Load`, `Retain`, or
+  `Pop`, so the check costs one lookup no matter how large the heap is
 - `Retain` creates another host-owned reference
 - `Release` drops a host-owned reference
 - every owned reference from `Alloc` or `Retain` must eventually be transferred or released

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -61,6 +61,13 @@ Reference counting is handled by threaded handlers and host APIs.
 | map replace/delete/clear | release map-owned refs |
 | `CLOSURE_NEW` | transfer popped function and upvalues into closure |
 | suspend closure coroutine | transfer callable, stack image, and yielded value; trace upvalues through callable |
+| `RETURN` | release every frame slot below the returned values |
+
+A frame owns its params, its locals, and any operands still stacked beneath the
+values it returns. Only the returns pass to the caller, so `RETURN` releases the
+rest before collapsing the frame, exactly as an exception unwind does. Leaving
+them unreleased inflates counts that no owner backs, and trial deletion reads an
+inflated count as ownership outside the heap, so such a leak is unreclaimable.
 
 `retain(addr)` increments `rc[addr]`.
 

--- a/docs/profile.md
+++ b/docs/profile.md
@@ -128,6 +128,14 @@ Aggregate metrics remain available for existing consumers:
 | `vm_jit_emits_total` | emitted trace objects |
 | `vm_jit_errors_total` | compile or link errors |
 | `vm_jit_bytes_total` | generated code bytes |
+| `vm_gc_cycles_total` | collections run |
+| `vm_gc_slots_total` | heap slots a collection walked, summed over cycles |
+
+Every collection pass walks the whole heap, so `vm_gc_slots_total` is the
+collector's total work; divided by the allocations a run performs it is the
+price paced allocation pays per object. A rising `vm_gc_cycles_total` on a
+program with a steady live set means garbage that reference counting is not
+reclaiming.
 
 Detailed lifecycle metrics retain bounded typed dimensions until `Metrics()`
 converts them to ordered string labels:

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -1029,7 +1029,7 @@ func dynamicCall(op instr.Opcode) ([]jen.Code, error) {
 	hostCore = append(hostCore, invoke(1, 1, tail)...)
 	host := []jen.Code{jen.Block(hostCore...)}
 	if tail {
-		host = append(host, jen.If(jen.Id("i").Dot("fp").Op(">").Lit(1)).Block(retire()...))
+		host = append(host, jen.If(jen.Id("i").Dot("fp").Op(">").Lit(1)).Block(retire(nil)...))
 	}
 	body := append(prefix, jen.Switch(jen.Id("fn").Op(":=").Id("i").Dot("heap").Index(jen.Id("addr")).Assert(jen.Type())).Block(
 		jen.Case(jen.Op("*").Qual("github.com/siyul-park/minivm/types", "Function")).Block(function...),
@@ -1365,7 +1365,7 @@ func invoke(targetSlots, advance int, tail bool) []jen.Code {
 		if targetSlots == 1 {
 			body = append(body, jen.Id("i").Dot("fr").Dot("ip").Op("+=").Lit(advance))
 		} else {
-			body = append(body, jen.If(jen.Id("i").Dot("fp").Op(">").Lit(1)).Block(retire()...))
+			body = append(body, jen.If(jen.Id("i").Dot("fp").Op(">").Lit(1)).Block(retire(nil)...))
 		}
 	} else {
 		body = append(body, jen.Id("i").Dot("fr").Dot("ip").Op("+=").Lit(advance))
@@ -1435,7 +1435,16 @@ func release(args, returns jen.Code) jen.Code {
 	)
 }
 
-func retire() []jen.Code {
+// retire emits a frame teardown. guard, when non-nil, is a condition the
+// caller computed while threading: the slot release only runs when it holds.
+func retire(guard jen.Code) []jen.Code {
+	sweep := jen.For(jen.List(jen.Id("_"), jen.Id("value")).Op(":=").Range().Id("i").Dot("stack").Index(
+		jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp").Op("-").Id("f").Dot("returns"),
+	)).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value")))
+	var discard jen.Code = sweep
+	if guard != nil {
+		discard = jen.If(guard).Block(sweep)
+	}
 	return []jen.Code{
 		jen.Id("f").Op(":=").Id("i").Dot("fr"),
 		jen.If(jen.Id("i").Dot("sp").Op("<").Id("f").Dot("returns")).Block(jen.Panic(jen.Id("ErrStackUnderflow"))),
@@ -1445,10 +1454,13 @@ func retire() []jen.Code {
 			jen.If(jen.Op("!").Id("ok")).Block(jen.Panic(jen.Id("ErrTypeMismatch"))),
 			jen.If(jen.Id("f").Dot("returns").Op(">").Lit(0)).Block(
 				jen.For(jen.List(jen.Id("_"), jen.Id("value")).Op(":=").Range().Id("i").Dot("stack").Index(
-					jen.Id("i").Dot("sp").Op("-").Id("f").Dot("returns").Op(":").Id("i").Dot("sp").Op("-").Lit(1),
+					jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp").Op("-").Lit(1),
 				)).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value"))),
 				jen.Id("co").Dot("value").Op("=").Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Lit(1)),
 			).Else().Block(
+				jen.For(jen.List(jen.Id("_"), jen.Id("value")).Op(":=").Range().Id("i").Dot("stack").Index(
+					jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp"),
+				)).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value"))),
 				jen.Id("i").Dot("retain").Call(jen.Lit(0)),
 				jen.Id("co").Dot("value").Op("=").Qual("github.com/siyul-park/minivm/types", "BoxedNull"),
 			),
@@ -1468,6 +1480,11 @@ func retire() []jen.Code {
 			jen.Id("i").Dot("sp").Op("=").Id("bp").Op("+").Lit(1),
 			jen.Return(),
 		),
+		jen.Comment("A frame owns its params, locals, and any operands left below the"),
+		jen.Comment("returned values; only the returns pass to the caller, so everything"),
+		jen.Comment("under them is released here. land does the same when an exception"),
+		jen.Comment("unwinds the frame, and the cycle collector needs counts to be exact."),
+		discard,
 		jen.Switch(jen.Id("f").Dot("returns")).Block(
 			jen.Case(jen.Lit(0)).Block(),
 			jen.Case(jen.Lit(1)).Block(jen.Id("i").Dot("stack").Index(jen.Id("f").Dot("bp")).Op("=").Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Lit(1))),
@@ -3817,10 +3834,26 @@ func returnOp() jen.Code {
 		Params(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter"))).
 		Block(
 			jen.Id("c").Dot("ip").Op("++"),
+			jen.Comment("A frame whose every slot is a plain scalar can only be holding"),
+			jen.Comment("scalars when its operand stack is balanced, so the release sweep"),
+			jen.Comment("is skipped for it. The kinds that can carry a ref are the same ones"),
+			jen.Comment("LOCAL_GET retains for."),
+			jen.Id("slots").Op(":=").Len(jen.Id("c").Dot("locals")),
+			jen.Id("owned").Op(":=").False(),
+			jen.For(jen.List(jen.Id("_"), jen.Id("kind")).Op(":=").Range().Id("c").Dot("locals")).Block(
+				jen.Switch(jen.Id("kind").Dot("Repr").Call()).Block(
+					jen.Case(
+						jen.Qual("github.com/siyul-park/minivm/types", "KindI32"),
+						jen.Qual("github.com/siyul-park/minivm/types", "KindF32"),
+						jen.Qual("github.com/siyul-park/minivm/types", "KindF64"),
+					).Block(),
+					jen.Default().Block(jen.Id("owned").Op("=").True()),
+				),
+			),
 			jen.Return(
 				jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(
 					jen.If(jen.Id("i").Dot("fp").Op("==").Lit(1)).Block(jen.Panic(jen.Id("ErrFrameUnderflow"))),
-					jen.Block(retire()...),
+					jen.Block(retire(jen.Id("owned").Op("||").Id("i").Dot("sp").Op("!=").Id("f").Dot("bp").Op("+").Id("slots").Op("+").Id("f").Dot("returns"))...),
 				),
 			),
 		)

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -55,6 +55,7 @@ type Interpreter struct {
 	base     int
 	target   int
 	interned map[string]types.Ref
+	owners   map[types.Value]int
 	free     []int
 	rc       []int
 	trial    []int
@@ -261,6 +262,7 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		stack:       make([]types.Boxed, opt.stack),
 		heap:        make([]types.Value, 0, opt.heap),
 		interned:    make(map[string]types.Ref),
+		owners:      make(map[types.Value]int),
 		free:        make([]int, 0, opt.heap),
 		rc:          make([]int, 0, opt.heap),
 		tick:        opt.tick,
@@ -506,7 +508,9 @@ func (i *Interpreter) Load(addr int) (types.Value, error) {
 	if !i.alive(addr) {
 		return nil, ErrSegmentationFault
 	}
-	return i.heap[addr], nil
+	val := i.heap[addr]
+	i.own(addr, val)
+	return val, nil
 }
 
 // Store replaces the value at addr. Concrete values transfer unique slot
@@ -548,6 +552,7 @@ func (i *Interpreter) Store(addr int, val types.Value) (err error) {
 		return ErrTypeMismatch
 	}
 	i.heap[addr] = val
+	i.own(addr, val)
 	i.dispose(addr, old)
 	if fn, ok := val.(*types.Function); ok {
 		i.bind(addr, fn, true)
@@ -583,6 +588,7 @@ func (i *Interpreter) Alloc(val types.Value) (addr int, err error) {
 		return int(i.intern(string(s))), nil
 	}
 	addr = i.alloc(val)
+	i.own(addr, val)
 	if fn, ok := val.(*types.Function); ok {
 		i.bind(addr, fn, true)
 	}
@@ -594,7 +600,9 @@ func (i *Interpreter) Retain(addr int) (types.Value, error) {
 		return nil, ErrSegmentationFault
 	}
 	i.retain(addr)
-	return i.heap[addr], nil
+	val := i.heap[addr]
+	i.own(addr, val)
+	return val, nil
 }
 
 func (i *Interpreter) Release(addr int) error {
@@ -613,7 +621,11 @@ func (i *Interpreter) Push(val types.Value) (err error) {
 	if i.owner(val) >= 0 {
 		return ErrTypeMismatch
 	}
-	i.stack[i.sp] = i.box(val)
+	boxed := i.box(val)
+	if boxed.Kind() == types.KindRef {
+		i.own(boxed.Ref(), val)
+	}
+	i.stack[i.sp] = boxed
 	i.sp++
 	return nil
 }
@@ -623,7 +635,12 @@ func (i *Interpreter) Pop() (types.Value, error) {
 		return nil, ErrStackUnderflow
 	}
 	i.sp--
-	return i.unbox(i.stack[i.sp]), nil
+	boxed := i.stack[i.sp]
+	val := i.unbox(boxed)
+	if boxed.Kind() == types.KindRef {
+		i.own(boxed.Ref(), val)
+	}
+	return val, nil
 }
 
 // PopBoxed consumes the top-of-stack value and returns its raw NaN-boxed word
@@ -1948,21 +1965,63 @@ func (i *Interpreter) releaseBox(v types.Boxed) {
 	}
 }
 
+// owner returns the slot that already holds val, or -1 when val is unowned.
+// Only a pointer value can be aliased into two slots; every other kind is
+// copied into its slot, so unowned is the answer for them by construction.
+//
+// owners only hints at the answer. The heap is the authority, so a hint left
+// behind by a freed or overwritten slot is discarded here instead of being
+// tracked on the interpreter's allocation path.
 func (i *Interpreter) owner(val types.Value) int {
-	pointer := reflect.ValueOf(val)
-	if !pointer.IsValid() || pointer.Kind() != reflect.Pointer {
+	if !aliasable(val) {
 		return -1
 	}
-	for addr, current := range i.heap {
-		if !i.alive(addr) {
-			continue
-		}
-		owner := reflect.ValueOf(current)
-		if owner.IsValid() && owner.Type() == pointer.Type() && owner.Pointer() == pointer.Pointer() {
-			return addr
+	addr, ok := i.owners[val]
+	if !ok || !i.holds(addr, val) {
+		return -1
+	}
+	return addr
+}
+
+// own hints that addr holds val. Only the host boundary records hints: the VM
+// never hands a value it allocated back to itself, so a pointer the host can
+// present has always crossed Alloc, Store, Push, Load, Retain, or Pop first.
+func (i *Interpreter) own(addr int, val types.Value) {
+	if !aliasable(val) {
+		return
+	}
+	// A hint survives only while its slot still holds it, so at most one per
+	// occupied slot is live. Twice that many entries means half are stale, and
+	// pruning then costs one pass per as many insertions as it discards.
+	if len(i.owners) >= max(2*(len(i.heap)-len(i.free)), heapRunway) {
+		i.prune()
+	}
+	i.owners[val] = addr
+}
+
+// prune drops every hint the heap no longer backs, keeping the index
+// proportional to the values the host actually holds without charging hint
+// removal to release and sweep.
+func (i *Interpreter) prune() {
+	for val, addr := range i.owners {
+		if !i.holds(addr, val) {
+			delete(i.owners, val)
 		}
 	}
-	return -1
+}
+
+// holds reports whether addr still stores val. The heap decides ownership, so
+// every hint is confirmed against it before it is trusted or kept.
+func (i *Interpreter) holds(addr int, val types.Value) bool {
+	return i.alive(addr) && i.heap[addr] == val
+}
+
+// aliasable reports whether val is a pointer, the only shape two slots can
+// share. A pointer is stored directly in the interface word and is comparable,
+// so the interface itself keys the index.
+func aliasable(val types.Value) bool {
+	typ := reflect.TypeOf(val)
+	return typ != nil && typ.Kind() == reflect.Pointer
 }
 
 func (i *Interpreter) alive(addr int) bool {
@@ -1977,7 +2036,12 @@ func (i *Interpreter) retains(addr int, n int) {
 	i.rc[addr] += n
 }
 
+// gc collects one cycle. Every pass walks the whole heap, so the recorded slot
+// count is what the collection cost; the two metrics together report collector
+// pressure without a build-time switch.
 func (i *Interpreter) gc() {
+	i.samples.AddMetric("vm_gc_cycles_total", 1)
+	i.samples.AddMetric("vm_gc_slots_total", float64(len(i.heap)))
 	i.scan()
 	i.mark()
 	i.sweep()

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1549,6 +1549,38 @@ func TestInterpreter_Run(t *testing.T) {
 		require.Empty(t, missing)
 	})
 
+	t.Run("releases frame slots on return", func(t *testing.T) {
+		// The callee returns a scalar, so the reference the caller passed in is
+		// discarded with the frame instead of handed back. A teardown that keeps
+		// it leaks one slot per call and exhausts a bounded heap.
+		callee := types.NewFunctionBuilder(&types.FunctionType{
+			Params:  []types.Type{types.TypeRef},
+			Returns: []types.Type{types.TypeI32},
+		}).Emit(instr.New(instr.I32_CONST, 0), instr.New(instr.RETURN)).MustBuild()
+
+		b := program.NewBuilder()
+		fn := b.Const(callee)
+		loop := b.Label()
+		done := b.Label()
+		b.Locals(types.TypeI32)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 0)
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 4*heapRunway).Emit(instr.I32_GE_S).BrIf(done)
+		b.Emit(instr.I32_CONST, 1).Emit(instr.REF_NEW)
+		b.Emit(instr.CONST_GET, uint64(fn)).Emit(instr.CALL).Emit(instr.DROP)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 0)
+		b.Br(loop)
+		b.Bind(done)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		require.NoError(t, program.Verify(prog))
+
+		i := New(prog, WithHeapLimit(heapRunway))
+		defer i.Close()
+
+		require.NoError(t, i.Run(context.Background()))
+	})
+
 	for _, tt := range []struct {
 		name        string
 		typ         types.Type
@@ -3844,6 +3876,37 @@ func TestInterpreter_Alloc(t *testing.T) {
 		require.NoError(t, err)
 		require.Same(t, value, loaded)
 		require.Equal(t, 0, value.closed)
+	})
+
+	t.Run("rejects pointer read back out of the heap", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		addr, err := i.Alloc(&trackedValue{})
+		require.NoError(t, err)
+		for range 4 * heapRunway {
+			_, err := i.Alloc(&trackedValue{})
+			require.NoError(t, err)
+		}
+
+		loaded, err := i.Load(addr)
+		require.NoError(t, err)
+		_, err = i.Alloc(loaded)
+		require.ErrorIs(t, err, ErrTypeMismatch)
+	})
+
+	t.Run("accepts pointer whose slot was released", func(t *testing.T) {
+		i := New(program.New(nil))
+		defer i.Close()
+
+		value := &trackedValue{}
+		addr, err := i.Alloc(value)
+		require.NoError(t, err)
+		require.NoError(t, i.Release(addr))
+
+		reused, err := i.Alloc(value)
+		require.NoError(t, err)
+		require.NotEqual(t, 0, reused)
 	})
 }
 

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -292,6 +292,19 @@ var (
 		},
 		instr.RETURN: func(c *threader) func(i *Interpreter) {
 			c.ip++
+			// A frame whose every slot is a plain scalar can only be holding
+			// scalars when its operand stack is balanced, so the release sweep
+			// is skipped for it. The kinds that can carry a ref are the same ones
+			// LOCAL_GET retains for.
+			slots := len(c.locals)
+			owned := false
+			for _, kind := range c.locals {
+				switch kind.Repr() {
+				case types.KindI32, types.KindF32, types.KindF64:
+				default:
+					owned = true
+				}
+			}
 			return func(i *Interpreter) {
 				if i.fp == 1 {
 					panic(ErrFrameUnderflow)
@@ -308,11 +321,14 @@ var (
 							panic(ErrTypeMismatch)
 						}
 						if f.returns > 0 {
-							for _, value := range i.stack[i.sp-f.returns : i.sp-1] {
+							for _, value := range i.stack[f.bp : i.sp-1] {
 								i.releaseBox(value)
 							}
 							co.value = i.stack[i.sp-1]
 						} else {
+							for _, value := range i.stack[f.bp:i.sp] {
+								i.releaseBox(value)
+							}
 							i.retain(0)
 							co.value = types.BoxedNull
 						}
@@ -333,6 +349,15 @@ var (
 						i.stack[bp] = types.BoxRef(coAddr)
 						i.sp = bp + 1
 						return
+					}
+					// A frame owns its params, locals, and any operands left below the
+					// returned values; only the returns pass to the caller, so everything
+					// under them is released here. land does the same when an exception
+					// unwinds the frame, and the cycle collector needs counts to be exact.
+					if owned || i.sp != f.bp+slots+f.returns {
+						for _, value := range i.stack[f.bp : i.sp-f.returns] {
+							i.releaseBox(value)
+						}
 					}
 					switch f.returns {
 					case 0:
@@ -549,11 +574,14 @@ var (
 								panic(ErrTypeMismatch)
 							}
 							if f.returns > 0 {
-								for _, value := range i.stack[i.sp-f.returns : i.sp-1] {
+								for _, value := range i.stack[f.bp : i.sp-1] {
 									i.releaseBox(value)
 								}
 								co.value = i.stack[i.sp-1]
 							} else {
+								for _, value := range i.stack[f.bp:i.sp] {
+									i.releaseBox(value)
+								}
 								i.retain(0)
 								co.value = types.BoxedNull
 							}
@@ -574,6 +602,13 @@ var (
 							i.stack[bp] = types.BoxRef(coAddr)
 							i.sp = bp + 1
 							return
+						}
+						// A frame owns its params, locals, and any operands left below the
+						// returned values; only the returns pass to the caller, so everything
+						// under them is released here. land does the same when an exception
+						// unwinds the frame, and the cycle collector needs counts to be exact.
+						for _, value := range i.stack[f.bp : i.sp-f.returns] {
+							i.releaseBox(value)
 						}
 						switch f.returns {
 						case 0:
@@ -39217,11 +39252,14 @@ var (
 									panic(ErrTypeMismatch)
 								}
 								if f.returns > 0 {
-									for _, value := range i.stack[i.sp-f.returns : i.sp-1] {
+									for _, value := range i.stack[f.bp : i.sp-1] {
 										i.releaseBox(value)
 									}
 									co.value = i.stack[i.sp-1]
 								} else {
+									for _, value := range i.stack[f.bp:i.sp] {
+										i.releaseBox(value)
+									}
 									i.retain(0)
 									co.value = types.BoxedNull
 								}
@@ -39242,6 +39280,13 @@ var (
 								i.stack[bp] = types.BoxRef(coAddr)
 								i.sp = bp + 1
 								return
+							}
+							// A frame owns its params, locals, and any operands left below the
+							// returned values; only the returns pass to the caller, so everything
+							// under them is released here. land does the same when an exception
+							// unwinds the frame, and the cycle collector needs counts to be exact.
+							for _, value := range i.stack[f.bp : i.sp-f.returns] {
+								i.releaseBox(value)
 							}
 							switch f.returns {
 							case 0:

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -308,6 +308,9 @@ func (t *tracer) clone(i *Interpreter) Interpreter {
 	out.work = nil
 	out.refbuf = nil
 	out.interned = map[string]types.Ref{}
+	// Capture never serves a host ownership query, and every allocating opcode
+	// is unrecordable, so the clone only needs a writable index of its own.
+	out.owners = map[types.Value]int{}
 	for idx := 0; idx < out.fp; idx++ {
 		addr := out.frames[idx].addr
 		if addr >= 0 && addr < len(out.code) {


### PR DESCRIPTION
Two defects landed together with the heap-ownership rework and made
allocation-heavy guest programs regress badly (#169, #170).

owner() answered "is this pointer already in a heap slot?" by scanning
every live slot with reflect.ValueOf().Pointer(). It runs on Alloc,
Store, and Push, so an embedder that allocates once per guest operation
paid O(heap) per allocation and ran quadratically: a fannkuch-redux
program that took 6.1s stopped finishing inside 45s. Replace the scan
with an index keyed by the value itself. Only the host boundary records
hints, so the interpreter's own allocation path is untouched, and lookup
validates against the heap, so a hint left by a freed or reused slot
self-heals instead of needing removal bookkeeping on release and sweep.
A prune pass bounds the index and doubles the budget it survives, which
keeps upkeep amortized constant.

RETURN moved the returned values down and truncated the stack without
releasing the params, locals, and operands it discarded, so every call
that received a reference leaked one count. land already releases those
slots when an exception unwinds a frame; RETURN now does the same.
Reference counting had leaked this way before, but the old root-based
mark and sweep reclaimed it; trial deletion reads an inflated count as
ownership outside the heap and cannot, so the leak became unbounded.
Frames whose every slot is a plain scalar skip the sweep when their
operand stack is balanced, which keeps scalar recursion close to its
former cost.

Measured with the reporter's program corpus on linux/amd64 (min of
three): fannkuch 6.9s where it previously did not finish, binarytrees
1.60s against 1.80s before the regression window, and the unrelated
kernels unchanged. RecursiveFib(20)/threaded costs 604 -> 625 ns/op for
the exact counts.

Adds vm_gc_cycles_total and vm_gc_slots_total so collector pressure is
observable, a heap-exhaustion regression test that fails without the
RETURN fix, and two builder-based benchmarks covering the reported
shapes with no external dependency.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017ZsuY2FrrwQ7S3PGw98RQh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory-management performance for recursive workloads and host-integrated operations.
  * Reduced unnecessary cleanup work during routine execution and returns.

* **Bug Fixes**
  * Improved frame cleanup to prevent retained references from exhausting available memory.
  * Strengthened pointer ownership handling and garbage-collection reliability.

* **Documentation**
  * Added guidance for heap ownership, return-value memory behavior, and garbage-collection metrics.
  * Expanded benchmark coverage and documented new memory-related results.

* **Monitoring**
  * Added metrics for total garbage-collection cycles and processed heap slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->