### PR TITLE
fix(interp): repair tail-call and native store ownership

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -140,12 +140,13 @@ Each `Interpreter` is single-goroutine-owned during use. `Pool` lets multiple go
 - Heap indices are stable and must not move.
 - Values that contain refs must implement `types.Traceable`.
 - Large `i64` values may spill to the heap while preserving bytecode semantics.
+- Heap index 0 is a permanent null sentinel and is never reclaimed.
 
 See `memory-model.md` and `value-representation.md` for the detailed rules.
 
 ### Frames
 
-A frame separates the function/template address from the callable reference.
+A frame separates the function/template address from the callable reference. `RETURN_CALL` replaces an activation only after the replacement owns forwarded arguments and the retiring activation has released all of its owned ref slots. JIT frame ownership is independent of register caching; uncached ref locals are still released from their VM stack slots.
 
 | Field | Meaning |
 |---|---|

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -41,9 +41,10 @@ The VM core uses only the Go standard library. The CLI and tests use small exter
 
 On non-ARM64 platforms, only the threaded interpreter and optimizer are active.
 ARM64 mutation lowering uses the same guarded fresh-register store path for
-primitive and ref `ARRAY_SET`/`STRUCT_SET` operations; when the no-spill
-register budget is exceeded, native compilation falls back to threaded
-execution.
+primitive and ref `ARRAY_SET`/`STRUCT_SET` operations. Primitive stores can
+continue tracing; ref `ARRAY_SET` and ref-field `STRUCT_SET` report a terminal
+status. When the no-spill register budget is exceeded, native compilation
+falls back to threaded execution.
 
 JIT stubs compile cleanly but do not emit native code. `asm/amd64` is currently a placeholder: it preserves the generic `asm.Arch` shape, but its encoder and ABI return `asm.ErrNotImplemented`.
 

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,6 +40,10 @@ The VM core uses only the Go standard library. The CLI and tests use small exter
 | Linux / x86-64 | ✅ | ✅ | — |
 
 On non-ARM64 platforms, only the threaded interpreter and optimizer are active.
+ARM64 mutation lowering uses the same guarded fresh-register store path for
+primitive and ref `ARRAY_SET`/`STRUCT_SET` operations; when the no-spill
+register budget is exceeded, native compilation falls back to threaded
+execution.
 
 JIT stubs compile cleanly but do not emit native code. `asm/amd64` is currently a placeholder: it preserves the generic `asm.Arch` shape, but its encoder and ABI return `asm.ErrNotImplemented`.
 

--- a/docs/instruction-set.md
+++ b/docs/instruction-set.md
@@ -260,7 +260,7 @@ Do not group multiple opcodes in one row. Keep this table in opcode-value order 
 | Arrays | `ARRAY_NEW_DEFAULT` | `array.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Arrays | `ARRAY_LEN` | `array.len` | ✅ | 🔲 | native typed-array length fast path |
 | Arrays | `ARRAY_GET` | `array.get` | ✅ | 🔲 | native typed-array get fast path |
-| Arrays | `ARRAY_SET` | `array.set` | ◐ | 🔲 | primitive typed arrays may continue; boxed/ref writes stay terminal |
+| Arrays | `ARRAY_SET` | `array.set` | ◐ | 🔲 | guarded native store when the no-spill budget permits; ref stores remain terminal |
 | Arrays | `ARRAY_FILL` | `array.fill` | ◐ | 🔲 | terminal deopt boundary; trace prefix stays native |
 | Arrays | `ARRAY_COPY` | `array.copy` | ◐ | 🔲 | terminal deopt boundary; trace prefix stays native |
 | Arrays | `ARRAY_APPEND` | `array.append` | ◐ | 🔲 | terminal deopt boundary; trace prefix stays native |
@@ -269,7 +269,7 @@ Do not group multiple opcodes in one row. Keep this table in opcode-value order 
 | Structs | `STRUCT_NEW` | `struct.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Structs | `STRUCT_NEW_DEFAULT` | `struct.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Structs | `STRUCT_GET` | `struct.get` | ✅ | 🔲 | native field get fast path; static plans resolve constant field indexes |
-| Structs | `STRUCT_SET` | `struct.set` | ◐ | 🔲 | scalar fields may continue; ref-field writes stay terminal |
+| Structs | `STRUCT_SET` | `struct.set` | ◐ | 🔲 | guarded native store when the no-spill budget permits; ref-field writes remain terminal |
 | Maps | `MAP_NEW` | `map.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Maps | `MAP_NEW_DEFAULT` | `map.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Maps | `MAP_LEN` | `map.len` | ◐ | 🔲 | terminal fallback |
@@ -291,7 +291,7 @@ Do not group multiple opcodes in one row. Keep this table in opcode-value order 
 
 ### Control
 
-Branch offsets are relative to the end of the branch instruction. `RETURN_CALL` is the tail-call primitive. Function bodies must end with `RETURN`, `RETURN_CALL`, or `UNREACHABLE`; top-level code may fall through.
+Branch offsets are relative to the end of the branch instruction. `RETURN_CALL` is the tail-call primitive. Function bodies must end with `RETURN`, `RETURN_CALL`, or `UNREACHABLE`; top-level code may fall through. Tail replacement transfers ownership to the new activation and releases the retiring activation's owned slots exactly once.
 
 ### References
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -312,9 +312,9 @@ Native calls are frame-aware. The lowering checks frame budget, increments nativ
 
 On deoptimization, native frames append enough journal records for Go to rebuild the VM call chain.
 
-`RETURN` closes a function entry trace only when it returns from the outer recorded frame. Inlined callee returns stitch values back into the caller's symbolic stack. `RETURN_CALL` tail-loop and tail-morph paths replace the current activation only after the replacement owns forwarded arguments and the retiring activation has released every owned ref local.
+`RETURN` closes a function entry trace only when it returns from the outer recorded frame. Inlined callee returns stitch values back into the caller's symbolic stack. `RETURN_CALL` tail-loop and tail-morph paths first preflight the retiring activation, then own forwarded arguments and release the retiring frame.
 
-Native frame teardown mirrors threaded ownership: `stitch` and `ret` first preserve returned refs that still point into the retiring frame, then `releaseFrame` drops each owned ref local through the normal refcount guard before the frame is removed. Frame cleanup preflights all ref locals before emitting the release sequence; a zero-or-one refcount deoptimizes instead of freeing an object natively.
+Native frame teardown mirrors threaded ownership: `stitch` and `ret` first guard the retiring refs, then preserve returned refs that still point into the frame, and finally `releaseFrame` drops the owned refs before the frame is removed. The guard counts duplicate addresses together; native teardown deoptimizes when any address cannot cover all pending releases, so native code never decrements an object to zero without the interpreter's reclaim path.
 
 Top-level module code has no synthetic `RETURN`. Falling off the end closes the module trace and writes live operands back to the VM stack.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -312,7 +312,7 @@ Native calls are frame-aware. The lowering checks frame budget, increments nativ
 
 On deoptimization, native frames append enough journal records for Go to rebuild the VM call chain.
 
-`RETURN` closes a function entry trace only when it returns from the outer recorded frame. Inlined callee returns stitch values back into the caller's symbolic stack.
+`RETURN` closes a function entry trace only when it returns from the outer recorded frame. Inlined callee returns stitch values back into the caller's symbolic stack. `RETURN_CALL` tail-loop and tail-morph paths replace the current activation only after the replacement owns forwarded arguments and the retiring activation has released every owned ref local.
 
 Native frame teardown mirrors threaded ownership: `stitch` and `ret` first preserve returned refs that still point into the retiring frame, then `releaseFrameRefs` drops each owned ref local through the normal refcount guard before the frame is removed. Frame cleanup preflights all ref locals before emitting the release sequence; a zero-or-one refcount deoptimizes instead of freeing an object natively.
 
@@ -454,7 +454,7 @@ A committing (loop back-edge) flush rejects any live deferred ref: owning it wou
 
 ARM64 supports selected heap fast paths.
 
-Native full-trace reads include observed shapes for scalar `REF_GET`, selected `ARRAY_LEN`, selected `ARRAY_GET`, selected `STRUCT_GET`, `ERROR_GET`, `CORO_DONE`, and `CORO_VALUE`. `ARRAY_SET` is native only for compile-time constant typed-array containers; other containers deopt to the threaded handler.
+Native full-trace reads include observed shapes for scalar `REF_GET`, selected `ARRAY_LEN`, selected `ARRAY_GET`, selected `STRUCT_GET`, `ERROR_GET`, `CORO_DONE`, and `CORO_VALUE`. `ARRAY_SET` and `STRUCT_SET` use the guarded fresh-register heap path for both primitive and ref stores; the former compile-time-constant-container restriction is removed.
 
 Heap reads guard ref address, heap itab, array element kind, struct type pointer, struct field kind, index bounds, and release safety when needed.
 
@@ -462,11 +462,11 @@ Ref reads retain the loaded element or payload. A container consumer releases it
 
 Heap-promoted `i64` values fall back before boxing.
 
-A primitive typed-array `ARRAY_SET` may continue through native execution only for a compile-time constant container. A scalar-field `STRUCT_SET` may continue in the anchor frame before any inlined call. Lowering materializes the smallest resumable state needed by each mutation; guard failure resumes at the original opcode, while success performs the scalar store and continues to later operations or the loop back-edge.
+Primitive typed-array `ARRAY_SET` and scalar-field `STRUCT_SET` may continue through native execution when their guarded heap path fits the no-spill register budget. Guard failure resumes at the original opcode; success performs the store and continues to later operations or the loop back-edge.
 
-Ref-element `ARRAY_SET` and ref-field `STRUCT_SET` remain terminal mutations. Before the store, lowering owns a deferred element or field value so the transferred container edge carries exactly one retain, matching threaded execution. Their hot path may perform the store and resume threaded execution at the next instruction, while recursive release or any failed guard remains interpreter-owned.
+Ref-element `ARRAY_SET` and ref-field `STRUCT_SET` are terminal mutations. Before the store, lowering owns a deferred element or field value so the transferred container edge carries exactly one retain, matching threaded execution. A replaced `BoxedNull` field/element has no heap ownership and is not released.
 
-Mutation plans are always no-spill. Leaf traces reuse pinned and dead registers for stack homes, heap cells, refcounts, and boxing scratch so primitive mutation loops fit the physical register bank. A mutation after inlined calls retains the terminal boundary; register exhaustion still rejects compilation cleanly instead of spilling across a back-edge (regression test: `interp.TestARM64_ArraySetAfterNestedCalls`).
+Mutation plans are always no-spill. Stores use the common fresh-register heap path; if the physical register budget is exhausted, `asm.Build` rejects native compilation with `CompileReasonRegisterPressure` and threaded execution remains installed. Native compilation must never spill a store path across a back-edge.
 
 Allocation and complex ref-bearing mutations stay threaded or terminate the native trace.
 

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -228,7 +228,7 @@ Linear spill state is unsafe across a loop back-edge, and mutation blocks can co
 - `asm/rewriter.go` rejects spilling for code containing an intra-code backward branch.
 - `noSpill` scans every step in the completed plan, including learned continuations, and forbids spilling whenever `ARRAY_SET` or `STRUCT_SET` is present.
 
-When a plan forbids spilling, the compiler wraps the target architecture in `noSpillArch`. Its `Frame()` returns `nil` according to the assembler contract, so register exhaustion rejects native compilation cleanly and threaded dispatch remains installed. Continuable primitive array stores therefore lower through an explicit state barrier and reuse dead registers rather than depending on spill slots.
+When a plan forbids spilling, the compiler wraps the target architecture in `noSpillArch`. Its `Frame()` returns `nil` according to the assembler contract, so register exhaustion rejects native compilation cleanly and threaded dispatch remains installed. `ARRAY_SET` and `STRUCT_SET` use the common fresh-register heap path rather than a store-specific register-recycling path.
 
 Native code does not marshal parameters or returns. It writes results and trap state into the journal, and the Go wrapper restores interpreter state from there.
 
@@ -306,7 +306,7 @@ A call may lower to native `BL` when the observed target is a JIT-eligible `*typ
 
 Unsupported targets fall back, including host calls, allocation, maps, unsupported functions, unsupported closures, and heap mutations outside the selected guarded fast paths.
 
-Static plans recognize direct `CONST_GET function; CALL` pairs. Each interpreter owns a fixed-size `natives` slot array; installing or synchronizing a function entry publishes its executable address atomically. The caller loads the slot at runtime and uses `BLR`, so compile order does not matter: a null slot falls back at the CALL, while a later callee installation is visible without recompiling the caller. Self-recursion remains on the established trace self-call path, and `RETURN_CALL` remains threaded.
+Static plans recognize direct `CONST_GET function; CALL` pairs. Each interpreter owns a fixed-size `natives` slot array; installing or synchronizing a function entry publishes its executable address atomically. The caller loads the slot at runtime and uses `BLR`, so compile order does not matter: a null slot falls back at the CALL, while a later callee installation is visible without recompiling the caller. Self-recursion remains on the established trace self-call path; supported `RETURN_CALL` paths use native tail-loop or tail-morph lowering.
 
 Native calls are frame-aware. The lowering checks frame budget, increments native depth, saves caller state, enters the callee trace, and restores caller state on return.
 
@@ -314,7 +314,7 @@ On deoptimization, native frames append enough journal records for Go to rebuild
 
 `RETURN` closes a function entry trace only when it returns from the outer recorded frame. Inlined callee returns stitch values back into the caller's symbolic stack. `RETURN_CALL` tail-loop and tail-morph paths replace the current activation only after the replacement owns forwarded arguments and the retiring activation has released every owned ref local.
 
-Native frame teardown mirrors threaded ownership: `stitch` and `ret` first preserve returned refs that still point into the retiring frame, then `releaseFrameRefs` drops each owned ref local through the normal refcount guard before the frame is removed. Frame cleanup preflights all ref locals before emitting the release sequence; a zero-or-one refcount deoptimizes instead of freeing an object natively.
+Native frame teardown mirrors threaded ownership: `stitch` and `ret` first preserve returned refs that still point into the retiring frame, then `releaseFrame` drops each owned ref local through the normal refcount guard before the frame is removed. Frame cleanup preflights all ref locals before emitting the release sequence; a zero-or-one refcount deoptimizes instead of freeing an object natively.
 
 Top-level module code has no synthetic `RETURN`. Falling off the end closes the module trace and writes live operands back to the VM stack.
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -199,6 +199,7 @@ Rules:
 
 - never free it
 - never put it in `free`
+- releasing `BoxedNull` is a no-op
 - `BoxedNull` is `BoxRef(0)`
 
 ### Only refs use RC
@@ -207,13 +208,25 @@ Primitive boxed values do not participate in reference counting. Only `KindRef` 
 
 ### RC must be exact and symmetric
 
-Every ownership edge contributes exactly one count. Every retained ref must be
-released exactly once. Missing counts can collect a value too early; excess
-counts can turn unreachable garbage into a false external root.
+Every ownership edge contributes exactly one count. Every retained non-null ref must be
+released exactly once. `BoxedNull` is the permanent null sentinel and carries no
+heap ownership, so releasing it must not decrement or reclaim heap index 0. Missing
+counts can collect a value too early; excess counts can turn unreachable garbage
+into a false external root.
 
 ### Heap indices are stable
 
 Do not keep addresses into the heap slice across any operation that may allocate. Keep integer heap indexes instead.
+
+### Tail-call frame replacement
+
+`RETURN_CALL` replaces the retiring activation. Forwarded arguments are a separate
+ownership set: the replacement activation owns them before the retiring frame releases
+its slots. The retiring slot sweep excludes those forwarded arguments.
+
+Register caching does not define ownership. A ref local remains owned until frame
+retirement even when it has no cached native register; the JIT materializes its boxed
+value from the VM stack when necessary.
 
 ### Ref ownership must be explicit
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -220,9 +220,10 @@ Do not keep addresses into the heap slice across any operation that may allocate
 
 ### Tail-call frame replacement
 
-`RETURN_CALL` replaces the retiring activation. Forwarded arguments are a separate
-ownership set: the replacement activation owns them before the retiring frame releases
-its slots. The retiring slot sweep excludes those forwarded arguments.
+`RETURN_CALL` replaces the retiring activation. The retiring frame is first checked for
+a safe native release; only then does the replacement activation own forwarded arguments
+and the retiring frame release its slots. The retiring slot sweep excludes those
+forwarded arguments.
 
 Register caching does not define ownership. A ref local remains owned until frame
 retirement even when it has no cached native register; the JIT materializes its boxed

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -1494,6 +1494,12 @@ func replace(callee target, targetSlots int, releaseTarget bool, advance int, la
 			jen.Id("f").Op("=").Id("i").Dot("fr"),
 			jen.Id("base").Op("=").Id("f").Dot("bp"),
 			jen.If(jen.Id("base").Op("+").Id("params").Op("+").Id("locals").Op(">").Len(jen.Id("i").Dot("stack"))).Block(jen.Panic(jen.Id("ErrStackOverflow"))),
+			jen.For(jen.List(jen.Id("_"), jen.Id("value")).Op(":=").Range().Id("i").Dot("stack").Index(
+				jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp").Op("-").Id("params").Op("-").Lit(1),
+			)).Block(
+				jen.If(jen.Id("value").Dot("Kind").Call().Op("!=").Qual("github.com/siyul-park/minivm/types", "KindRef")).Block(jen.Continue()),
+				jen.Id("i").Dot("release").Call(jen.Id("value").Dot("Ref").Call()),
+			),
 			jen.Copy(jen.Id("i").Dot("stack").Index(jen.Id("base").Op(":").Id("base").Op("+").Id("params")), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Id("params").Op("-").Lit(1).Op(":").Id("i").Dot("sp").Op("-").Lit(1))),
 			jen.If(jen.Id("f").Dot("release")).Block(jen.Id("i").Dot("release").Call(jen.Id("f").Dot("ref"))),
 			jen.If(jen.Id("locals").Op(">").Lit(0)).Block(clearRange(jen.Id("base").Op("+").Id("params"), jen.Id("base").Op("+").Id("params").Op("+").Id("locals"))),
@@ -1537,6 +1543,12 @@ func replace(callee target, targetSlots int, releaseTarget bool, advance int, la
 		jen.Id("f").Op(":=").Id("i").Dot("fr"),
 		jen.Id("base").Op(":=").Id("f").Dot("bp"),
 		jen.If(jen.Id("base").Op("+").Id("params").Op("+").Id("locals").Op(">").Len(jen.Id("i").Dot("stack"))).Block(jen.Panic(jen.Id("ErrStackOverflow"))),
+		jen.For(jen.List(jen.Id("_"), jen.Id("value")).Op(":=").Range().Id("i").Dot("stack").Index(
+			jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp").Op("-").Id("params"),
+		)).Block(
+			jen.If(jen.Id("value").Dot("Kind").Call().Op("!=").Qual("github.com/siyul-park/minivm/types", "KindRef")).Block(jen.Continue()),
+			jen.Id("i").Dot("release").Call(jen.Id("value").Dot("Ref").Call()),
+		),
 		jen.Copy(jen.Id("i").Dot("stack").Index(jen.Id("base").Op(":").Id("base").Op("+").Id("params")), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Id("params").Op(":").Id("i").Dot("sp"))),
 		jen.If(jen.Id("f").Dot("release")).Block(jen.Id("i").Dot("release").Call(jen.Id("f").Dot("ref"))),
 		jen.If(jen.Id("locals").Op(">").Lit(0)).Block(clearRange(jen.Id("base").Op("+").Id("params"), jen.Id("base").Op("+").Id("params").Op("+").Id("locals"))),

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -1498,7 +1498,7 @@ func replace(callee target, targetSlots int, releaseTarget bool, advance int, la
 				jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp").Op("-").Id("params").Op("-").Lit(1),
 			)).Block(
 				jen.If(jen.Id("value").Dot("Kind").Call().Op("!=").Qual("github.com/siyul-park/minivm/types", "KindRef")).Block(jen.Continue()),
-				jen.Id("i").Dot("release").Call(jen.Id("value").Dot("Ref").Call()),
+				jen.Id("i").Dot("releaseBox").Call(jen.Id("value")),
 			),
 			jen.Copy(jen.Id("i").Dot("stack").Index(jen.Id("base").Op(":").Id("base").Op("+").Id("params")), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Id("params").Op("-").Lit(1).Op(":").Id("i").Dot("sp").Op("-").Lit(1))),
 			jen.If(jen.Id("f").Dot("release")).Block(jen.Id("i").Dot("release").Call(jen.Id("f").Dot("ref"))),
@@ -1547,7 +1547,7 @@ func replace(callee target, targetSlots int, releaseTarget bool, advance int, la
 			jen.Id("f").Dot("bp").Op(":").Id("i").Dot("sp").Op("-").Id("params"),
 		)).Block(
 			jen.If(jen.Id("value").Dot("Kind").Call().Op("!=").Qual("github.com/siyul-park/minivm/types", "KindRef")).Block(jen.Continue()),
-			jen.Id("i").Dot("release").Call(jen.Id("value").Dot("Ref").Call()),
+			jen.Id("i").Dot("releaseBox").Call(jen.Id("value")),
 		),
 		jen.Copy(jen.Id("i").Dot("stack").Index(jen.Id("base").Op(":").Id("base").Op("+").Id("params")), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Id("params").Op(":").Id("i").Dot("sp"))),
 		jen.If(jen.Id("f").Dot("release")).Block(jen.Id("i").Dot("release").Call(jen.Id("f").Dot("ref"))),

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -2127,7 +2127,7 @@ func (i *Interpreter) retainBox(v types.Boxed) {
 }
 
 func (i *Interpreter) releaseBox(v types.Boxed) {
-	if v.Kind() == types.KindRef {
+	if v.Kind() == types.KindRef && v.Ref() != 0 {
 		i.release(v.Ref())
 	}
 }

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -6769,7 +6769,7 @@ func TestWithThreshold(t *testing.T) {
 			Returns(types.TypeI32)
 		// Store the same host-pushed local into index 0 twice in a row: the
 		// second ARRAY_SET observes old==val (both reads of LOCAL_GET 1 name
-		// the same ref), exercising releaseBoxUnlessEqual's aliased-store path
+		// the same ref), exercising releaseBoxExcept's aliased-store path
 		// natively within a single call. Read the slot back through ARRAY_GET
 		// and STRING_LEN (rather than inspecting the interpreter's heap table
 		// directly) so the check only relies on legitimate VM operations —

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -6895,7 +6895,7 @@ func TestWithThreshold(t *testing.T) {
 		for _, hit := range tree.hits {
 			hits += hit
 		}
-		require.Equal(t, int64(0), hits)
+		require.Greater(t, hits, int64(0))
 	})
 
 	t.Run("deopts after i64 array get with stack shape intact", func(t *testing.T) {
@@ -7027,7 +7027,7 @@ func TestWithThreshold(t *testing.T) {
 		for _, hit := range tree.hits {
 			hits += hit
 		}
-		require.Equal(t, int64(0), hits)
+		require.Greater(t, hits, int64(0))
 	})
 
 	t.Run("jits learned callee branch through caller tail", func(t *testing.T) {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -75,10 +75,7 @@ type lowering struct {
 	kind       entryKind
 	leaf       bool
 	nativeLoop bool
-
-	reuseLocals bool
-	spare       asm.VReg
-	carried     []carriedLocal
+	carried    []carriedLocal
 
 	// hoist caches one loop-invariant container's slice header, derived by a
 	// per-entry prologue (see arm64Lowerer.hoist). The registers are pure

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -964,16 +964,15 @@ func (l arm64Lowerer) globalSet(ctx *lowering, op step, pop bool) bool {
 		return false
 	}
 	vp := &ctx.values[len(ctx.values)-1]
-	if vp.kind != kind || !vp.raw {
-		if vp.kind != types.KindRef || kind != types.KindRef {
+	if kind == types.KindRef {
+		if vp.kind != types.KindRef {
 			return false
 		}
+	} else if vp.kind != kind || !vp.raw {
+		return false
 	}
 	var boxed asm.VReg
-	deferred := false
-	if kind == types.KindRef {
-		deferred = vp.backing != backingStack
-	}
+	deferred := kind == types.KindRef && vp.backing != backingStack
 	boxed, ok = l.box(ctx, *vp)
 	if !ok {
 		return false
@@ -983,23 +982,19 @@ func (l arm64Lowerer) globalSet(ctx *lowering, op step, pop bool) bool {
 		pre := ctx.pre()
 		old := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(old, base, int16(idx*8)))
-		if kind == types.KindRef {
-			if pop && deferred {
-				l.releaseBox(ctx, old, pre, op.ip)
-			} else {
-				l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
-			}
+		if pop && deferred {
+			l.releaseBox(ctx, old, pre, op.ip)
+		} else {
+			l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
 		}
-		if kind == types.KindRef {
-			if _, ok := l.own(ctx, vp); !ok {
-				return false
-			}
-			if !l.detach(ctx, backingGlobal, idx) {
-				return false
-			}
-			if !pop {
-				l.retainBoxExcept(ctx, old, boxed)
-			}
+		if _, ok := l.own(ctx, vp); !ok {
+			return false
+		}
+		if !l.detach(ctx, backingGlobal, idx) {
+			return false
+		}
+		if !pop {
+			l.retainBoxExcept(ctx, old, boxed)
 		}
 	}
 	ctx.assembler.Emit(arm64.STR(boxed, base, int16(idx*8)))
@@ -3001,18 +2996,16 @@ func (l arm64Lowerer) upvalSet(ctx *lowering, op step) bool {
 		pre := ctx.pre()
 		old := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(old, base, int16(idx*8)))
-		if kind == types.KindRef && deferred {
+		if deferred {
 			l.releaseBox(ctx, old, pre, op.ip)
-		} else if kind == types.KindRef {
+		} else {
 			l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
 		}
-		if kind == types.KindRef {
-			if _, ok := l.own(ctx, vp); !ok {
-				return false
-			}
-			if !l.detach(ctx, backingUpval, idx) {
-				return false
-			}
+		if _, ok := l.own(ctx, vp); !ok {
+			return false
+		}
+		if !l.detach(ctx, backingUpval, idx) {
+			return false
 		}
 	}
 	ctx.assembler.Emit(arm64.STR(boxed, base, int16(idx*8)))

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -900,9 +900,9 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 		// it keeps the stack copy alongside the slot; the retain runs only on the
 		// non-deopt path, so a re-run in the interpreter cannot double-apply it.
 		// SET transfers the stack's reference and skips the retain.
-		l.releaseBoxUnlessEqual(ctx, old, boxed, pre, op.ip)
+		l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
 		if !pop {
-			l.retainBoxUnlessEqual(ctx, old, boxed)
+			l.retainBoxExcept(ctx, old, boxed)
 		}
 		ctx.assembler.Emit(arm64.STR(boxed, addr, int16((f.base+idx)*8)))
 		f.locals[idx] = value{reg: boxed, kind: types.KindRef}
@@ -999,9 +999,9 @@ func (l arm64Lowerer) globalSet(ctx *lowering, op step, pop bool) bool {
 		// it keeps the stack copy alongside the slot; the retain runs only on the
 		// non-deopt path, so a re-run in the interpreter cannot double-apply it.
 		// SET transfers the stack's reference and skips the retain.
-		l.releaseBoxUnlessEqual(ctx, old, boxed, pre, op.ip)
+		l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
 		if !pop {
-			l.retainBoxUnlessEqual(ctx, old, boxed)
+			l.retainBoxExcept(ctx, old, boxed)
 		}
 	}
 	ctx.assembler.Emit(arm64.STR(boxed, base, int16(idx*8)))
@@ -1199,7 +1199,7 @@ func (l arm64Lowerer) arrayGetKnown(ctx *lowering, op step) bool {
 		return false
 	}
 
-	pre := append([]value(nil), ctx.values...)
+	pre := ctx.pre()
 	if !l.flush(ctx, flushSnapshot) {
 		return false
 	}
@@ -1441,7 +1441,7 @@ func (l arm64Lowerer) directCall(ctx *lowering, op step) bool {
 	a.Bind(ready)
 
 	marker := ctx.pop()
-	if marker.fn != op.callee || ctx.count() < params || !l.args(ctx, target, params) {
+	if marker.fn != op.callee || ctx.count() < params || !l.checkArgs(ctx, target, params) {
 		return false
 	}
 	// A real BLR hands this caller's flushed operand stack to the interpreter
@@ -2326,7 +2326,7 @@ func (l arm64Lowerer) call(ctx *lowering, op step) bool {
 		closureRef = 0
 	}
 	ctx.pop()
-	if ctx.count() < params || !l.args(ctx, target, params) {
+	if ctx.count() < params || !l.checkArgs(ctx, target, params) {
 		return false
 	}
 	if op.callee == ctx.addr {
@@ -2518,16 +2518,16 @@ func (l arm64Lowerer) tailLoop(ctx *lowering, op step) bool {
 	// A tail call stands in return position: no operands survive besides the
 	// arguments just consumed. The anchor frame has opBase 0, so ctx.count() == 0
 	// means ctx.values is empty here and no deferred operand needs owning; the
-	// arguments are owned into the new frame by locals() below.
+	// arguments are owned into the new frame by initLocals() below.
 	if ctx.count() != 0 {
 		return false
 	}
 	old := ctx.frame()
 	f := newActivation(ctx.addr, target, 0, 0)
-	if !l.locals(ctx, &f, args) {
+	if !l.initLocals(ctx, &f, args) {
 		return false
 	}
-	if !l.releaseFrameRefs(ctx, old, op.ip) {
+	if !l.releaseFrame(ctx, old, op.ip) {
 		return false
 	}
 	ctx.frames = append(ctx.frames[:0], f)
@@ -2557,17 +2557,16 @@ func (l arm64Lowerer) tailMorph(ctx *lowering, op step) bool {
 	if ctx.count() != 0 {
 		return false
 	}
-	// Only the innermost frame is replaced in place. Its own operands are gone
-	// (count() == 0), and any surviving operand belongs to an outer frame below
-	// this base: a backingLocal slot there is < base by construction, and an
-	// backingUpval names a closure that does not die in this morph, so no sweep is
-	// needed. The arguments are owned into the new frame by locals() below.
+	// The innermost activation is retired in place. Its operands are gone
+	// (count() == 0); outer-frame operands are outside this activation's local
+	// ownership. initLocals() first acquires any argument ownership that the new
+	// frame needs, then releaseFrame drops the retiring activation.
 	f := newActivation(op.callee, target, base, len(ctx.values))
 	f.resume = op.ip + 1
-	if !l.locals(ctx, &f, args) {
+	if !l.initLocals(ctx, &f, args) {
 		return false
 	}
-	if !l.releaseFrameRefs(ctx, old, op.ip) {
+	if !l.releaseFrame(ctx, old, op.ip) {
 		return false
 	}
 	ctx.frames[len(ctx.frames)-1] = f
@@ -2622,15 +2621,14 @@ func (l arm64Lowerer) tailTarget(ctx *lowering, op step) (*types.Function, int, 
 		}
 	}
 	ctx.pop()
-	if ctx.count() < params || !l.args(ctx, target, params) {
+	if ctx.count() < params || !l.checkArgs(ctx, target, params) {
 		return nil, 0, false
 	}
 	return target, params, true
 }
 
-// args verifies the top params operands match the callee's declared
-// parameter kinds.
-func (l arm64Lowerer) args(ctx *lowering, target *types.Function, params int) bool {
+// checkArgs verifies the top params operands match the callee's parameter kinds.
+func (l arm64Lowerer) checkArgs(ctx *lowering, target *types.Function, params int) bool {
 	kinds := target.Slots()
 	if len(kinds) < params {
 		return false
@@ -2653,10 +2651,10 @@ func (l arm64Lowerer) args(ctx *lowering, target *types.Function, params int) bo
 	return true
 }
 
-// locals fills frame f with the call arguments args in its parameter slots and
+// initLocals fills frame f with call arguments in its parameter slots and
 // a raw zero in every remaining local, matching threaded tail()/CALL's clear.
 // Each slot is loaded and dirty so the next flush commits it to the VM stack.
-func (l arm64Lowerer) locals(ctx *lowering, f *activation, args []value) bool {
+func (l arm64Lowerer) initLocals(ctx *lowering, f *activation, args []value) bool {
 	for k := range args {
 		// This becomes a new frame's own tracked local, so a deferred ref
 		// argument must own its retain: the new backing slot is unrelated storage
@@ -2706,7 +2704,7 @@ func (l arm64Lowerer) stitch(ctx *lowering, ip int) bool {
 			}
 		}
 	}
-	if !l.releaseFrameRefs(ctx, f, ip) {
+	if !l.releaseFrame(ctx, f, ip) {
 		return false
 	}
 	ctx.values = ctx.values[:f.opBase]
@@ -2731,7 +2729,7 @@ func (l arm64Lowerer) ret(ctx *lowering, ip int) bool {
 		}
 	}
 	f := ctx.frame()
-	if !l.releaseFrameRefs(ctx, f, ip) {
+	if !l.releaseFrame(ctx, f, ip) {
 		return false
 	}
 	vStack := ctx.pin(scratchStack)
@@ -2755,10 +2753,10 @@ func (l arm64Lowerer) ret(ctx *lowering, ip int) bool {
 	return true
 }
 
-// releaseFrameRefs drops the ownership held by an activation's VM local slots.
-func (l arm64Lowerer) releaseFrameRefs(ctx *lowering, f *activation, ip int) bool {
+// releaseFrame drops the ownership held by an activation's VM local slots.
+func (l arm64Lowerer) releaseFrame(ctx *lowering, f *activation, ip int) bool {
 	refs := make([]asm.VReg, 0, len(f.kinds))
-	var stackBase asm.VReg
+	var vmStackBase asm.VReg
 	for idx, kind := range f.kinds {
 		if kind != types.KindRef {
 			continue
@@ -2772,11 +2770,11 @@ func (l arm64Lowerer) releaseFrameRefs(ctx *lowering, f *activation, ip int) boo
 			refs = append(refs, ref)
 			continue
 		}
-		if stackBase.Width() == asm.WidthUndefined {
-			stackBase = l.base(ctx, ctx.pin(scratchStack))
+		if vmStackBase.Width() == asm.WidthUndefined {
+			vmStackBase = l.base(ctx, ctx.pin(scratchStack))
 		}
 		ref := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDR(ref, stackBase, int16((f.base+idx)*8)))
+		ctx.assembler.Emit(arm64.LDR(ref, vmStackBase, int16((f.base+idx)*8)))
 		refs = append(refs, ref)
 	}
 	if len(refs) == 0 {
@@ -2787,13 +2785,23 @@ func (l arm64Lowerer) releaseFrameRefs(ctx *lowering, f *activation, ip int) boo
 	if !ok {
 		return false
 	}
-	base := l.rcBase(ctx)
+	rcBase := l.rcBase(ctx)
+	// Preflight every owned ref before mutating any count. A later guard must
+	// deopt without leaving earlier native releases applied.
 	for _, ref := range refs {
+		skip := ctx.assembler.Label()
 		addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.ANDI(addr, ref, maskI32))
-		rc := l.guardRC(ctx, addr, base, fail)
-		ctx.assembler.Emit(arm64.SUBI(rc, rc, 1))
-		ctx.assembler.Emit(arm64.STRR(rc, base, addr))
+		ctx.assembler.Emit(arm64.ANDI(addr, ref, maskI32), arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, skip))
+		l.guardRC(ctx, addr, rcBase, fail)
+		ctx.assembler.Bind(skip)
+	}
+	for _, ref := range refs {
+		skip := ctx.assembler.Label()
+		addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+		ctx.assembler.Emit(arm64.ANDI(addr, ref, maskI32), arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, skip))
+		rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+		ctx.assembler.Emit(arm64.LDRR(rc, rcBase, addr), arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
+		ctx.assembler.Bind(skip)
 	}
 	return true
 }
@@ -2979,7 +2987,7 @@ func (l arm64Lowerer) upvalSet(ctx *lowering, op step) bool {
 		pre := ctx.pre()
 		old := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(old, base, int16(idx*8)))
-		l.releaseBoxUnlessEqual(ctx, old, boxed, pre, op.ip)
+		l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
 	}
 	ctx.assembler.Emit(arm64.STR(boxed, base, int16(idx*8)))
 	ctx.pop()
@@ -3419,7 +3427,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) (bool, bool) {
 	if kind == types.KindRef {
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
-		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
+		l.releaseBoxExcept(ctx, old, val.reg, pre, op.ip)
 		if owned {
 			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
@@ -3441,10 +3449,10 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) (bool, bool) {
 		}
 	}
 	ctx.values = ctx.values[:len(ctx.values)-3]
-	if kind == types.KindRef || op.terminal {
+	if op.terminal || kind == types.KindRef {
 		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op)), true
 	}
-	return true, kind == types.KindRef || op.terminal
+	return true, false
 }
 
 func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
@@ -3605,7 +3613,7 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) (bool, bool) {
 	if kind == types.KindRef {
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
-		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
+		l.releaseBoxExcept(ctx, old, val.reg, pre, op.ip)
 		if owned {
 			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
@@ -3625,10 +3633,10 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) (bool, bool) {
 		a.Emit(arm64.STRR(stored, dataPtr, idx))
 	}
 	ctx.values = ctx.values[:len(ctx.values)-3]
-	if kind == types.KindRef || op.terminal {
+	if op.terminal || kind == types.KindRef {
 		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op)), true
 	}
-	return true, kind == types.KindRef || op.terminal
+	return true, false
 }
 
 func (l arm64Lowerer) sign32(ctx *lowering, v asm.VReg) asm.VReg {
@@ -4016,18 +4024,12 @@ func (l arm64Lowerer) report(ctx *lowering, vCtrl asm.VReg, trap, nextIP int) {
 	a.Emit(arm64.STR(vIP, vCtrl, int16(journalNextIP*8)))
 }
 
-func (l arm64Lowerer) releaseBoxUnlessEqual(ctx *lowering, old, val asm.VReg, pre []value, ip int) {
-	l.unlessEqual(ctx, old, val, func() { l.releaseBox(ctx, old, pre, ip) })
-	ctx.values = append(ctx.values[:0], pre...)
-}
-
-// unlessEqual emits body guarded by a CMP+BEQ skip over equal registers.
-func (l arm64Lowerer) unlessEqual(ctx *lowering, a, b asm.VReg, body func()) {
+func (l arm64Lowerer) releaseBoxExcept(ctx *lowering, old, val asm.VReg, pre []value, ip int) {
 	done := ctx.assembler.Label()
-	ctx.assembler.Emit(arm64.CMP(a, b))
-	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBEQ, done))
-	body()
+	ctx.assembler.Emit(arm64.CMP(old, val), arm64.BCondLabel(arm64.OpBEQ, done))
+	l.releaseBox(ctx, old, pre, ip)
 	ctx.assembler.Bind(done)
+	ctx.values = append(ctx.values[:0], pre...)
 }
 
 func (l arm64Lowerer) releaseBox(ctx *lowering, v asm.VReg, pre []value, ip int) {
@@ -4040,8 +4042,11 @@ func (l arm64Lowerer) releaseBox(ctx *lowering, v asm.VReg, pre []value, ip int)
 	})
 }
 
-func (l arm64Lowerer) retainBoxUnlessEqual(ctx *lowering, old, val asm.VReg) {
-	l.unlessEqual(ctx, old, val, func() { l.retainBox(ctx, val) })
+func (l arm64Lowerer) retainBoxExcept(ctx *lowering, old, val asm.VReg) {
+	done := ctx.assembler.Label()
+	ctx.assembler.Emit(arm64.CMP(old, val), arm64.BCondLabel(arm64.OpBEQ, done))
+	l.retainBox(ctx, val)
+	ctx.assembler.Bind(done)
 }
 
 func (l arm64Lowerer) retainBox(ctx *lowering, v asm.VReg) {
@@ -4112,7 +4117,7 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 				continue
 			}
 			if f.state[idx]&localStored == 0 {
-				boxed, ok := l.boxHome(ctx, f.locals[idx])
+				boxed, ok := l.box(ctx, f.locals[idx])
 				if !ok {
 					return false
 				}
@@ -4139,7 +4144,7 @@ func (l arm64Lowerer) flush(ctx *lowering, mode flushMode) bool {
 		}
 		switch v.backing {
 		case backingStack:
-			boxed, ok := l.boxHome(ctx, v)
+			boxed, ok := l.box(ctx, v)
 			if !ok {
 				return false
 			}
@@ -4187,7 +4192,7 @@ func (l arm64Lowerer) commitCarried(ctx *lowering) bool {
 	}
 	addr := l.base(ctx, ctx.pin(scratchStack))
 	for _, carried := range ctx.carried {
-		boxed, ok := l.boxHome(ctx, carried.value)
+		boxed, ok := l.box(ctx, carried.value)
 		if !ok {
 			return false
 		}
@@ -4236,10 +4241,6 @@ func (l arm64Lowerer) baseTo(ctx *lowering, vStack, addr asm.VReg) {
 	vBP := ctx.pin(scratchBP)
 	ctx.assembler.Emit(arm64.LSLI(addr, vBP, 3))
 	ctx.assembler.Emit(arm64.ADD(addr, vStack, addr))
-}
-
-func (l arm64Lowerer) boxHome(ctx *lowering, v value) (asm.VReg, bool) {
-	return l.box(ctx, v)
 }
 
 // detach owns every operand backed by the slot identified by (backing, slot) before

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -158,8 +158,9 @@ func (l arm64Lowerer) emitExits(ctx *lowering) bool {
 				}
 				ctx.assembler.Emit(arm64.ANDI(refAddr, reg, maskI32))
 				if rcBase.Width() == asm.WidthUndefined {
-					rcBase = l.rcBase(ctx)
+					rcBase = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 				}
+				ctx.assembler.Emit(arm64.LDR(rcBase, ctx.pin(scratchCtrl), int16(journalRC*8)))
 				if rc.Width() == asm.WidthUndefined {
 					rc = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 				}
@@ -4031,7 +4032,11 @@ func (l arm64Lowerer) unlessEqual(ctx *lowering, a, b asm.VReg, body func()) {
 
 func (l arm64Lowerer) releaseBox(ctx *lowering, v asm.VReg, pre []value, ip int) {
 	l.refOnly(ctx, v, func(addr asm.VReg) {
+		a := ctx.assembler
+		done := a.Label()
+		a.Emit(arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, done))
 		l.releaseRef(ctx, addr, pre, ip)
+		a.Bind(done)
 	})
 }
 

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -878,16 +878,9 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 		return false
 	}
 	if vp.kind == types.KindRef {
-		// Own the incoming value before it is captured into a guard snapshot:
-		// pre() must observe backingStack, or a deopt on this op would re-enter
-		// the interpreter expecting a retain the stub cannot see anymore.
-		// detach() then materializes every other deferred reader of the slot
-		// this SET is about to overwrite.
-		boxed, ok := l.own(ctx, vp)
+		deferred := vp.backing != backingStack
+		boxed, ok := l.box(ctx, *vp)
 		if !ok {
-			return false
-		}
-		if !l.detach(ctx, backingLocal, f.base+idx) {
 			return false
 		}
 		pre := ctx.pre()
@@ -895,12 +888,17 @@ func (l arm64Lowerer) localSet(ctx *lowering, op step, pop bool) bool {
 		addr := l.base(ctx, vStack)
 		old := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(old, addr, int16((f.base+idx)*8)))
-		// Release the overwritten ref first: it is the only deopt point, so no
-		// refcount is mutated before it. TEE then retains the stored ref because
-		// it keeps the stack copy alongside the slot; the retain runs only on the
-		// non-deopt path, so a re-run in the interpreter cannot double-apply it.
-		// SET transfers the stack's reference and skips the retain.
-		l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
+		if pop && deferred {
+			l.releaseBox(ctx, old, pre, op.ip)
+		} else {
+			l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
+		}
+		if _, ok := l.own(ctx, vp); !ok {
+			return false
+		}
+		if !l.detach(ctx, backingLocal, f.base+idx) {
+			return false
+		}
 		if !pop {
 			l.retainBoxExcept(ctx, old, boxed)
 		}
@@ -972,36 +970,36 @@ func (l arm64Lowerer) globalSet(ctx *lowering, op step, pop bool) bool {
 		}
 	}
 	var boxed asm.VReg
+	deferred := false
 	if kind == types.KindRef {
-		// Own the incoming value before it can be captured by a guard
-		// snapshot, then detach every other deferred reader of the slot this
-		// SET is about to overwrite (see localSet).
-		boxed, ok = l.own(ctx, vp)
-		if !ok {
-			return false
-		}
-		if !l.detach(ctx, backingGlobal, idx) {
-			return false
-		}
-	} else {
-		boxed, ok = l.box(ctx, *vp)
-		if !ok {
-			return false
-		}
+		deferred = vp.backing != backingStack
+	}
+	boxed, ok = l.box(ctx, *vp)
+	if !ok {
+		return false
 	}
 	base := ctx.pin(scratchGlobals)
-	if kind == types.KindRef || kind == types.KindI64 {
+	if kind == types.KindRef {
 		pre := ctx.pre()
 		old := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(old, base, int16(idx*8)))
-		// Release the overwritten ref first: it is the only deopt point, so no
-		// refcount is mutated before it. TEE then retains the stored ref because
-		// it keeps the stack copy alongside the slot; the retain runs only on the
-		// non-deopt path, so a re-run in the interpreter cannot double-apply it.
-		// SET transfers the stack's reference and skips the retain.
-		l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
-		if !pop {
-			l.retainBoxExcept(ctx, old, boxed)
+		if kind == types.KindRef {
+			if pop && deferred {
+				l.releaseBox(ctx, old, pre, op.ip)
+			} else {
+				l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
+			}
+		}
+		if kind == types.KindRef {
+			if _, ok := l.own(ctx, vp); !ok {
+				return false
+			}
+			if !l.detach(ctx, backingGlobal, idx) {
+				return false
+			}
+			if !pop {
+				l.retainBoxExcept(ctx, old, boxed)
+			}
 		}
 	}
 	ctx.assembler.Emit(arm64.STR(boxed, base, int16(idx*8)))
@@ -2524,12 +2522,14 @@ func (l arm64Lowerer) tailLoop(ctx *lowering, op step) bool {
 	}
 	old := ctx.frame()
 	f := newActivation(ctx.addr, target, 0, 0)
+	refs, ok := l.guardFrame(ctx, old, op.ip)
+	if !ok {
+		return false
+	}
 	if !l.initLocals(ctx, &f, args) {
 		return false
 	}
-	if !l.releaseFrame(ctx, old, op.ip) {
-		return false
-	}
+	l.releaseFrame(ctx, refs)
 	ctx.frames = append(ctx.frames[:0], f)
 	if !l.flush(ctx, flushCommit) {
 		return false
@@ -2563,12 +2563,14 @@ func (l arm64Lowerer) tailMorph(ctx *lowering, op step) bool {
 	// frame needs, then releaseFrame drops the retiring activation.
 	f := newActivation(op.callee, target, base, len(ctx.values))
 	f.resume = op.ip + 1
+	refs, ok := l.guardFrame(ctx, old, op.ip)
+	if !ok {
+		return false
+	}
 	if !l.initLocals(ctx, &f, args) {
 		return false
 	}
-	if !l.releaseFrame(ctx, old, op.ip) {
-		return false
-	}
+	l.releaseFrame(ctx, refs)
 	ctx.frames[len(ctx.frames)-1] = f
 	return true
 }
@@ -2691,6 +2693,10 @@ func (l arm64Lowerer) stitch(ctx *lowering, ip int) bool {
 		return false
 	}
 	rets := append([]value(nil), ctx.values[len(ctx.values)-f.returns:]...)
+	refs, ok := l.guardFrame(ctx, f, ip)
+	if !ok {
+		return false
+	}
 	// A return backed by one of the callee's locals must acquire an independent
 	// retain before that local is released with the rest of the retiring frame.
 	for i := range rets {
@@ -2704,9 +2710,7 @@ func (l arm64Lowerer) stitch(ctx *lowering, ip int) bool {
 			}
 		}
 	}
-	if !l.releaseFrame(ctx, f, ip) {
-		return false
-	}
+	l.releaseFrame(ctx, refs)
 	ctx.values = ctx.values[:f.opBase]
 	ctx.frames = ctx.frames[:len(ctx.frames)-1]
 	ctx.values = append(ctx.values, rets...)
@@ -2720,18 +2724,19 @@ func (l arm64Lowerer) ret(ctx *lowering, ip int) bool {
 		return false
 	}
 	a := ctx.assembler
+	f := ctx.frame()
+	refs, ok := l.guardFrame(ctx, f, ip)
+	if !ok {
+		return false
+	}
 	// A native entry frame owns every ref local/parameter until RETURN. Retain
-	// deferred return values first so a value returned from one of those locals
-	// survives the local-slot cleanup below.
+	// deferred return values before the local-slot cleanup below.
 	for idx := 0; idx < ctx.returns; idx++ {
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-ctx.returns+idx]); !ok {
 			return false
 		}
 	}
-	f := ctx.frame()
-	if !l.releaseFrame(ctx, f, ip) {
-		return false
-	}
+	l.releaseFrame(ctx, refs)
 	vStack := ctx.pin(scratchStack)
 	addr := l.base(ctx, vStack)
 	for idx := 0; idx < ctx.returns; idx++ {
@@ -2753,57 +2758,75 @@ func (l arm64Lowerer) ret(ctx *lowering, ip int) bool {
 	return true
 }
 
-// releaseFrame drops the ownership held by an activation's VM local slots.
-func (l arm64Lowerer) releaseFrame(ctx *lowering, f *activation, ip int) bool {
-	refs := make([]asm.VReg, 0, len(f.kinds))
-	var vmStackBase asm.VReg
-	for idx, kind := range f.kinds {
+// guardFrame checks that an activation can be released without deopt.
+func (l arm64Lowerer) guardFrame(ctx *lowering, f *activation, ip int) ([]asm.VReg, bool) {
+	addrs := make([]asm.VReg, 0, len(f.kinds))
+	var stack asm.VReg
+	a := ctx.assembler
+	for i, kind := range f.kinds {
 		if kind != types.KindRef {
 			continue
 		}
-		v := f.locals[idx]
+		v := f.locals[i]
+		var ref asm.VReg
 		if v.reg.Width() != asm.WidthUndefined {
-			ref, ok := l.box(ctx, v)
+			var ok bool
+			ref, ok = l.box(ctx, v)
 			if !ok {
-				return false
+				return nil, false
 			}
-			refs = append(refs, ref)
-			continue
+		} else {
+			if stack.Width() == asm.WidthUndefined {
+				stack = l.base(ctx, ctx.pin(scratchStack))
+			}
+			ref = a.Reg(asm.RegTypeInt, asm.Width64)
+			a.Emit(arm64.LDR(ref, stack, int16((f.base+i)*8)))
 		}
-		if vmStackBase.Width() == asm.WidthUndefined {
-			vmStackBase = l.base(ctx, ctx.pin(scratchStack))
-		}
-		ref := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDR(ref, vmStackBase, int16((f.base+idx)*8)))
-		refs = append(refs, ref)
+		addr := a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.ANDI(addr, ref, maskI32))
+		addrs = append(addrs, addr)
 	}
-	if len(refs) == 0 {
-		return true
+	if len(addrs) == 0 {
+		return nil, true
 	}
-	pre := append([]value(nil), ctx.values...)
+	pre := ctx.pre()
 	fail, ok := l.sideExit(ctx, pre, ip, prof.ExitGuardValue, ctx.opcode(ip))
 	if !ok {
-		return false
+		return nil, false
 	}
 	rcBase := l.rcBase(ctx)
-	// Preflight every owned ref before mutating any count. A later guard must
-	// deopt without leaving earlier native releases applied.
-	for _, ref := range refs {
-		skip := ctx.assembler.Label()
-		addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.ANDI(addr, ref, maskI32), arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, skip))
-		l.guardRC(ctx, addr, rcBase, fail)
-		ctx.assembler.Bind(skip)
+	for i, addr := range addrs {
+		skip := a.Label()
+		pending := a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, skip))
+		a.Emit(arm64.LDI(pending, 1)...)
+		for j := 0; j < i; j++ {
+			a.Emit(arm64.CMP(addr, addrs[j]))
+			noMatch := a.Label()
+			a.Emit(arm64.BCondLabel(arm64.OpBNE, noMatch), arm64.ADDI(pending, pending, 1))
+			a.Bind(noMatch)
+		}
+		rc := a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.LDRR(rc, rcBase, addr), arm64.CMP(rc, pending), arm64.BCondLabel(arm64.OpBLE, fail))
+		a.Bind(skip)
 	}
-	for _, ref := range refs {
-		skip := ctx.assembler.Label()
-		addr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.ANDI(addr, ref, maskI32), arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, skip))
-		rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDRR(rc, rcBase, addr), arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
-		ctx.assembler.Bind(skip)
+	return addrs, true
+}
+
+// releaseFrame drops refs after guardFrame succeeds.
+func (l arm64Lowerer) releaseFrame(ctx *lowering, addrs []asm.VReg) {
+	if len(addrs) == 0 {
+		return
 	}
-	return true
+	rcBase := l.rcBase(ctx)
+	a := ctx.assembler
+	for _, addr := range addrs {
+		skip := a.Label()
+		a.Emit(arm64.CMPI(addr, 0), arm64.BCondLabel(arm64.OpBEQ, skip))
+		rc := a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.LDRR(rc, rcBase, addr), arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
+		a.Bind(skip)
+	}
 }
 
 // complete finishes top-level module code: live locals and operands are boxed
@@ -2968,26 +2991,29 @@ func (l arm64Lowerer) upvalSet(ctx *lowering, op step) bool {
 	}
 	var boxed asm.VReg
 	var ok bool
-	if kind == types.KindRef {
-		boxed, ok = l.own(ctx, vp)
-		if !ok {
-			return false
-		}
-		if !l.detach(ctx, backingUpval, idx) {
-			return false
-		}
-	} else {
-		boxed, ok = l.box(ctx, *vp)
-		if !ok {
-			return false
-		}
+	deferred := kind == types.KindRef && vp.backing != backingStack
+	boxed, ok = l.box(ctx, *vp)
+	if !ok {
+		return false
 	}
 	base := l.upvalBase(ctx)
-	if kind == types.KindRef || kind == types.KindI64 {
+	if kind == types.KindRef {
 		pre := ctx.pre()
 		old := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 		ctx.assembler.Emit(arm64.LDR(old, base, int16(idx*8)))
-		l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
+		if kind == types.KindRef && deferred {
+			l.releaseBox(ctx, old, pre, op.ip)
+		} else if kind == types.KindRef {
+			l.releaseBoxExcept(ctx, old, boxed, pre, op.ip)
+		}
+		if kind == types.KindRef {
+			if _, ok := l.own(ctx, vp); !ok {
+				return false
+			}
+			if !l.detach(ctx, backingUpval, idx) {
+				return false
+			}
+		}
 	}
 	ctx.assembler.Emit(arm64.STR(boxed, base, int16(idx*8)))
 	ctx.pop()
@@ -3366,11 +3392,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) (bool, bool) {
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false, false
 	}
-	if kind == types.KindRef {
-		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
-			return false, false
-		}
-	}
+	deferred := kind == types.KindRef && ctx.values[len(ctx.values)-1].backing != backingStack
 	owned := container.backing == backingStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
@@ -3427,7 +3449,14 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) (bool, bool) {
 	if kind == types.KindRef {
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
-		l.releaseBoxExcept(ctx, old, val.reg, pre, op.ip)
+		if deferred {
+			l.releaseBox(ctx, old, pre, op.ip)
+		} else {
+			l.releaseBoxExcept(ctx, old, val.reg, pre, op.ip)
+		}
+		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
+			return false, false
+		}
 		if owned {
 			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
@@ -3557,11 +3586,7 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) (bool, bool) {
 	if op.shape.itab != 0 && op.shape.itab != heapStruct {
 		return false, false
 	}
-	if kind == types.KindRef {
-		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
-			return false, false
-		}
-	}
+	deferred := kind == types.KindRef && ctx.values[len(ctx.values)-1].backing != backingStack
 	container := ctx.values[len(ctx.values)-3]
 	owned := container.backing == backingStack
 	pre := ctx.pre()
@@ -3613,7 +3638,14 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) (bool, bool) {
 	if kind == types.KindRef {
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
-		l.releaseBoxExcept(ctx, old, val.reg, pre, op.ip)
+		if deferred {
+			l.releaseBox(ctx, old, pre, op.ip)
+		} else {
+			l.releaseBoxExcept(ctx, old, val.reg, pre, op.ip)
+		}
+		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
+			return false, false
+		}
 		if owned {
 			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -656,28 +656,28 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 		case instr.ARRAY_LEN:
 			ok = l.arrayLen(ctx, op)
 		case instr.ARRAY_SET:
-			terminal := op.terminal || ctx.count() > 0 && ctx.values[len(ctx.values)-1].kind == types.KindRef
-			if !l.arraySet(ctx, op) {
+			var terminal bool
+			ok, terminal = l.arraySet(ctx, op)
+			if !ok {
 				return false, false
 			}
 			if terminal {
 				return true, idx == len(ops)-1
 			}
-			ok = true
 		case instr.STRUCT_GET:
 			if !l.structGet(ctx, op) {
 				return false, false
 			}
 			ok = true
 		case instr.STRUCT_SET:
-			terminal := op.terminal || ctx.count() > 0 && ctx.values[len(ctx.values)-1].kind == types.KindRef
-			if !l.structSet(ctx, op) {
+			var terminal bool
+			ok, terminal = l.structSet(ctx, op)
+			if !ok {
 				return false, false
 			}
 			if terminal {
 				return true, idx == len(ops)-1
 			}
-			ok = true
 		case instr.ERROR_GET:
 			ok = l.errorGet(ctx, op)
 		case instr.CORO_DONE:
@@ -3322,9 +3322,9 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 	return true
 }
 
-func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
+func (l arm64Lowerer) arraySet(ctx *lowering, op step) (bool, bool) {
 	if ctx.count() < 3 || ctx.values[len(ctx.values)-2].kind != types.KindI32 || ctx.values[len(ctx.values)-3].kind != types.KindRef {
-		return false
+		return false, false
 	}
 	container := ctx.values[len(ctx.values)-3]
 	kind := ctx.values[len(ctx.values)-1].kind
@@ -3348,15 +3348,18 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	case types.KindF64:
 		want = heapArrayF64
 		scale = 3
+	case types.KindRef:
+		want = heapArrayRef
+		base = int16(arrayElems)
 	default:
-		return false
+		return false, false
 	}
 	if op.shape.itab != 0 && op.shape.itab != want {
-		return false
+		return false, false
 	}
 	if kind == types.KindRef {
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
-			return false
+			return false, false
 		}
 	}
 	owned := container.backing == backingStack
@@ -3368,7 +3371,7 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		container.backing == backingLocal && container.slot == ctx.hoist.slot && want == ctx.hoist.want {
 		bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
 		if !ok {
-			return false
+			return false, false
 		}
 		l.guardIndex(ctx, idx, ctx.hoist.n, bounds)
 		switch kind {
@@ -3385,23 +3388,23 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 			a.Emit(arm64.STRR(val.reg, ctx.hoist.dataPtr, idx))
 		}
 		ctx.values = ctx.values[:len(ctx.values)-3]
-		return true
+		return true, op.terminal
 	}
 	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	ref, ok := l.box(ctx, container)
 	if !ok {
-		return false
+		return false, false
 	}
 	addr, itab, data := l.guardHeap(ctx, ref, fail)
 	l.guardItab(ctx, itab, want, fail)
@@ -3438,9 +3441,9 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	}
 	ctx.values = ctx.values[:len(ctx.values)-3]
 	if kind == types.KindRef || op.terminal {
-		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
+		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op)), true
 	}
-	return true
+	return true, kind == types.KindRef || op.terminal
 }
 
 func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
@@ -3532,22 +3535,22 @@ func (l arm64Lowerer) guardBoxable(ctx *lowering, v asm.VReg, fail asm.Label) {
 	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
 }
 
-func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
+func (l arm64Lowerer) structSet(ctx *lowering, op step) (bool, bool) {
 	if ctx.count() < 3 || ctx.values[len(ctx.values)-2].kind != types.KindI32 || ctx.values[len(ctx.values)-3].kind != types.KindRef {
-		return false
+		return false, false
 	}
 	kind := ctx.values[len(ctx.values)-1].kind
 	switch kind {
 	case types.KindI1, types.KindI8, types.KindI32, types.KindI64, types.KindF32, types.KindF64, types.KindRef:
 	default:
-		return false
+		return false, false
 	}
 	if op.shape.itab != 0 && op.shape.itab != heapStruct {
-		return false
+		return false, false
 	}
 	if kind == types.KindRef {
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
-			return false
+			return false, false
 		}
 	}
 	container := ctx.values[len(ctx.values)-3]
@@ -3557,24 +3560,24 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
 	ref, ok := l.box(ctx, container)
 	if !ok {
-		return false
+		return false, false
 	}
 	a := ctx.assembler
 	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	kindFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardKind, int(op.op))
 	if !ok {
-		return false
+		return false, false
 	}
 	addr, itab, data := l.guardHeap(ctx, ref, fail)
 	l.guardItab(ctx, itab, heapStruct, fail)
@@ -3622,9 +3625,9 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 	}
 	ctx.values = ctx.values[:len(ctx.values)-3]
 	if kind == types.KindRef || op.terminal {
-		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
+		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op)), true
 	}
-	return true
+	return true, kind == types.KindRef || op.terminal
 }
 
 func (l arm64Lowerer) sign32(ctx *lowering, v asm.VReg) asm.VReg {

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -124,8 +124,6 @@ func (l arm64Lowerer) emitExits(ctx *lowering) bool {
 	// can have many exits, each otherwise adding its own fresh registers).
 	var reg, refAddr, rcBase, rc asm.VReg
 	for _, exit := range ctx.exits {
-		ctx.reuseLocals = false
-		ctx.spare = asm.VReg{}
 		ctx.values = exit.values
 		ctx.frames = exit.frames
 		ctx.assembler.Bind(exit.label)
@@ -160,9 +158,8 @@ func (l arm64Lowerer) emitExits(ctx *lowering) bool {
 				}
 				ctx.assembler.Emit(arm64.ANDI(refAddr, reg, maskI32))
 				if rcBase.Width() == asm.WidthUndefined {
-					rcBase = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+					rcBase = l.rcBase(ctx)
 				}
-				l.rcBaseTo(ctx, rcBase)
 				if rc.Width() == asm.WidthUndefined {
 					rc = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 				}
@@ -188,8 +185,6 @@ func (l arm64Lowerer) emitBlock(ctx *lowering, id int, tail []int) bool {
 	}
 	block := ctx.blocks[id]
 	if block.state != nil {
-		ctx.reuseLocals = false
-		ctx.spare = asm.VReg{}
 		ctx.values = ctx.values[:0]
 		for _, slot := range block.state {
 			ctx.values = append(ctx.values, value{kind: slot.kind, ref: slot.ref, backing: slot.backing, slot: slot.slot})
@@ -2526,8 +2521,12 @@ func (l arm64Lowerer) tailLoop(ctx *lowering, op step) bool {
 	if ctx.count() != 0 {
 		return false
 	}
+	old := ctx.frame()
 	f := newActivation(ctx.addr, target, 0, 0)
 	if !l.locals(ctx, &f, args) {
+		return false
+	}
+	if !l.releaseFrameRefs(ctx, old, op.ip) {
 		return false
 	}
 	ctx.frames = append(ctx.frames[:0], f)
@@ -2565,6 +2564,9 @@ func (l arm64Lowerer) tailMorph(ctx *lowering, op step) bool {
 	f := newActivation(op.callee, target, base, len(ctx.values))
 	f.resume = op.ip + 1
 	if !l.locals(ctx, &f, args) {
+		return false
+	}
+	if !l.releaseFrameRefs(ctx, old, op.ip) {
 		return false
 	}
 	ctx.frames[len(ctx.frames)-1] = f
@@ -2755,14 +2757,25 @@ func (l arm64Lowerer) ret(ctx *lowering, ip int) bool {
 // releaseFrameRefs drops the ownership held by an activation's VM local slots.
 func (l arm64Lowerer) releaseFrameRefs(ctx *lowering, f *activation, ip int) bool {
 	refs := make([]asm.VReg, 0, len(f.kinds))
+	var stackBase asm.VReg
 	for idx, kind := range f.kinds {
-		if kind != types.KindRef || f.locals[idx].reg.Width() == asm.WidthUndefined {
+		if kind != types.KindRef {
 			continue
 		}
-		ref, ok := l.box(ctx, f.locals[idx])
-		if !ok {
-			return false
+		v := f.locals[idx]
+		if v.reg.Width() != asm.WidthUndefined {
+			ref, ok := l.box(ctx, v)
+			if !ok {
+				return false
+			}
+			refs = append(refs, ref)
+			continue
 		}
+		if stackBase.Width() == asm.WidthUndefined {
+			stackBase = l.base(ctx, ctx.pin(scratchStack))
+		}
+		ref := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+		ctx.assembler.Emit(arm64.LDR(ref, stackBase, int16((f.base+idx)*8)))
 		refs = append(refs, ref)
 	}
 	if len(refs) == 0 {
@@ -2891,15 +2904,9 @@ func (l arm64Lowerer) loadLocal(ctx *lowering, f *activation, idx, ip int) bool 
 		return false
 	}
 	vStack := ctx.pin(scratchStack)
-	reg, reusable := l.localReg(ctx, f, idx)
-	if reusable {
-		l.baseTo(ctx, vStack, reg)
-		ctx.assembler.Emit(arm64.LDR(reg, reg, int16((f.base+idx)*8)))
-	} else {
-		addr := l.base(ctx, vStack)
-		reg = ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-		ctx.assembler.Emit(arm64.LDR(reg, addr, int16((f.base+idx)*8)))
-	}
+	addr := l.base(ctx, vStack)
+	reg := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
+	ctx.assembler.Emit(arm64.LDR(reg, addr, int16((f.base+idx)*8)))
 	if kind == types.KindI64 {
 		// A heap-promoted i64 is a ref the trace cannot read as a value; guard
 		// the inline tag and deopt at the load if it promoted, then sign-extend
@@ -3320,9 +3327,6 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		return false
 	}
 	container := ctx.values[len(ctx.values)-3]
-	if container.backing != backingConst {
-		return l.exit(ctx, op.ip, prof.ExitTerminalOp, int(op.op))
-	}
 	kind := ctx.values[len(ctx.values)-1].kind
 	var want uintptr
 	var base int16
@@ -3351,11 +3355,6 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		return false
 	}
 	if kind == types.KindRef {
-		// The stored ref transfers into the element, so it must own its retain:
-		// threaded ARRAY_SET moves the popped operand's +1 into the container,
-		// and a deferred value has none. Own before pre() so the pre snapshot and
-		// every exit snapshot see backingStack and no stub double-retains it
-		// (mirrors localSet).
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
 			return false
 		}
@@ -3367,11 +3366,6 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 	a := ctx.assembler
 	if ctx.hoist.live && kind != types.KindRef && !op.terminal &&
 		container.backing == backingLocal && container.slot == ctx.hoist.slot && want == ctx.hoist.want {
-		// The hoisted store needs no shape or refcount guard and is not a
-		// state barrier: the prologue proved the container, the local slot
-		// keeps its retain, and locals stay register-cached across it. The
-		// element address lands in a fresh register so the hoisted slice
-		// header stays intact for the rest of the body.
 		bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
 		if !ok {
 			return false
@@ -3390,148 +3384,60 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) bool {
 		case types.KindI64, types.KindF64:
 			a.Emit(arm64.STRR(val.reg, ctx.hoist.dataPtr, idx))
 		}
-		ctx.values = ctx.values[: len(ctx.values)-3 : len(ctx.values)-3]
+		ctx.values = ctx.values[:len(ctx.values)-3]
 		return true
+	}
+	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
+	if !ok {
+		return false
+	}
+	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
+	if !ok {
+		return false
+	}
+	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
+	if !ok {
+		return false
 	}
 	ref, ok := l.box(ctx, container)
 	if !ok {
 		return false
 	}
-	continuable := kind != types.KindRef && !op.terminal
-	var fail, bounds, valueFail asm.Label
-	if !continuable {
-		fail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
-		if !ok {
-			return false
-		}
-		bounds, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
-		if !ok {
-			return false
-		}
-		valueFail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
-		if !ok {
-			return false
-		}
-	} else {
-		// A continuable primitive store is a state barrier: materialize the
-		// pre-op frame once, then let all guards share that resumable snapshot.
-		// Clearing the local register cache bounds no-spill pressure and makes
-		// subsequent operations reload from the slots just written.
-		if !l.flush(ctx, flushSnapshot) {
-			return false
-		}
-		l.clearLocals(ctx)
-		ctx.reuseLocals = len(ctx.values) == 3
-		fail = ctx.queueExit(nil, op.ip, prof.ExitGuardShape, int(op.op))
-		bounds = ctx.queueExit(nil, op.ip, prof.ExitGuardBounds, int(op.op))
-		valueFail = ctx.queueExit(nil, op.ip, prof.ExitGuardValue, int(op.op))
-	}
-	var addr, itab, data, scratch asm.VReg
-	remat := false
-	if continuable {
-		work := l.localScratch(ctx)
-		if work.Width() == asm.WidthUndefined && val.known && val.kind.Repr() == types.KindI32 {
-			work = val.reg
-			remat = true
-		}
-		cell := asm.VReg{}
-		if ctx.leaf {
-			cell = ctx.pin(scratchSP)
-		}
-		addr, itab, data, scratch = l.loadHeap(ctx, ref, work, cell)
-	} else {
-		addr, itab, data = l.guardHeap(ctx, ref, fail)
-	}
-	if continuable {
-		l.guardItabTo(ctx, itab, scratch, want, fail)
-	} else {
-		l.guardItab(ctx, itab, want, fail)
-	}
-
-	var dataPtr, n asm.VReg
-	if continuable {
-		dataPtr = itab
-		n = data
-		l.sliceHeaderTo(ctx, data, dataPtr, n, base)
-	} else {
-		dataPtr, n = l.sliceHeader(ctx, data, base)
-	}
+	addr, itab, data := l.guardHeap(ctx, ref, fail)
+	l.guardItab(ctx, itab, want, fail)
+	dataPtr, n := l.sliceHeader(ctx, data, base)
 	l.guardIndex(ctx, idx, n, bounds)
-
-	var rcBase, rc, rcAddr asm.VReg
+	var rcBase, rc asm.VReg
 	if owned {
-		if continuable {
-			rcBase = scratch
-			l.rcBaseTo(ctx, rcBase)
-			ctx.assembler.Emit(arm64.MOV(n, addr))
-			rcAddr = addr
-			rc = n
-			l.guardRCTo(ctx, rc, rcAddr, rcBase, valueFail)
-		} else {
-			rcBase = l.rcBase(ctx)
-			rcAddr = addr
-			rc = l.guardRC(ctx, rcAddr, rcBase, valueFail)
-		}
+		rcBase = l.rcBase(ctx)
+		rc = l.guardRC(ctx, addr, rcBase, valueFail)
 	}
-
 	if kind == types.KindRef {
-		// The container's refcount deopt point (guardRC above) runs before the
-		// overwritten element's release, which carries its own internal deopt
-		// (releaseBoxUnlessEqual -> releaseRef -> guardRC). Neither refcount is
-		// decremented until both checks pass, matching the release-old-ref-first
-		// idiom used by globalSet. A deferred container has no matching release
-		// to run at all.
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
 		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
 		if owned {
-			a.Emit(arm64.SUBI(rc, rc, 1))
-			a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
 		a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 	} else {
-		// All primitive-store guards have passed, so release the consumed array
-		// operand before address formation. This shortens addr/rc liveness and
-		// keeps mutation loops within the no-spill register budget.
 		if owned {
-			a.Emit(arm64.SUBI(rc, rc, 1))
-			a.Emit(arm64.STRR(rc, rcBase, rcAddr))
+			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
 		switch kind {
 		case types.KindI1, types.KindI8:
-			target := n
-			if remat {
-				target = scratch
-			}
-			a.Emit(arm64.ADD(target, dataPtr, idx))
-			if remat {
-				a.Emit(arm64.LDI(val.reg, uint64(val.imm))...)
-			}
-			a.Emit(arm64.STRB(val.reg, target, 0))
+			target := a.Reg(asm.RegTypeInt, asm.Width64)
+			a.Emit(arm64.ADD(target, dataPtr, idx), arm64.STRB(val.reg, target, 0))
 		case types.KindI32, types.KindF32:
-			target := n
-			if remat {
-				target = scratch
-			}
-			a.Emit(arm64.LSLI(target, idx, scale))
-			a.Emit(arm64.ADD(target, dataPtr, target))
-			if remat {
-				a.Emit(arm64.LDI(val.reg, uint64(val.imm))...)
-			}
-			a.Emit(arm64.STRW(val.reg, target, 0))
+			off := a.Reg(asm.RegTypeInt, asm.Width64)
+			target := a.Reg(asm.RegTypeInt, asm.Width64)
+			a.Emit(arm64.LSLI(off, idx, scale), arm64.ADD(target, dataPtr, off), arm64.STRW(val.reg, target, 0))
 		case types.KindI64, types.KindF64:
-			if remat {
-				a.Emit(arm64.LDI(val.reg, uint64(val.imm))...)
-			}
 			a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 		}
-		if continuable && remat && owned {
-			ctx.spare = rc
-		}
 	}
-
-	ctx.values = ctx.values[: len(ctx.values)-3 : len(ctx.values)-3]
-	if !continuable {
+	ctx.values = ctx.values[:len(ctx.values)-3]
+	if kind == types.KindRef || op.terminal {
 		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
 	}
 	return true
@@ -3640,184 +3546,87 @@ func (l arm64Lowerer) structSet(ctx *lowering, op step) bool {
 		return false
 	}
 	if kind == types.KindRef {
-		// The stored ref transfers into the field, so it must own its retain:
-		// threaded STRUCT_SET moves the popped operand's +1 into the container,
-		// and a deferred value has none. Own before pre() so the pre snapshot and
-		// every exit snapshot see backingStack and no stub double-retains it
-		// (mirrors localSet).
 		if _, ok := l.own(ctx, &ctx.values[len(ctx.values)-1]); !ok {
 			return false
 		}
 	}
-	owned := ctx.values[len(ctx.values)-3].backing == backingStack
+	container := ctx.values[len(ctx.values)-3]
+	owned := container.backing == backingStack
 	pre := ctx.pre()
 	val := ctx.values[len(ctx.values)-1]
 	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
-	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-3])
+	ref, ok := l.box(ctx, container)
 	if !ok {
 		return false
 	}
 	a := ctx.assembler
-	continuable := kind != types.KindRef && !op.terminal
-	var fail, bounds, valueFail, kindFail asm.Label
-	if !continuable {
-		fail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
-		if !ok {
-			return false
-		}
-		bounds, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
-		if !ok {
-			return false
-		}
-		valueFail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
-		if !ok {
-			return false
-		}
-		kindFail, ok = l.sideExit(ctx, pre, op.ip, prof.ExitGuardKind, int(op.op))
-		if !ok {
-			return false
-		}
-	} else {
-		// A continuable scalar-field store is a state barrier: materialize the
-		// pre-op frame once, then let all guards share that resumable snapshot.
-		// Clearing the local register cache bounds no-spill pressure and makes
-		// subsequent operations reload from the slots just written.
-		if !l.flush(ctx, flushSnapshot) {
-			return false
-		}
-		l.clearLocals(ctx)
-		ctx.reuseLocals = len(ctx.values) == 3
-		fail = ctx.queueExit(nil, op.ip, prof.ExitGuardShape, int(op.op))
-		bounds = ctx.queueExit(nil, op.ip, prof.ExitGuardBounds, int(op.op))
-		valueFail = ctx.queueExit(nil, op.ip, prof.ExitGuardValue, int(op.op))
-		kindFail = ctx.queueExit(nil, op.ip, prof.ExitGuardKind, int(op.op))
+	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
+	if !ok {
+		return false
 	}
-	var addr, itab, data, scratch asm.VReg
-	if continuable {
-		work := l.localScratch(ctx)
-		cell := asm.VReg{}
-		if ctx.leaf {
-			cell = ctx.pin(scratchSP)
-		}
-		addr, itab, data, scratch = l.loadHeap(ctx, ref, work, cell)
-		l.guardItabTo(ctx, itab, scratch, heapStruct, fail)
-	} else {
-		addr, itab, data = l.guardHeap(ctx, ref, fail)
-		l.guardItab(ctx, itab, heapStruct, fail)
+	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
+	if !ok {
+		return false
 	}
-
-	// The continuable path recycles the guard registers as their live ranges
-	// end: typ takes itab, the fields header takes scratch, the field cursor
-	// walks typ/n, and the rc pair takes the dead kind-check registers. This
-	// keeps scalar struct stores within the no-spill register budget.
-	typ := itab
-	if !continuable {
-		typ = a.Reg(asm.RegTypeInt, asm.Width64)
+	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
+	if !ok {
+		return false
 	}
+	kindFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardKind, int(op.op))
+	if !ok {
+		return false
+	}
+	addr, itab, data := l.guardHeap(ctx, ref, fail)
+	l.guardItab(ctx, itab, heapStruct, fail)
+	typ := a.Reg(asm.RegTypeInt, asm.Width64)
 	a.Emit(arm64.LDR(typ, data, int16(structTyp)))
 	if op.shape.typ != 0 {
-		want := scratch
-		if !continuable {
-			want = a.Reg(asm.RegTypeInt, asm.Width64)
-		}
+		want := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDI(want, uint64(op.shape.typ))...)
-		a.Emit(arm64.CMP(typ, want))
-		a.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
+		a.Emit(arm64.CMP(typ, want), arm64.BCondLabel(arm64.OpBNE, fail))
 	}
-	var fields, n asm.VReg
-	if continuable {
-		fields = scratch
-		n = a.Reg(asm.RegTypeInt, asm.Width64)
-		l.sliceHeaderTo(ctx, typ, fields, n, int16(fieldsSlice))
-	} else {
-		fields, n = l.sliceHeader(ctx, typ, int16(fieldsSlice))
-	}
+	fields, n := l.sliceHeader(ctx, typ, int16(fieldsSlice))
 	l.guardIndex(ctx, idx, n, bounds)
-
-	fieldOff := n
-	if !continuable {
-		fieldOff = a.Reg(asm.RegTypeInt, asm.Width64)
-	}
+	fieldOff := a.Reg(asm.RegTypeInt, asm.Width64)
+	field := a.Reg(asm.RegTypeInt, asm.Width64)
+	fieldKindReg := a.Reg(asm.RegTypeInt, asm.Width64)
 	a.Emit(arm64.LDI(fieldOff, uint64(fieldSize))...)
-	a.Emit(arm64.MUL(fieldOff, idx, fieldOff))
-	field := typ
-	if !continuable {
-		field = a.Reg(asm.RegTypeInt, asm.Width64)
-	}
-	a.Emit(arm64.ADD(field, fields, fieldOff))
-	fieldKindReg := fields
-	if !continuable {
-		fieldKindReg = a.Reg(asm.RegTypeInt, asm.Width64)
-	}
-	a.Emit(arm64.LDRB(fieldKindReg, field, int16(fieldKind)))
-	a.Emit(arm64.CMPI(fieldKindReg, uint16(kind)))
-	a.Emit(arm64.BCondLabel(arm64.OpBNE, kindFail))
-
+	a.Emit(arm64.MUL(fieldOff, idx, fieldOff), arm64.ADD(field, fields, fieldOff), arm64.LDRB(fieldKindReg, field, int16(fieldKind)), arm64.CMPI(fieldKindReg, uint16(kind)), arm64.BCondLabel(arm64.OpBNE, kindFail))
 	var rcBase, rc asm.VReg
 	if owned {
-		if continuable {
-			rcBase = fieldKindReg
-			l.rcBaseTo(ctx, rcBase)
-			rc = fieldOff
-			l.guardRCTo(ctx, rc, addr, rcBase, valueFail)
-		} else {
-			rcBase = l.rcBase(ctx)
-			rc = l.guardRC(ctx, addr, rcBase, valueFail)
-		}
+		rcBase = l.rcBase(ctx)
+		rc = l.guardRC(ctx, addr, rcBase, valueFail)
 	}
-
-	var dataPtr asm.VReg
-	if continuable {
-		dataPtr = field
-		a.Emit(arm64.LDR(dataPtr, data, int16(structData)+sliceData))
-	} else {
-		dataPtr, _ = l.sliceHeader(ctx, data, int16(structData))
-	}
+	dataPtr, _ := l.sliceHeader(ctx, data, int16(structData))
 	if kind == types.KindRef {
-		// Mirrors arraySet's ref-element handling: the container's guardRC
-		// above is the deopt point for the container's own refcount, and the
-		// overwritten field's release (releaseBoxUnlessEqual) carries its own
-		// internal deopt. Neither refcount is decremented until both checks
-		// pass. A deferred container has no matching release to run at all.
 		old := a.Reg(asm.RegTypeInt, asm.Width64)
 		a.Emit(arm64.LDRR(old, dataPtr, idx))
 		l.releaseBoxUnlessEqual(ctx, old, val.reg, pre, op.ip)
 		if owned {
-			a.Emit(arm64.SUBI(rc, rc, 1))
-			a.Emit(arm64.STRR(rc, rcBase, addr))
+			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
 		a.Emit(arm64.STRR(val.reg, dataPtr, idx))
 	} else {
-		// All scalar-store guards have passed, so release the consumed struct
-		// operand before the store. This shortens addr/rc liveness and keeps
-		// mutation loops within the no-spill register budget.
 		if owned {
-			a.Emit(arm64.SUBI(rc, rc, 1))
-			a.Emit(arm64.STRR(rc, rcBase, addr))
+			a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
 		}
 		var stored asm.VReg
 		switch kind {
 		case types.KindI1, types.KindI8, types.KindI32, types.KindF32:
-			stored = data
-			if !continuable {
-				stored = a.Reg(asm.RegTypeInt, asm.Width64)
-			}
+			stored = a.Reg(asm.RegTypeInt, asm.Width64)
 			a.Emit(arm64.ANDI(stored, val.reg, maskI32))
 		case types.KindI64, types.KindF64:
 			stored = val.reg
 		}
 		a.Emit(arm64.STRR(stored, dataPtr, idx))
 	}
-
-	ctx.values = ctx.values[: len(ctx.values)-3 : len(ctx.values)-3]
-	if !continuable {
+	ctx.values = ctx.values[:len(ctx.values)-3]
+	if kind == types.KindRef || op.terminal {
 		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op))
 	}
 	return true
 }
 
-// sign32 sign-extends a raw i32's low lane for signed division and
-// shifts; zero32 zero-extends it for their unsigned counterparts.
 func (l arm64Lowerer) sign32(ctx *lowering, v asm.VReg) asm.VReg {
 	out := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.SXTW(out, v))
@@ -4101,33 +3910,8 @@ func (l arm64Lowerer) retainDeferred(ctx *lowering) {
 	}
 }
 
-// loadHeap loads a heap cell for a value already proven to have ref kind by the
-// symbolic stack. It reuses ref and off as outputs, so callers use it only after
-// a state barrier whose exits reload boxed operands from their VM stack slots.
-func (arm64Lowerer) loadHeap(ctx *lowering, ref, off, cell asm.VReg) (asm.VReg, asm.VReg, asm.VReg, asm.VReg) {
-	a := ctx.assembler
-	addr := a.Reg(asm.RegTypeInt, asm.Width64)
-	a.Emit(arm64.ANDI(addr, ref, maskI32))
-	if cell.Width() == asm.WidthUndefined {
-		cell = a.Reg(asm.RegTypeInt, asm.Width64)
-	}
-	a.Emit(arm64.LDR(cell, ctx.pin(scratchCtrl), int16(journalHeap*8)))
-	if off.Width() == asm.WidthUndefined {
-		off = a.Reg(asm.RegTypeInt, asm.Width64)
-	}
-	a.Emit(arm64.LSLI(off, addr, 4))
-	a.Emit(arm64.ADD(cell, cell, off))
-	itab := ref
-	data := off
-	a.Emit(
-		arm64.LDR(itab, cell, 0),
-		arm64.LDR(data, cell, 8),
-	)
-	return addr, itab, data, cell
-}
-
 // guardHeap loads a heap cell or branches to fail on a non-ref tag. Unlike
-// loadHeap, it preserves ref because queued side exits may still need the boxed
+// it preserves ref because queued side exits may still need the boxed
 // operand.
 func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.VReg, asm.VReg, asm.VReg) {
 	a := ctx.assembler
@@ -4158,15 +3942,8 @@ func (arm64Lowerer) guardHeap(ctx *lowering, ref asm.VReg, fail asm.Label) (asm.
 func (l arm64Lowerer) sliceHeader(ctx *lowering, data asm.VReg, base int16) (asm.VReg, asm.VReg) {
 	ptr := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	n := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	l.sliceHeaderTo(ctx, data, ptr, n, base)
+	ctx.assembler.Emit(arm64.LDR(ptr, data, base+sliceData), arm64.LDR(n, data, base+sliceLen))
 	return ptr, n
-}
-
-func (arm64Lowerer) sliceHeaderTo(ctx *lowering, data, ptr, n asm.VReg, base int16) {
-	ctx.assembler.Emit(
-		arm64.LDR(ptr, data, base+sliceData),
-		arm64.LDR(n, data, base+sliceLen),
-	)
 }
 
 // guardIndex uses one unsigned check: sign-extended negative i32 indexes are
@@ -4178,13 +3955,8 @@ func (arm64Lowerer) guardIndex(ctx *lowering, idx, n asm.VReg, fail asm.Label) {
 
 func (l arm64Lowerer) guardItab(ctx *lowering, got asm.VReg, want uintptr, fail asm.Label) {
 	v := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	l.guardItabTo(ctx, got, v, want, fail)
-}
-
-func (arm64Lowerer) guardItabTo(ctx *lowering, got, scratch asm.VReg, want uintptr, fail asm.Label) {
-	ctx.assembler.Emit(arm64.LDI(scratch, uint64(want))...)
-	ctx.assembler.Emit(arm64.CMP(got, scratch))
-	ctx.assembler.Emit(arm64.BCondLabel(arm64.OpBNE, fail))
+	ctx.assembler.Emit(arm64.LDI(v, uint64(want))...)
+	ctx.assembler.Emit(arm64.CMP(got, v), arm64.BCondLabel(arm64.OpBNE, fail))
 }
 
 // unwind appends one journal frame record per live symbolic frame,
@@ -4441,60 +4213,6 @@ func (l arm64Lowerer) clearLocals(ctx *lowering) {
 	}
 }
 
-// localScratch returns a flushed local register that is no longer live in the
-// operand stack, or an undefined register when none can be reused safely.
-func (l arm64Lowerer) localScratch(ctx *lowering) asm.VReg {
-	for fi := range ctx.frames {
-		frame := &ctx.frames[fi]
-		for idx, local := range frame.locals {
-			if l.carried(ctx, frame.base+idx) != nil {
-				continue
-			}
-			reg := local.reg
-			if reg.Width() == asm.WidthUndefined {
-				continue
-			}
-			used := false
-			for _, value := range ctx.values {
-				if value.reg.Width() != asm.WidthUndefined && value.reg.ID() == reg.ID() {
-					used = true
-					break
-				}
-			}
-			if !used {
-				return reg
-			}
-		}
-	}
-	return asm.VReg{}
-}
-
-// localReg reuses target's pre-barrier register only when no live operand or
-// reloaded local aliases it.
-func (l arm64Lowerer) localReg(ctx *lowering, target *activation, idx int) (asm.VReg, bool) {
-	reg := target.locals[idx].reg
-	if !ctx.reuseLocals || reg.Width() == asm.WidthUndefined {
-		return asm.VReg{}, false
-	}
-	for _, value := range ctx.values {
-		if value.reg.Width() != asm.WidthUndefined && value.reg.ID() == reg.ID() {
-			return asm.VReg{}, false
-		}
-	}
-	for fi := range ctx.frames {
-		frame := &ctx.frames[fi]
-		for li, value := range frame.locals {
-			if frame == target && li == idx || frame.state[li]&localLoaded == 0 {
-				continue
-			}
-			if value.reg.Width() != asm.WidthUndefined && value.reg.ID() == reg.ID() {
-				return asm.VReg{}, false
-			}
-		}
-	}
-	return reg, true
-}
-
 func (l arm64Lowerer) base(ctx *lowering, vStack asm.VReg) asm.VReg {
 	if ctx.leaf {
 		addr := ctx.pin(scratchSP)
@@ -4513,22 +4231,6 @@ func (l arm64Lowerer) baseTo(ctx *lowering, vStack, addr asm.VReg) {
 }
 
 func (l arm64Lowerer) boxHome(ctx *lowering, v value) (asm.VReg, bool) {
-	if ctx.spare.Width() != asm.WidthUndefined && ctx.spare.ID() != v.reg.ID() && v.raw {
-		var tag uint64
-		switch v.kind {
-		case types.KindI1:
-			tag = tagI1
-		case types.KindI8:
-			tag = tagI8
-		case types.KindI32:
-			tag = tagI32
-		default:
-			return l.box(ctx, v)
-		}
-		ctx.assembler.Emit(arm64.ANDI(ctx.spare, v.reg, maskI32))
-		ctx.assembler.Emit(arm64.MOVK(ctx.spare, uint16(tag>>48), 48))
-		return ctx.spare, true
-	}
 	return l.box(ctx, v)
 }
 
@@ -4665,15 +4367,9 @@ func (l arm64Lowerer) retain(ctx *lowering, fn int) {
 // guardRC keeps releases that could free objects in the interpreter.
 func (l arm64Lowerer) guardRC(ctx *lowering, addr, rcBase asm.VReg, fail asm.Label) asm.VReg {
 	rc := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	l.guardRCTo(ctx, rc, addr, rcBase, fail)
-	return rc
-}
-
-func (arm64Lowerer) guardRCTo(ctx *lowering, rc, addr, rcBase asm.VReg, fail asm.Label) {
 	a := ctx.assembler
-	a.Emit(arm64.LDRR(rc, rcBase, addr))
-	a.Emit(arm64.CMPI(rc, 1))
-	a.Emit(arm64.BCondLabel(arm64.OpBLE, fail))
+	a.Emit(arm64.LDRR(rc, rcBase, addr), arm64.CMPI(rc, 1), arm64.BCondLabel(arm64.OpBLE, fail))
+	return rc
 }
 
 func (l arm64Lowerer) refOnly(ctx *lowering, v asm.VReg, body func(asm.VReg)) {
@@ -4695,12 +4391,8 @@ func (l arm64Lowerer) refOnly(ctx *lowering, v asm.VReg, body func(asm.VReg)) {
 
 func (l arm64Lowerer) rcBase(ctx *lowering) asm.VReg {
 	base := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
-	l.rcBaseTo(ctx, base)
-	return base
-}
-
-func (arm64Lowerer) rcBaseTo(ctx *lowering, base asm.VReg) {
 	ctx.assembler.Emit(arm64.LDR(base, ctx.pin(scratchCtrl), int16(journalRC*8)))
+	return base
 }
 
 // lower emits one plan through the common block pipeline.
@@ -4753,8 +4445,6 @@ func lower(ctx *lowering, plan plan) bool {
 	}
 	for n := 0; n < len(ctx.work); n++ {
 		work := ctx.work[n]
-		ctx.reuseLocals = false
-		ctx.spare = asm.VReg{}
 		ctx.values = work.values
 		ctx.frames = work.frames
 		ctx.assembler.Bind(work.label)

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -435,7 +435,7 @@ var (
 							if value.Kind() != types.KindRef {
 								continue
 							}
-							i.release(value.Ref())
+							i.releaseBox(value)
 						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params-1:i.sp-1])
 						if f.release {
@@ -507,7 +507,7 @@ var (
 							if value.Kind() != types.KindRef {
 								continue
 							}
-							i.release(value.Ref())
+							i.releaseBox(value)
 						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params-1:i.sp-1])
 						if f.release {
@@ -50391,7 +50391,7 @@ var (
 							if value.Kind() != types.KindRef {
 								continue
 							}
-							i.release(value.Ref())
+							i.releaseBox(value)
 						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params:i.sp])
 						if f.release {
@@ -50463,7 +50463,7 @@ var (
 							if value.Kind() != types.KindRef {
 								continue
 							}
-							i.release(value.Ref())
+							i.releaseBox(value)
 						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params:i.sp])
 						if f.release {

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -431,6 +431,12 @@ var (
 						if base+params+locals > len(i.stack) {
 							panic(ErrStackOverflow)
 						}
+						for _, value := range i.stack[f.bp : i.sp-params-1] {
+							if value.Kind() != types.KindRef {
+								continue
+							}
+							i.release(value.Ref())
+						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params-1:i.sp-1])
 						if f.release {
 							i.release(f.ref)
@@ -496,6 +502,12 @@ var (
 						base = f.bp
 						if base+params+locals > len(i.stack) {
 							panic(ErrStackOverflow)
+						}
+						for _, value := range i.stack[f.bp : i.sp-params-1] {
+							if value.Kind() != types.KindRef {
+								continue
+							}
+							i.release(value.Ref())
 						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params-1:i.sp-1])
 						if f.release {
@@ -50375,6 +50387,12 @@ var (
 						if base+params+locals > len(i.stack) {
 							panic(ErrStackOverflow)
 						}
+						for _, value := range i.stack[f.bp : i.sp-params] {
+							if value.Kind() != types.KindRef {
+								continue
+							}
+							i.release(value.Ref())
+						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params:i.sp])
 						if f.release {
 							i.release(f.ref)
@@ -50440,6 +50458,12 @@ var (
 						base := f.bp
 						if base+params+locals > len(i.stack) {
 							panic(ErrStackOverflow)
+						}
+						for _, value := range i.stack[f.bp : i.sp-params] {
+							if value.Kind() != types.KindRef {
+								continue
+							}
+							i.release(value.Ref())
 						}
 						copy(i.stack[base:base+params], i.stack[i.sp-params:i.sp])
 						if f.release {


### PR DESCRIPTION
## Summary

Fixes #179 across threaded and ARM64 JIT execution.

- make `ARRAY_SET`/`STRUCT_SET` terminal exits obey the lowering contract
- unify native stores on the fresh-register heap path
- fix ref stores, including `BoxedNull`, and per-exit RC state
- release retiring frame refs on threaded `RETURN_CALL` and JIT tail transitions
- preserve returned refs before frame retirement
- keep generated interpreter output in sync
- simplify related JIT naming and remove obsolete store register-recycling state

## Validation

- `go test -race ./interp`
- `make generate`
- `make check-generated`
- `make lint`
- `make fuzz`
- `make benchmark-pr`

The change was also repeatedly exercised against the ARM64 deferred-ref, self-call, hoisted-container, and native struct/array store regressions.

Closes #179.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reference cleanup during calls, tail calls, frame replacement, and stack updates.
  - Prevented accidental release of the permanent null reference.
  - Improved safety when updating array and structure values, including reference handling and bounds checks.

- **Performance**
  - Expanded ARM64 native support for array and structure mutations.
  - Added graceful fallback to threaded execution when native register limits are exceeded.

- **Documentation**
  - Clarified memory management, heap behavior, frame ownership, tail calls, and native mutation support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->