### PR TITLE
refactor: string handling and improve memory management in the interp…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,38 +2,15 @@
 
 @../AGENTS.md
 
-## Claude Code Overlay
+Claude-specific additions to the shared contract above. Keep every shared rule in `AGENTS.md` so Claude Code and Codex stay aligned.
 
-This file imports the common agent contract from `AGENTS.md`. Keep shared rules there so Claude Code and Codex stay aligned.
+## Execution
 
-Use this file only for Claude-specific execution reminders.
+- For multi-file, uncertain, or risky work: explore, then plan, then edit.
+- Pick a runnable verification target before editing, not after.
+- Run the `AGENTS.md` Completion Gate before reporting done, committing a stage, or opening a PR.
+- Report evidence in the final summary: commands run, docs updated, and any intentionally skipped simplification, validation, or benchmark with its reason.
 
-## Required Claude Flow
+## Benchmarks
 
-1. Start from the imported `AGENTS.md` workflow.
-2. For multi-file, uncertain, or risky work, explore first, then plan, then edit.
-3. Give yourself a runnable verification target before editing whenever possible.
-4. Before reporting done, complete the `AGENTS.md` Completion Gate and the Claude checklist below.
-5. Show evidence in the final summary: tests run, docs updated, and any intentionally skipped simplification.
-
-## Claude Checklist
-
-Before reporting done, re-read every changed code and test file and verify:
-
-- `docs/coding-patterns.md` §2 and §16 were applied.
-- Top-down package/API/flow review and bottom-up review of every affected symbol are complete.
-- Every symbol has a current owner and reason; duplicate, wrapper, dead, mergeable, or private candidates were resolved.
-- Functions keep one abstraction level, single-use helpers remain inline unless they isolate real mechanics, and receiver-owned behavior is a method.
-- Declarations form a caller-before-callee staircase; fields and groups follow specification §9.
-- Public APIs remain minimal and compatible unless the user explicitly authorized a change.
-- Every test package uses the production package name plus `_test`, accesses no private symbol or representation, uses public observable behavior or a real artifact boundary, isolates arrange per subtest, and uses `require`.
-- No new test file was created without a matching production file, and new cases sit with the owner `docs/testing.md` assigns rather than in a new concept file.
-- Every applicable execution mode (threaded, fused, optimized, JIT) is covered, or the final summary states why a mode is not applicable.
-- Performance work has a baseline, profile-guided owner, correctness checks, and reproducible before/after evidence (specification §14).
-- Documentation, workflow, and conventions were updated in their specification §15 owner documents.
-
-Record any intentionally skipped simplification, validation, or benchmark target and its reason in the final summary.
-
-## Verification Commands
-
-Use `make benchmark-pr` for the quick benchmark report, `make benchmark-core` for the canonical suite, `make benchmark-compare` only for tagged external comparisons, `make fuzz` for bounded fuzz smoke, and `make coverage-check` for the recorded coverage floor.
+Use `make benchmark-pr` for a quick report and `make benchmark-core` for the canonical suite. `make benchmark-compare` is only for tagged external comparisons.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,7 +26,9 @@ Before reporting done, re-read every changed code and test file and verify:
 - Functions keep one abstraction level, single-use helpers remain inline unless they isolate real mechanics, and receiver-owned behavior is a method.
 - Declarations form a caller-before-callee staircase; fields and groups follow specification §9.
 - Public APIs remain minimal and compatible unless the user explicitly authorized a change.
-- Every test package uses the production package name plus `_test`, accesses no private symbol or representation, uses public observable behavior or a real artifact boundary, isolates arrange per subtest, matches production owners, and uses `require`.
+- Every test package uses the production package name plus `_test`, accesses no private symbol or representation, uses public observable behavior or a real artifact boundary, isolates arrange per subtest, and uses `require`.
+- No new test file was created without a matching production file, and new cases sit with the owner `docs/testing.md` assigns rather than in a new concept file.
+- Every applicable execution mode (threaded, fused, optimized, JIT) is covered, or the final summary states why a mode is not applicable.
 - Performance work has a baseline, profile-guided owner, correctness checks, and reproducible before/after evidence (specification §14).
 - Documentation, workflow, and conventions were updated in their specification §15 owner documents.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,9 @@
 
 Repository instructions for Codex and Claude Code. Codex reads this file directly; Claude Code loads `.claude/CLAUDE.md`, which imports it.
 
-`docs/coding-patterns.md` is the normative coding specification. Keep detailed rules there, not here. When instructions conflict, choose the more specific one and record the conflict in the final summary.
+`docs/coding-patterns.md` is the normative coding specification and is binding: a change that violates it is not complete, however well it works. Keep detailed rules there, not here.
+
+Read the section that governs the change before writing it. Nearby code is not a license - match an existing pattern only after confirming it is specification-compliant, because a non-compliant precedent will otherwise propagate. When instructions conflict, choose the more specific one and record the conflict in the final summary.
 
 ## Commands
 
@@ -66,7 +68,7 @@ Do not report work complete until all of these hold:
 1. Every changed file was re-read against `docs/coding-patterns.md` §2 and the task-specific sections.
 2. Every affected symbol still has a reason to exist; removable ones were removed, inlined, merged, narrowed, privatized, or renamed by role.
 3. A further simplification pass found no safe improvement.
-4. Tests follow §12 and assert only public observable behavior.
+4. Tests follow §12 and assert only public observable behavior. Any new test file has a matching production file, and every new case sits with the owner `docs/testing.md` assigns.
 5. Performance claims carry the reproducible before/after evidence §14 requires.
 6. Generated output was regenerated, not hand-edited, and `make check-generated` passes.
 7. Documentation was updated per the §15 owner matrix and unrelated user changes are absent.
@@ -113,8 +115,11 @@ Violations cause silent corruption or invalid execution.
 
 ## Tests
 
-Apply `docs/coding-patterns.md` §12; `docs/testing.md` carries ownership and opcode coverage status.
+Apply `docs/coding-patterns.md` §12. Before adding a **new test file**, read §12.1 and the layer/owner table in `docs/testing.md`; most new coverage belongs in an existing owner, not a new file.
 
+- Each test file MUST match the production file owning the symbol: `foo_test.go` requires `foo.go`. The only exceptions are the per-package `fuzz_test.go` and `example_test.go` conventions. Catch-all concept files (`test_helpers_test.go`, or a `string_test.go` with no `string.go`) MUST NOT be created.
+- `docs/testing.md` assigns the owner by layer: runtime opcode behavior belongs to `interp.TestInterpreter_Run`, semantic parity to the owning transform/optimizer/interpreter test, internal invariants to the nearest public or artifact boundary.
+- A change touching threaded, fused, optimized, or JIT paths MUST cover every applicable mode, or state in the final summary why a mode is not applicable.
 - One top-level test per public symbol: `Test<Func>` or `Test<Type>_<Method>`; sub-cases go under `t.Run`.
 - Every test package uses the production package name plus `_test` and acts as an importing client.
 - Tests access no private symbol or representation. Assert internal invariants through public behavior, generated output, or executable boundaries.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,8 @@ Violations cause silent corruption or invalid execution.
 - Threaded closure errors should `panic`; `interp.Run()` recovers and annotates `at=<ip>`.
 - A `frame` separates `addr` (template/code index for code/profiler/JIT) from `ref` (heap index released on `RETURN`). They differ for closures; every frame-creating `CALL`/fused path must set both, and non-closure paths must reset `upvals = nil`.
 - `closure.new` takes the function ref from the stack top and transfers ownership of the function ref plus upvals into the closure.
+- Strings carry no identity invariant: every string comparison and every `string`-keyed map compares content, so equal contents may occupy different refs. Only the constant pool deduplicates, at load time.
+- `string.concat` never mutates a published string. Joins share one append-only buffer per interpreter and always publish a new ref; growth only writes above every published length, `Reset` clears the buffer, and a speculative trace clone must start its own.
 - Compile-time threaded code advances `c.ip`; runtime threaded execution advances `f.ip`.
 - JIT handlers return `true` only after lowering the opcode and advancing `s.ip` by its exact width.
 - On JIT type mismatch or unsupported lowering, return `false` without mutating IR, stack, params, facts, or labels.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,8 @@
 # AGENTS.md
 
-Repository instructions for Codex and Claude Code. Codex reads this file directly; Claude Code loads `.claude/CLAUDE.md`, which imports it.
+Repository instructions for coding agents. Codex reads this file directly; Claude Code loads `.claude/CLAUDE.md`, which imports it.
 
-`docs/coding-patterns.md` is the normative coding specification and is binding: a change that violates it is not complete, however well it works. Keep detailed rules there, not here.
-
-Read the section that governs the change before writing it. Nearby code is not a license - match an existing pattern only after confirming it is specification-compliant, because a non-compliant precedent will otherwise propagate. When instructions conflict, choose the more specific one and record the conflict in the final summary.
+`docs/coding-patterns.md` is the normative coding specification and is binding: a change that violates it is not complete, however well it works. Read the section that governs a change before writing it, and match nearby code only after confirming that precedent is specification-compliant. When instructions conflict, follow the more specific one and record the conflict in the final summary.
 
 ## Commands
 
@@ -22,14 +20,7 @@ make benchmark-core    # full canonical package + VM kernel suite
 make benchmark-compare # external runtime comparisons (compare build tag)
 ```
 
-Run a single test or a subset:
-
-```bash
-go test -race -run TestFoo ./interp/...
-go test -race -run 'TestInterpreter_WithDebugger|TestDebugger_Breakpoints' ./interp
-```
-
-`./dist/minivm` starts the interactive assembly REPL.
+Run a subset with `go test -race -run TestFoo ./interp/...`. `./dist/minivm` starts the interactive assembly REPL.
 
 ## Architecture
 
@@ -39,19 +30,9 @@ program.Program -> threader -> []func(*Interpreter) -> Interpreter.Run()
                                                         `- hot segments promoted to native ARM64
 ```
 
-Execution is a closure-threaded interpreter with an adaptive trace JIT. A `program.Program` is threaded into one closure per instruction; a profiler promotes hot segments to native ARM64 and falls back to the threaded closures for anything the backend cannot lower.
+A `program.Program` is threaded into one closure per instruction; a profiler promotes hot segments to native ARM64 and falls back to the threaded closures for anything the backend cannot lower. `docs/architecture.md` owns package boundaries and execution flow; `docs/README.md` indexes every topic document.
 
-| Package | Responsibility |
-|---|---|
-| `program/` | bytecode + constants container |
-| `instr/` | opcode definitions, encoding, parsing, formatting |
-| `types/` | boxed values, arrays, structs, strings, NaN boxing |
-| `interp/` | interpreter, threaded compiler, JIT driver |
-| `asm/`, `asm/arm64/` | virtual-register IR, register allocation, executable buffers, ARM64 encoder/ABI |
-| `pass/`, `analysis/`, `transform/`, `optimize/` | pass pipeline, analyses, transforms, optimizer wiring |
-| `cli/`, `cmd/minivm/` | CLI command tree, REPL, entrypoint |
-
-**`interp/threaded.go` is generated.** Edit the emitters in `internal/cmd/geninterp/lower.go` (and fusion patterns in `pattern.go`), then run `make generate`. Never hand-edit the generated file.
+**`interp/threaded.go` is generated.** Edit the emitters in `internal/cmd/geninterp/lower.go` (fusion patterns in `pattern.go`), then run `make generate`. Never hand-edit the generated file.
 
 ## Workflow
 
@@ -61,6 +42,8 @@ Execution is a closure-threaded interpreter with an adaptive trace JIT. A `progr
 4. Review top-down from package contract to mechanics, and bottom-up across every affected symbol. Repository-wide refactors MUST inventory every production and test symbol.
 5. Validate the narrowest relevant behavior first, then the race, static, generated, and benchmark checks the change warrants.
 
+Prefer `codegraph` MCP tools over grep for structural questions (definitions, callers, call flow, impact).
+
 ### Completion Gate
 
 Do not report work complete until all of these hold:
@@ -68,7 +51,7 @@ Do not report work complete until all of these hold:
 1. Every changed file was re-read against `docs/coding-patterns.md` §2 and the task-specific sections.
 2. Every affected symbol still has a reason to exist; removable ones were removed, inlined, merged, narrowed, privatized, or renamed by role.
 3. A further simplification pass found no safe improvement.
-4. Tests follow §12 and assert only public observable behavior. Any new test file has a matching production file, and every new case sits with the owner `docs/testing.md` assigns.
+4. Tests follow §12 and sit with the owner `docs/testing.md` assigns.
 5. Performance claims carry the reproducible before/after evidence §14 requires.
 6. Generated output was regenerated, not hand-edited, and `make check-generated` passes.
 7. Documentation was updated per the §15 owner matrix and unrelated user changes are absent.
@@ -88,43 +71,27 @@ Do not report work complete until all of these hold:
 | Debugger / stepping | `docs/debugging.md`, `docs/profile.md` | `interp/debugger.go`, `cli/repl.go` | `go test -race -run 'TestInterpreter_WithDebugger\|TestDebugger_Breakpoints' ./interp` |
 | Concurrent VM use | `docs/architecture.md` (`interp/`) | `interp/pool.go` | `go test -race ./interp` |
 
-`docs/README.md` indexes the full documentation set. Prefer `codegraph` MCP tools over grep for structural questions (definitions, callers, call flow, impact).
-
 ## Key Invariants
 
-Violations cause silent corruption or invalid execution.
+Violations cause silent corruption or invalid execution. `docs/architecture.md` §Key Invariants holds the full list; `docs/jit-internals.md` holds the JIT contracts.
 
-- Heap index `0` is permanently `Null`.
-- `release()` must stay iterative, never recursive.
-- Threaded closure errors should `panic`; `interp.Run()` recovers and annotates `at=<ip>`.
-- A `frame` separates `addr` (template/code index for code/profiler/JIT) from `ref` (heap index released on `RETURN`). They differ for closures; every frame-creating `CALL`/fused path must set both, and non-closure paths must reset `upvals = nil`.
-- `closure.new` takes the function ref from the stack top and transfers ownership of the function ref plus upvals into the closure.
-- Strings carry no identity invariant: every string comparison and every `string`-keyed map compares content, so equal contents may occupy different refs. Only the constant pool deduplicates, at load time.
-- `string.concat` never mutates a published string. Joins share one append-only buffer per interpreter and always publish a new ref; growth only writes above every published length, `Reset` clears the buffer, and a speculative trace clone must start its own.
-- Compile-time threaded code advances `c.ip`; runtime threaded execution advances `f.ip`.
-- JIT handlers return `true` only after lowering the opcode and advancing `s.ip` by its exact width.
-- On JIT type mismatch or unsupported lowering, return `false` without mutating IR, stack, params, facts, or labels.
-- Executable buffers publish each code block from a fresh mapping inside `asm.Buffer.install`; it must sync the instruction cache on Darwin/ARM64 before sealing, and published mappings remain immutable and executable until `Buffer.Free`.
+- Heap index `0` is permanently `Null`, and `release()` must stay iterative, never recursive.
+- A `frame` separates `addr` (template/code index) from `ref` (heap index released on `RETURN`); they differ for closures, so every frame-creating `CALL`/fused path sets both and non-closure paths reset `upvals = nil`.
+- Strings compare by content, never identity; `string.concat` publishes a new ref and never mutates a published string.
+- Threaded closure errors `panic`; `interp.Run()` recovers and annotates `at=<ip>`. Compile-time threading advances `c.ip`, runtime execution advances `f.ip`.
+- A JIT handler returns `true` only after lowering the opcode and advancing `s.ip` by its exact width; on type mismatch or unsupported lowering it returns `false` without mutating IR, stack, params, facts, or labels.
+- Any JIT path that can hand state back to the interpreter — guard exit, fallback, spill decision, loop back-edge, hoisted container — has an exact contract in `docs/jit-internals.md`. Read it before touching one.
 - Offset-preserving passes must preserve byte offsets; `GVNPass` and `DCEPass` are the known exceptions and must repair branches/handlers.
-- `asm.Relaxer.Relax` implementations must return a replacement sequence that is already in range; `asm.Assembler.encode`'s fixpoint loop relies on this to relax each branch at most once and terminate.
-- A JIT trace fragment's own `status`, not the root trace's, decides how its ops lower when they run out; `tracePlan` must skip any `aborted` root or branch, so a fragment that recorded a partial, unsupported prefix is never planned or inlined into a parent trace.
-- `noSpill` (`interp/jit_plan.go`) must scan the whole plan (every block, not just the root's tail) before allowing spilling; when it rejects, `noSpillArch` forces `asm.Build` to fail instead of inserting a spill frame.
-- A deferred (slot-backed or const) ref operand carries no retain of its own; it must be owned or redeemed before any path that hands the flushed operand stack to the interpreter (ownership transfer, guard exit stub, trap-fallback/module-completion redeem, or a real call), and a committing (loop back-edge) flush rejects any live deferred ref.
-- Eligible call-free native loops keep up to seven read-written inline scalar locals authoritative in X19-X25 across the back-edge; every guard exit, fallback, yield, completion, state barrier, or continuation that can expose or reload VM slots must commit or preserve those registers first, and ineligible plans keep the per-iteration slot commit.
-- Hoisted container registers are valid only within one native loop entry: the prologue re-guards tag and itab on every entry, hoist eligibility requires a call-free loop plan with no store to the container local, `asm.OpPseudoUse` keeps the derived registers live across the native back-edge, and a loop fallback that resumes at the header must run the shadowed threaded handler once (the header slot holds the native stub, so redispatching it would livelock).
 
 ## Tests
 
-Apply `docs/coding-patterns.md` §12. Before adding a **new test file**, read §12.1 and the layer/owner table in `docs/testing.md`; most new coverage belongs in an existing owner, not a new file.
+Apply `docs/coding-patterns.md` §12; before adding a **new test file**, read §12.1 and the layer/owner table in `docs/testing.md`, because most new coverage belongs in an existing owner.
 
-- Each test file MUST match the production file owning the symbol: `foo_test.go` requires `foo.go`. The only exceptions are the per-package `fuzz_test.go` and `example_test.go` conventions. Catch-all concept files (`test_helpers_test.go`, or a `string_test.go` with no `string.go`) MUST NOT be created.
-- `docs/testing.md` assigns the owner by layer: runtime opcode behavior belongs to `interp.TestInterpreter_Run`, semantic parity to the owning transform/optimizer/interpreter test, internal invariants to the nearest public or artifact boundary.
+- Each test file MUST match the production file owning the symbol: `foo_test.go` requires `foo.go`. Only the per-package `fuzz_test.go` and `example_test.go` conventions are exempt; catch-all concept files MUST NOT be created.
 - A change touching threaded, fused, optimized, or JIT paths MUST cover every applicable mode, or state in the final summary why a mode is not applicable.
 - One top-level test per public symbol: `Test<Func>` or `Test<Type>_<Method>`; sub-cases go under `t.Run`.
-- Every test package uses the production package name plus `_test` and acts as an importing client.
-- Tests access no private symbol or representation. Assert internal invariants through public behavior, generated output, or executable boundaries.
-- Keep setup, execution, and assertions visible unless §12 permits a real reusable abstraction.
-- Use `require`, not `assert`.
+- Every test package uses the production package name plus `_test`, acts as an importing client, and accesses no private symbol or representation. Assert internal invariants through public behavior, generated output, or executable boundaries.
+- Keep setup, execution, and assertions visible unless §12 permits a real reusable abstraction, and use `require`, not `assert`.
 
 ## Documentation Maintenance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,143 +1,35 @@
 # AGENTS.md
 
-Repository instructions for Codex and Claude Code.
+Repository instructions for Codex and Claude Code. Codex reads this file directly; Claude Code loads `.claude/CLAUDE.md`, which imports it.
 
-This file is the common agent contract. Codex reads `AGENTS.md` directly. Claude Code loads `.claude/CLAUDE.md`, which imports this file and adds Claude-specific reminders.
+`docs/coding-patterns.md` is the normative coding specification. Keep detailed rules there, not here. When instructions conflict, choose the more specific one and record the conflict in the final summary.
 
-Keep this file terse and actionable. Put detailed coding rules in `docs/coding-patterns.md`, not here.
-
-## Instruction Priority
-
-1. Follow the user's latest explicit request first.
-2. Follow the closest applicable repository instruction file.
-3. Use this file as the root repository workflow contract.
-4. Apply `docs/coding-patterns.md` as the normative coding specification.
-5. Match nearby code only when it is more specific and specification-compliant.
-
-If instructions conflict, choose the more specific instruction and record the conflict in the final summary.
-
-## Quick Commands
+## Commands
 
 ```bash
 make init              # install goimports/godoc and go install ./...
 make test              # go test -race ./...
+make lint              # goimports -w . && go vet ./...
+make generate          # regenerate interp/threaded.go from internal/cmd/geninterp
+make check-generated   # fail if the generated file is stale
+make build             # build ./dist/minivm
+make fuzz              # bounded trust-boundary fuzz smoke
+make coverage-check    # enforce recorded total-coverage baseline
 make benchmark-pr      # quick pull-request benchmark report
 make benchmark-core    # full canonical package + VM kernel suite
-make benchmark-compare # optional external runtime comparisons
-make fuzz              # bounded trust-boundary fuzz smoke
-make lint              # goimports -w . && go vet ./...
-make coverage          # CI-style full test run with coverage.out
-make coverage-check    # enforce recorded total-coverage baseline
-make build             # build ./dist/minivm
-
-go test -race ./...
-go test -race -run TestFoo ./interp/...
-go test -race -run 'TestInterpreter_WithDebugger|TestDebugger_Breakpoints' ./interp
-
-./dist/minivm          # interactive assembly REPL
+make benchmark-compare # external runtime comparisons (compare build tag)
 ```
 
-## Required Workflow
+Run a single test or a subset:
 
-1. Run `git status --short`; never overwrite or commit unrelated user changes.
-2. Prefer structural tools for symbol ownership and call-flow exploration; use grep/read for literal text and final verification.
-3. Read task-relevant docs from the Task Router before changing code or tests.
-4. Apply `docs/coding-patterns.md` §2 and §16 to every code/test change, plus sections selected by §1.3.
-5. Review top-down from package contract to mechanics and bottom-up across every affected symbol. Repository-wide refactors MUST inventory every production and test symbol.
-6. Make the smallest correct change. Do not add speculative structure or preserve obsolete compatibility without an explicit contract.
-7. Validate the narrowest relevant behavior first, then race, static, generated, architecture, and benchmark checks warranted by the change.
-8. Run the Completion Gate before reporting done, committing a logical stage, opening a PR, or updating a PR.
+```bash
+go test -race -run TestFoo ./interp/...
+go test -race -run 'TestInterpreter_WithDebugger|TestDebugger_Breakpoints' ./interp
+```
 
-## Completion Gate
+`./dist/minivm` starts the interactive assembly REPL.
 
-Do not call work complete until every item is true:
-
-1. Every changed file was re-read against `docs/coding-patterns.md` §2 and the task-specific sections.
-2. Top-down ownership and bottom-up symbol reviews are complete at the requested scope.
-3. Every affected symbol has a current reason to exist; removable symbols were removed, inlined, merged, narrowed, privatized, or renamed by role.
-4. The chosen algorithm and control flow are the simplest correct options found without a measured performance regression.
-5. Another simplification pass found no safe improvement.
-6. Declarations form a caller-before-callee staircase and follow specification §9.
-7. Tests follow specification §12 and assert only public observable behavior.
-8. Performance claims include the reproducible evidence required by specification §14.
-9. Commits and documentation follow specification §15, and unrelated user changes are absent.
-10. Any intentionally skipped simplification or validation is recorded with its reason.
-
-## Coding Standard Map
-
-`docs/coding-patterns.md` is normative. Use this map only for routing.
-
-| Need | Read in `docs/coding-patterns.md` |
-|---|---|
-| Every code/test change | §2, §16 |
-| Functions, helpers, naming | §3-§4 |
-| Types, constructors, public APIs | §5 |
-| Package and runtime ownership | §6-§8 |
-| Declaration and field order | §9 |
-| Errors and panic/recover | §10 |
-| Concurrency and lifecycle | §11 |
-| Tests and public specifications | §12 |
-| Generated and architecture code | §13 |
-| Performance and benchmarks | §14 |
-| Commits and documentation | §15 |
-
-## Task Router
-
-| Task | Read | Usually edit | Verify |
-|---|---|---|---|
-| Opcode semantics | `docs/instruction-set.md`, `docs/guides/add-opcode.md` | `instr/`, `interp/threaded.go`, `interp/jit_arm64.go` | `go test ./instr ./interp` |
-| Runtime/stack/frame bug | `docs/architecture.md`, `docs/memory-model.md` | `interp/`, `types/` | `go test ./interp ./types` |
-| Ref/GC/host function | `docs/memory-model.md`, `docs/value-representation.md` | `interp/host.go`, `interp/threaded.go`, `types/` | `go test ./interp ./types` |
-| JIT/ARM64 backend | `docs/jit-internals.md`, `docs/value-representation.md` | `interp/jit*.go`, `asm/`, `asm/arm64/` | `go test ./asm/... ./interp` |
-| Optimizer/pass | `docs/pass-system.md` | `analysis/`, `transform/`, `optimize/`, `pass/` | `go test ./analysis ./transform ./optimize ./pass` |
-| Bytecode verification / untrusted input | `docs/verification.md` | `program/verify.go`, `instr/type.go` | `go test ./program ./interp` |
-| REPL/CLI | `docs/guides/repl.md` | `cli/`, `cmd/minivm/`, `instr/parse.go` | `go test ./cli/... ./cmd/minivm ./instr` |
-| Debugger / stepping | `docs/debugging.md`, `docs/profile.md` | `interp/debugger.go`, `cli/repl.go` | `go test -race -run 'TestInterpreter_WithDebugger|TestDebugger_Breakpoints' ./interp` |
-| Style-only change | `docs/coding-patterns.md` | touched package | package tests |
-| Concurrent VM use | `docs/architecture.md` (`interp/`) | `interp/pool.go` | `go test -race ./interp` |
-
-## Documentation Index
-
-Read only docs relevant to the task.
-
-| Document | Covers |
-|---|---|
-| `docs/architecture.md` | component map, package boundaries, ownership, execution flow |
-| `docs/value-representation.md` | NaN-boxed `Boxed`, kind encoding, I64 heap spilling, dynamic `ref` |
-| `docs/memory-model.md` | heap layout, reference counting, mark-and-sweep GC, invariants |
-| `docs/profile.md` | sampling profiles, tick cadence, JIT thresholds, metrics |
-| `docs/instruction-set.md` | full opcode reference: stack effects, operand widths, JIT status |
-| `docs/jit-internals.md` | trace JIT contracts: tracer, lowerer, frame journal, calls, loops |
-| `docs/pass-system.md` | analysis manager, transform pipeline, optimizer levels |
-| `docs/verification.md` | static bytecode validator: checks, error sentinels, limits |
-| `docs/coding-patterns.md` | style authority: principles, symbol review, naming, file layout, APIs, errors, tests, PR/docs rules |
-| `docs/guides/add-opcode.md` | end-to-end checklist for adding an instruction |
-| `docs/guides/add-architecture.md` | checklist for adding a JIT backend |
-| `docs/guides/repl.md` | REPL commands, bytecode debugging, branch syntax |
-| `docs/compatibility.md` | Go version, platform matrix, CGO, build tags, `unsafe` usage |
-| `docs/host-integration.md` | `HostFunction`, `Marshal`/`Unmarshal`, host objects |
-| `docs/testing.md` | executable specification layers, API ownership, opcode coverage |
-| `docs/benchmarks.md` | measured performance, cross-runtime comparison, methodology |
-| `docs/debugging.md` | debugger API, breakpoints, stepping, inspection |
-
-## Code Exploration
-
-Prefer `codegraph` MCP tools over grep/read for structural questions.
-
-| Question | Tool |
-|---|---|
-| Where is symbol X defined? | `codegraph_search` |
-| Focused context for a task/area | `codegraph_context` |
-| How does X reach Y? / trace the flow | `codegraph_trace` |
-| What calls Y? | `codegraph_callers` |
-| What does Y call? | `codegraph_callees` |
-| What breaks if I change Z? | `codegraph_impact` |
-| Show Y's signature/source | `codegraph_node` |
-| Survey several related symbols' source | `codegraph_explore` |
-| What files exist under path/ | `codegraph_files` |
-| Is the index healthy? | `codegraph_status` |
-
-## Project Map
+## Architecture
 
 ```text
 program.Program -> threader -> []func(*Interpreter) -> Interpreter.Run()
@@ -145,20 +37,56 @@ program.Program -> threader -> []func(*Interpreter) -> Interpreter.Run()
                                                         `- hot segments promoted to native ARM64
 ```
 
+Execution is a closure-threaded interpreter with an adaptive trace JIT. A `program.Program` is threaded into one closure per instruction; a profiler promotes hot segments to native ARM64 and falls back to the threaded closures for anything the backend cannot lower.
+
 | Package | Responsibility |
 |---|---|
 | `program/` | bytecode + constants container |
 | `instr/` | opcode definitions, encoding, parsing, formatting |
 | `types/` | boxed values, arrays, structs, strings, NaN boxing |
 | `interp/` | interpreter, threaded compiler, JIT driver |
-| `asm/` | virtual-register IR, register allocation, executable buffers |
-| `asm/arm64/` | ARM64 encoder, ABI, trampolines |
-| `pass/` | generic pass pipeline |
-| `analysis/` | shared analysis passes |
-| `transform/` | optimization transforms |
-| `optimize/` | optimization pipeline wiring |
-| `cli/` | CLI command tree, REPL, and shared value formatting |
-| `cmd/minivm/` | CLI entrypoint |
+| `asm/`, `asm/arm64/` | virtual-register IR, register allocation, executable buffers, ARM64 encoder/ABI |
+| `pass/`, `analysis/`, `transform/`, `optimize/` | pass pipeline, analyses, transforms, optimizer wiring |
+| `cli/`, `cmd/minivm/` | CLI command tree, REPL, entrypoint |
+
+**`interp/threaded.go` is generated.** Edit the emitters in `internal/cmd/geninterp/lower.go` (and fusion patterns in `pattern.go`), then run `make generate`. Never hand-edit the generated file.
+
+## Workflow
+
+1. Run `git status --short`; never overwrite or commit unrelated user changes.
+2. Read the Task Router docs for the area before changing code or tests.
+3. Apply `docs/coding-patterns.md` §2 and §16 to every code/test change, plus the sections its §1.3 selects.
+4. Review top-down from package contract to mechanics, and bottom-up across every affected symbol. Repository-wide refactors MUST inventory every production and test symbol.
+5. Validate the narrowest relevant behavior first, then the race, static, generated, and benchmark checks the change warrants.
+
+### Completion Gate
+
+Do not report work complete until all of these hold:
+
+1. Every changed file was re-read against `docs/coding-patterns.md` §2 and the task-specific sections.
+2. Every affected symbol still has a reason to exist; removable ones were removed, inlined, merged, narrowed, privatized, or renamed by role.
+3. A further simplification pass found no safe improvement.
+4. Tests follow §12 and assert only public observable behavior.
+5. Performance claims carry the reproducible before/after evidence §14 requires.
+6. Generated output was regenerated, not hand-edited, and `make check-generated` passes.
+7. Documentation was updated per the §15 owner matrix and unrelated user changes are absent.
+8. Any intentionally skipped simplification or validation is recorded with its reason.
+
+## Task Router
+
+| Task | Read | Usually edit | Verify |
+|---|---|---|---|
+| Opcode semantics | `docs/instruction-set.md`, `docs/guides/add-opcode.md` | `internal/cmd/geninterp/`, `instr/`, `interp/jit_arm64.go` | `go test ./instr ./interp` |
+| Runtime/stack/frame bug | `docs/architecture.md`, `docs/memory-model.md` | `interp/`, `types/` | `go test ./interp ./types` |
+| Ref/GC/host function | `docs/memory-model.md`, `docs/value-representation.md` | `interp/host.go`, `types/` | `go test ./interp ./types` |
+| JIT/ARM64 backend | `docs/jit-internals.md`, `docs/value-representation.md` | `interp/jit*.go`, `asm/`, `asm/arm64/` | `go test ./asm/... ./interp` |
+| Optimizer/pass | `docs/pass-system.md` | `analysis/`, `transform/`, `optimize/`, `pass/` | `go test ./analysis ./transform ./optimize ./pass` |
+| Bytecode verification / untrusted input | `docs/verification.md` | `program/verify.go`, `instr/type.go` | `go test ./program ./interp` |
+| REPL/CLI | `docs/guides/repl.md` | `cli/`, `cmd/minivm/`, `instr/parse.go` | `go test ./cli/... ./cmd/minivm ./instr` |
+| Debugger / stepping | `docs/debugging.md`, `docs/profile.md` | `interp/debugger.go`, `cli/repl.go` | `go test -race -run 'TestInterpreter_WithDebugger\|TestDebugger_Breakpoints' ./interp` |
+| Concurrent VM use | `docs/architecture.md` (`interp/`) | `interp/pool.go` | `go test -race ./interp` |
+
+`docs/README.md` indexes the full documentation set. Prefer `codegraph` MCP tools over grep for structural questions (definitions, callers, call flow, impact).
 
 ## Key Invariants
 
@@ -185,22 +113,21 @@ Violations cause silent corruption or invalid execution.
 
 ## Tests
 
-Use `docs/testing.md` for ownership and opcode coverage status. Before writing or modifying tests, read relevant docs from the Task Router and apply `docs/coding-patterns.md` §12.
+Apply `docs/coding-patterns.md` §12; `docs/testing.md` carries ownership and opcode coverage status.
 
-- One top-level test per public symbol: `Test<Func>` or `Test<Type>_<Method>`.
+- One top-level test per public symbol: `Test<Func>` or `Test<Type>_<Method>`; sub-cases go under `t.Run`.
 - Every test package uses the production package name plus `_test` and acts as an importing client.
-- Put sub-cases under `t.Run`; do not split them into parallel top-level tests.
-- Keep setup, execution, and assertions visible unless specification §12 permits a real reusable abstraction.
-- Tests access no private symbol or representation; internal invariants are asserted through public observable behavior, generated output, or executable boundaries.
+- Tests access no private symbol or representation. Assert internal invariants through public behavior, generated output, or executable boundaries.
+- Keep setup, execution, and assertions visible unless §12 permits a real reusable abstraction.
 - Use `require`, not `assert`.
 
 ## Documentation Maintenance
 
-Update docs when behavior, invariants, commands, architecture, pitfalls, workflow, or conventions change. Use the owner matrix in `docs/coding-patterns.md` §15:
+Update docs when behavior, invariants, commands, architecture, workflow, or conventions change, using the owner matrix in `docs/coding-patterns.md` §15:
 
-- workflow / convention rules -> update both `AGENTS.md` and `.claude/CLAUDE.md`
-- invariants / pitfalls -> update `docs/architecture.md`
-- opcode semantics / JIT status -> update `docs/instruction-set.md`
-- JIT contracts / assembler APIs -> update `docs/jit-internals.md`
+- workflow / convention rules -> `AGENTS.md` and `.claude/CLAUDE.md`
+- invariants / pitfalls -> `docs/architecture.md`
+- opcode semantics / JIT status -> `docs/instruction-set.md`
+- JIT contracts / assembler APIs -> `docs/jit-internals.md`
 
-Keep edits terse and factual; document current behavior only; preserve formatting; verify Markdown.
+Keep edits terse and factual, document current behavior only, and preserve formatting.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -135,12 +135,13 @@ Each `Interpreter` is single-goroutine-owned during use. `Pool` lets multiple go
 
 ### Heap and Values
 
-- Heap index `0` is permanently `Null`.
+- Heap index `0` is a permanent `Null` sentinel and is never reclaimed.
 - Only `KindRef` values participate in reference counting.
+- `release()` must stay iterative, never recursive.
 - Heap indices are stable and must not move.
 - Values that contain refs must implement `types.Traceable`.
 - Large `i64` values may spill to the heap while preserving bytecode semantics.
-- Heap index 0 is a permanent null sentinel and is never reclaimed.
+- Strings carry no identity invariant: every comparison and every `string`-keyed map compares content, so equal contents may occupy different refs. Only the constant pool deduplicates, at load time.
 
 See `memory-model.md` and `value-representation.md` for the detailed rules.
 
@@ -153,7 +154,7 @@ A frame separates the function/template address from the callable reference. `RE
 | `addr` | function/template slot used for code, profiling, and JIT |
 | `ref` | callable heap ref released on return |
 
-For plain functions, `addr == ref`. For closures, `addr` points to the function template and `ref` points to the closure object.
+For plain functions, `addr == ref`. For closures, `addr` points to the function template and `ref` points to the closure object. Every frame-creating `CALL` or fused path must set both fields, and non-closure paths must reset `upvals = nil`. `closure.new` takes the function ref from the stack top and transfers ownership of that ref plus the upvals into the closure.
 
 ### Threaded Dispatch
 
@@ -170,7 +171,7 @@ The interpreter requests native compilation through `compiler.Compile(i, root)` 
 - Native code is speculative and guarded.
 - Blocks with declared entry state carry no register state across edges; stack and dirty locals are materialized in VM memory.
 - Native-call slots are fixed for an interpreter lifetime and published atomically on function-entry installation.
-- Unsupported paths must fall back to threaded execution.
+- Unsupported paths must fall back to threaded execution. A handler returns `true` only after lowering the opcode and advancing `s.ip` by its exact width; on type mismatch or unsupported lowering it returns `false` without mutating IR, stack, params, facts, or labels.
 - JIT handlers must not duplicate complex interpreter behavior unless they can own all semantics.
 - Guard failure materializes VM state and resumes threaded dispatch.
 - ARM64 label branches are range-checked and relaxed only to replacements that are already in range; an unreachable target falls back to threaded execution.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -354,7 +354,7 @@ The `Traceable.Refs` benchmarks append into a caller-owned destination slice. Ev
 |---|---|---:|---:|---:|
 | `Array.Refs` | no refs | 3.148 | 0 | 0 |
 | `Array.Refs` | child refs | 2.678 | 0 | 0 |
-| `TypedMap.Refs` | child refs | 27.66 | 0 | 0 |
+| `TypedMap.Refs` | no refs | 27.66 | 0 | 0 |
 | `Map.Refs` | no refs | 2.137 | 0 | 0 |
 | `Map.Refs` | child refs | 31.73 | 0 | 0 |
 | `Struct.Refs` | no refs | 2.149 | 0 | 0 |
@@ -450,9 +450,13 @@ from joining.
 
 ```bash
 cd benchmarks
+# RecursiveFib/35 is excluded to match the published comparison protocol.
 go test -run='^$' \
-  -bench='^(BenchmarkControl|BenchmarkCall|BenchmarkMemory|BenchmarkNumeric)' \
-  -benchmem -benchtime=100ms -count=3 ./...
+  -bench='^(BenchmarkControl|BenchmarkMemory|BenchmarkNumeric|BenchmarkCall_(ClosureCounter|NQueens|Fannkuch|IndirectRecursiveFib))' \
+  -benchmem -benchtime=300ms -count=3 .
+go test -run='^$' \
+  -bench='^BenchmarkCall_RecursiveFib$/^20$' \
+  -benchmem -benchtime=300ms -count=3 .
 ```
 
 ### Recursive Fibonacci
@@ -468,7 +472,7 @@ go test -run='^$' \
 
 ```bash
 go test -run='^$' \
-  -bench='^(BenchmarkNew|BenchmarkInterpreter_(Reset|Push|Pop|PopBoxed|Peek|Alloc|Retain|Release|StructGetLocalFusion|ArrayGetContainerFusion)|BenchmarkPool_(Get|Put))$' \
+  -bench='^(BenchmarkNew|BenchmarkInterpreter_(Run|Reset|Push|Pop|PopBoxed|Peek|Alloc|Retain|Release|StructGetLocalFusion|ArrayGetContainerFusion)|BenchmarkPool_(Get|Put))$' \
   -benchmem -benchtime=100ms -count=3 ./interp
 ```
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,271 +1,510 @@
 # minivm Benchmarks
 
-> **A performance map for the VM — not a leaderboard.**
+Comparisons here are tier-matched: minivm `threaded` is a bytecode interpreter and is
+compared against interpreters, while `default` and `jit` promote hot code to native
+and are compared against Wazero's compiler backend. Native Go is a reference bound,
+not a peer.
+
+**Interpreter tier.** minivm `threaded` is the fastest interpreter measured on 13 of
+the 19 canonical kernels. The widest margins are `BranchTree` (13.8x faster than the
+next interpreter), `ClosureCounter` (2.34x), `RecursiveFib(20)` (1.81x over CPython),
+`StructTreeWalk` (1.77x), `Sieve` (1.66x), and `SpectralNorm` (1.49x over CPython).
+It trails on six: CPython leads `NQueens` (1.44x), `NBody` (1.38x), `Fannkuch`
+(1.25x), and `BinaryTrees` (1.24x), GopherLua leads `PermutationFlips` (1.14x), and
+`StringBuild` is effectively a tie with CPython (1.04x).
+
+**Native tier.** This tier is not yet competitive with Wazero. minivm `default` leads
+only `IterativeFib` (1.30x); Wazero is ahead on `Sieve`, `TypedArraySum`,
+`BranchTree`, `RecursiveFib(20)`, and `IndirectRecursiveFib`. Note also that `jit`'s
+eager policy is slower than adaptive `default` on call-heavy kernels - 382.17 µs
+versus 39.60 µs on `RecursiveFib(20)` - so `default` is the tier to quote.
+
+**`StringBuild`**, this corpus's weakest kernel, moved from 1.63x slower than CPython
+to parity (1.04x) after `string.concat` stopped interning every intermediate and
+began sharing one append-only buffer. The same change cut the kernel from
+1,724,160 B/op to 85,408 B/op, a 20.2x reduction, and made `threaded` 1.62x faster
+in absolute terms.
+
+> **Environment**: August 13, 2026 - Apple M4 Pro - darwin/arm64 - Go 1.26.2 - CPython 3.13
 >
-> Current results: **August 10, 2026 · Apple M4 Pro · darwin/arm64 · Go 1.26.2**
+> **Statistics**: every comparison table below is the median of `-benchtime=300ms -count=3`.
+> All runtimes execute the same fixture and pass the same correctness check.
 
-This document records the current performance characteristics of minivm, the workloads that define them, and the methodology behind every comparison.
+This document does not reduce a runtime to one aggregate score. Each operation is
+compared directly against every control that can run it, and `ns/op`, `B/op`, and
+`allocs/op` are recorded together.
 
-## Performance at a glance
+## 1. Controls
 
-The most useful baseline for minivm is not a foreign language runtime. It is the Go ecosystem around it: native Go shows the cost of interpretation itself, while Go-based interpreters show how minivm compares with other implementations written in the same language and running on the same host.
+| Tier | Control | Meaning |
+|---|---|---|
+| Interpreter | minivm `threaded` | `WithThreshold(-1)`. Generated threaded execution, JIT disabled. |
+| Interpreter | CPython, Tengo, GopherLua, Goja, gpython, Yaegi | Bytecode or AST interpreters with no native code generation. |
+| Native | minivm `default` | Default adaptive execution; hot entries promote to the native tier. |
+| Native | minivm `jit` | `WithThreshold(0)`. Eager profiling and compilation policy. |
+| Native | Wazero | WebAssembly runtime using its optimizing compiler backend on arm64. |
+| Reference | Native Go | The same kernel written directly in Go. A lower bound, not a peer. |
 
-### Go ecosystem comparison
+A cell reads `—` when that runtime has no fixture for the operation. Bold marks the
+fastest runtime **within its own tier**.
 
-`threaded` is the appropriate minivm baseline for this comparison because it measures the VM without native JIT specialization. Results below are medians from the same three-sample run on this machine.
+## 2. Reading these results
 
-| Workload | minivm threaded | Native Go | wazero | Tengo | gopher-lua | Goja |
-|---|---:|---:|---:|---:|---:|---:|
-| RecursiveFib(20) | **323 µs** | 14.6 µs | 33.9 µs | 889 µs | 1.11 ms | 1.52 ms |
-| StructTreeWalk | **158 µs** | 12.8 µs | — | 281 µs | 549 µs | 447 µs |
-| BinaryTrees | **1.20 ms** | 118 µs | — | — | — | — |
+Read the tables row by row rather than through an aggregate. Each row is an
+independent statement with its own tier controls and memory behavior.
 
-These are not a leaderboard: each runtime has a different value model and execution architecture. The useful signal is the relative cost of executing the same deterministic workload. minivm's threaded interpreter is substantially closer to native Go and other Go-based runtimes on these kernels than the slower general-purpose interpreters in the comparison suite.
+Compare within a tier. An interpreter losing to a compiler is not a finding, and
+`threaded` beating `default` on a kernel is a statement about promotion policy, not
+about interpreters. `ClosureCounter`, `AllocationGraph`, `PermutationFlips`,
+`StructTreeWalk`, and `BinaryTrees` currently run fastest under `threaded`.
 
-### Current runtime profile
+Allocation behavior is a first-class result. `IterativeFib`, `TypedArraySum`,
+`BranchTree`, `Mandelbrot`, `RecursiveFib`, and `IndirectRecursiveFib` hold 0 B/op and
+0 allocs/op. CPython's `B/op` and `allocs/op` measure only the Go side of the
+comparison harness, not CPython's own allocator, so compare CPython on `ns/op` alone.
 
-| Signal | Current result | What it tells us |
-|---|---:|---|
-| Allocation-free execution | **0 B / 0 allocs** on several hot kernels | the VM can execute tight scalar loops without Go heap pressure |
-| StructTreeWalk | **159 µs / 768 B / 8 allocs** | reusable struct storage keeps recursive object workloads bounded |
-| BinaryTrees | **1.23 ms / 768 B / 8 allocs** | object-heavy execution stays allocation-light |
-| SpectralNorm | **42 µs / 648 B / 6 allocs** | numeric kernels benefit strongly from the adaptive tier |
-| StringBuild | **536–616 µs / 1.72 MB / 5,118 allocs** | strings remain the clearest allocation-heavy workload |
+For optimization work, reproduce the row, inspect the owning hot path, make the
+smallest change, rerun the same command, and compare medians for all three metrics
+before making a performance claim.
 
-The strongest signal is the combination: minivm keeps many VM operations allocation-free, reuses short-lived objects, and can move compute-heavy kernels toward native execution when the adaptive tier is effective. String construction remains a distinct workload with materially different allocation behavior.
+## 3. Canonical VM operations
 
-> **Current caveat:** Fannkuch `default` and `jit` still fail a correctness assertion in the `compare` suite. The issue is tracked separately in **#184**.
+### Control
 
-## How to reproduce
+#### `IterativeFib(30)`
 
-### External reference appendix
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **510.6 ns** | 0 | 0 |
+|  | Tengo | 9.27 µs | 90,592 | 61 |
+|  | GopherLua | 651.0 ns | 160 | 0 |
+|  | Goja | 2.21 µs | 368 | 20 |
+|  | gpython | 2.57 µs | 2,448 | 88 |
+|  | Yaegi | 2.84 µs | 2,036 | 101 |
+| Native | minivm `default` | **40.5 ns** | 0 | 0 |
+|  | minivm `jit` | 51.6 ns | 0 | 0 |
+|  | Wazero | 52.8 ns | 8 | 1 |
+| Reference | Native Go | 9.6 ns | 0 | 0 |
 
-```bash
-cd benchmarks
-go test -tags=compare -run='^$' \
-  -bench='^(BenchmarkNumeric_(NBody|SpectralNorm|Mandelbrot|MatMul)|BenchmarkCall_(NQueens|Fannkuch)|BenchmarkMemory_(BinaryTrees|SortStress|StringBuild))$' \
-  -benchmem -benchtime=300ms -count=3 ./...
-```
+#### `Sieve(256)`
 
-This appendix is supplementary. External runtimes are useful for context, but they are not the primary performance baseline for minivm; the Go ecosystem comparison above is.
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **11.40 µs** | 1,048 | 2 |
+|  | Tengo | 57.17 µs | 122,504 | 1,611 |
+|  | GopherLua | 22.85 µs | 18,416 | 44 |
+|  | Goja | 43.29 µs | 1,872 | 25 |
+|  | gpython | 35.62 µs | 5,704 | 30 |
+|  | Yaegi | 18.92 µs | 1,800 | 37 |
+| Native | minivm `default` | 1.64 µs | 1,048 | 2 |
+|  | minivm `jit` | 1.68 µs | 1,048 | 2 |
+|  | Wazero | **677.0 ns** | 8 | 1 |
+| Reference | Native Go | 268.6 ns | 0 | 0 |
+
+### Calls
+
+#### `RecursiveFib(20)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **310.71 µs** | 0 | 0 |
+|  | CPython | 562.79 µs | 26 | 0 |
+|  | Tengo | 930.21 µs | 319,347 | 28,655 |
+|  | GopherLua | 1.07 ms | 704 | 2 |
+|  | Goja | 1.52 ms | 4,680 | 39 |
+|  | gpython | 3.89 ms | 9,807,919 | 109,494 |
+|  | Yaegi | 4.50 ms | 8,302,177 | 192,840 |
+| Native | minivm `default` | 39.60 µs | 0 | 0 |
+|  | minivm `jit` | 382.17 µs | 0 | 0 |
+|  | Wazero | **33.20 µs** | 8 | 1 |
+| Reference | Native Go | 14.61 µs | 0 | 0 |
+
+#### `IndirectRecursiveFib`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **589.99 µs** | 0 | 0 |
+|  | Tengo | 944.71 µs | 319,359 | 28,655 |
+|  | GopherLua | 941.72 µs | 704 | 2 |
+|  | Goja | 1.37 ms | 4,680 | 39 |
+|  | gpython | 3.90 ms | 10,158,202 | 109,494 |
+|  | Yaegi | 10.98 ms | 13,059,853 | 394,041 |
+| Native | minivm `default` | 487.40 µs | 0 | 0 |
+|  | minivm `jit` | 695.33 µs | 0 | 0 |
+|  | Wazero | **42.34 µs** | 8 | 1 |
+| Reference | Native Go | 15.72 µs | 0 | 0 |
+
+#### `ClosureCounter(128)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **2.52 µs** | 64 | 2 |
+|  | Tengo | 13.59 µs | 92,272 | 261 |
+|  | GopherLua | 5.88 µs | 151 | 3 |
+|  | Goja | 10.11 µs | 1,264 | 13 |
+|  | gpython | 27.29 µs | 58,312 | 659 |
+|  | Yaegi | 33.69 µs | 34,784 | 786 |
+| Native | minivm `default` | 3.35 µs | 64 | 2 |
+|  | minivm `jit` | **3.32 µs** | 64 | 2 |
+| Reference | Native Go | 34.9 ns | 0 | 0 |
+
+#### `NQueens(7)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | 325.88 µs | 120 | 6 |
+|  | CPython | **226.15 µs** | 11 | 0 |
+|  | gpython | 782.30 µs | 363,441 | 4,156 |
+| Native | minivm `default` | **154.25 µs** | 120 | 6 |
+|  | minivm `jit` | 155.75 µs | 120 | 6 |
+| Reference | Native Go | 4.21 µs | 0 | 0 |
+
+#### `Fannkuch(6)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | 539.64 µs | 34,608 | 1,442 |
+|  | CPython | **430.81 µs** | 20 | 0 |
+|  | gpython | 1.57 ms | 1,367,678 | 16,944 |
+| Native | minivm `default` | **522.91 µs** | 34,608 | 1,442 |
+|  | minivm `jit` | 706.67 µs | 34,608 | 1,442 |
+| Reference | Native Go | 17.54 µs | 17,280 | 720 |
+
+### Memory and data structures
+
+#### `TypedArraySum(256)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **3.00 µs** | 0 | 0 |
+|  | Tengo | 15.83 µs | 94,208 | 513 |
+|  | GopherLua | 3.42 µs | 4,000 | 15 |
+|  | Goja | 13.29 µs | 2,080 | 238 |
+|  | gpython | 7.63 µs | 2,496 | 246 |
+|  | Yaegi | 4.23 µs | 296 | 8 |
+| Native | minivm `default` | 314.9 ns | 0 | 0 |
+|  | minivm `jit` | 509.3 ns | 0 | 0 |
+|  | Wazero | **161.0 ns** | 8 | 1 |
+| Reference | Native Go | 70.8 ns | 0 | 0 |
+
+#### `AllocationGraph(128)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **5.27 µs** | 1,024 | 128 |
+|  | Tengo | 13.60 µs | 96,288 | 388 |
+|  | GopherLua | 6.45 µs | 14,376 | 256 |
+|  | Goja | 25.84 µs | 78,016 | 770 |
+|  | gpython | 5.84 µs | 5,712 | 266 |
+|  | Yaegi | 13.81 µs | 1,492 | 142 |
+| Native | minivm `default` | 7.19 µs | 1,024 | 128 |
+|  | minivm `jit` | **7.09 µs** | 1,024 | 128 |
+| Reference | Native Go | 944.1 ns | 1,024 | 128 |
+
+#### `PermutationFlips(24,64)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | 114.89 µs | 14,336 | 128 |
+|  | Tengo | 321.12 µs | 292,858 | 9,856 |
+|  | GopherLua | **101.03 µs** | 78,808 | 451 |
+|  | Goja | 262.24 µs | 122,504 | 765 |
+|  | gpython | 228.35 µs | 115,560 | 2,496 |
+|  | Yaegi | 174.84 µs | 112,600 | 5,591 |
+| Native | minivm `default` | 151.37 µs | 14,336 | 128 |
+|  | minivm `jit` | **134.93 µs** | 14,336 | 128 |
+| Reference | Native Go | 1.08 µs | 0 | 0 |
+
+#### `StructTreeWalk(9)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **158.75 µs** | 768 | 8 |
+|  | Tengo | 280.54 µs | 458,379 | 5,114 |
+|  | GopherLua | 545.66 µs | 818,512 | 11,253 |
+|  | Goja | 448.41 µs | 558,961 | 6,149 |
+|  | gpython | 1.26 ms | 2,570,669 | 34,797 |
+|  | Yaegi | 846.99 µs | 1,422,624 | 35,306 |
+| Native | minivm `default` | **178.06 µs** | 768 | 8 |
+|  | minivm `jit` | 178.08 µs | 768 | 8 |
+| Reference | Native Go | 12.97 µs | 16,368 | 1,023 |
+
+#### `BinaryTrees(4..6)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | 1.23 ms | 768 | 8 |
+|  | CPython | **991.16 µs** | 45 | 0 |
+|  | gpython | 9.87 ms | 19,457,623 | 280,714 |
+| Native | minivm `default` | 1.35 ms | 768 | 8 |
+|  | minivm `jit` | **1.34 ms** | 768 | 8 |
+| Reference | Native Go | 118.71 µs | 201,936 | 8,414 |
+
+#### `SortStress(128,2)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **323.05 µs** | 5,136 | 512 |
+|  | CPython | 339.27 µs | 16 | 0 |
+|  | gpython | 870.26 µs | 23,448 | 2,034 |
+| Native | minivm `default` | **73.14 µs** | 5,136 | 512 |
+|  | minivm `jit` | 75.04 µs | 5,136 | 512 |
+| Reference | Native Go | 4.38 µs | 1,024 | 2 |
+
+#### `StringBuild(512)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | 383.91 µs | 85,408 | 4,107 |
+|  | CPython | **368.74 µs** | 17 | 0 |
+|  | gpython | 1.25 ms | 2,104,720 | 21,456 |
+| Native | minivm `default` | 392.13 µs | 85,408 | 4,107 |
+|  | minivm `jit` | **287.92 µs** | 85,408 | 4,107 |
+| Reference | Native Go | 138.19 µs | 855,892 | 5,001 |
+
+### Numeric
+
+#### `BranchTree(96)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **618.7 ns** | 0 | 0 |
+|  | Tengo | 16.98 µs | 95,384 | 660 |
+|  | GopherLua | 8.56 µs | 2,464 | 9 |
+|  | Goja | 13.91 µs | 1,992 | 196 |
+|  | gpython | 12.75 µs | 2,168 | 203 |
+|  | Yaegi | 10.56 µs | 1,832 | 308 |
+| Native | minivm `default` | 253.3 ns | 0 | 0 |
+|  | minivm `jit` | 247.3 ns | 0 | 0 |
+|  | Wazero | **167.0 ns** | 16 | 1 |
+| Reference | Native Go | 78.4 ns | 0 | 0 |
+
+#### `NBody(5,100)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | 319.44 µs | 504 | 14 |
+|  | CPython | **230.89 µs** | 11 | 0 |
+|  | gpython | 1.17 ms | 382,762 | 34,975 |
+| Native | minivm `default` | **100.73 µs** | 504 | 14 |
+|  | minivm `jit` | 100.78 µs | 504 | 14 |
+| Reference | Native Go | 3.39 µs | 0 | 0 |
+
+#### `SpectralNorm(24,2)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **279.86 µs** | 648 | 6 |
+|  | CPython | 415.89 µs | 20 | 0 |
+|  | gpython | 1.94 ms | 2,457,137 | 52,718 |
+| Native | minivm `default` | **41.84 µs** | 648 | 6 |
+|  | minivm `jit` | 41.87 µs | 648 | 6 |
+| Reference | Native Go | 2.79 µs | 576 | 3 |
+
+#### `Mandelbrot(16x16)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **144.06 µs** | 0 | 0 |
+|  | CPython | 181.52 µs | 9 | 0 |
+|  | gpython | 684.61 µs | 324,977 | 23,643 |
+| Native | minivm `default` | 49.06 µs | 0 | 0 |
+|  | minivm `jit` | **48.84 µs** | 0 | 0 |
+| Reference | Native Go | 2.99 µs | 0 | 0 |
+
+#### `MatMul(16)`
+
+| Tier | Runtime | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| Interpreter | minivm `threaded` | **176.90 µs** | 6,216 | 6 |
+|  | CPython | 210.72 µs | 10 | 0 |
+|  | gpython | 701.09 µs | 90,712 | 9,350 |
+| Native | minivm `default` | **37.94 µs** | 6,216 | 6 |
+|  | minivm `jit` | 37.96 µs | 6,216 | 6 |
+| Reference | Native Go | 2.66 µs | 6,144 | 3 |
+
+## 4. Direct interpreter operations
+
+These measure the cost of a public operation itself. Unlike the workload tables there is no `default`/`threaded`/`jit` axis for an API that has none, so each operation lists its own contrast cases instead.
+
+| Operation | Case | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `New` | Empty | 4,133 | 35,290 | 28 |
+| `New` | Program | 4,376 | 35,368 | 31 |
+| `New` | JITEnabled | 4,584 | 35,368 | 31 |
+| `Reset` | Scalar | 47.19 | 0 | 0 |
+| `Reset` | Heap | 84.72 | 8 | 1 |
+| `Reset` | JITState | **38.87** | 0 | 0 |
+| `Push` | Scalar | 21.87 | 0 | 0 |
+| `Push` | Reference | 100.5 | 16 | 1 |
+| `Pop` | — | 18.70 | 0 | 0 |
+| `PopBoxed` | — | 19.52 | 0 | 0 |
+| `Peek` | — | 2.032 | 0 | 0 |
+| `Alloc` | — | 21.10 | 0 | 0 |
+| `Retain` | — | 20.48 | 0 | 0 |
+| `Release` | — | 20.38 | 0 | 0 |
+| `Pool.Get` | Uncontended | 30.64 | 0 | 0 |
+| `Pool.Get` | Miss | 3.270 µs | 35,144 | 25 |
+| `Pool.Get` | SharedJITMiss | 15.464 µs | 44,760 | 284 |
+| `Pool.Get` | ParallelRoundTrip | 327.0 ns | 1 | 0 |
+| `Pool.Put` | Uncontended | 136.3 ns | 0 | 0 |
+| `StructGetLocalFusion` | — | 227.112 ms | 221,640 | 33 |
+| `ArrayGetContainerFusion` | global | 3.619 ms | 16 | 2 |
+| `ArrayGetContainerFusion` | upvalue | 3.719 ms | 72 | 4 |
+
+## 5. Reference traversal operations
+
+The `Traceable.Refs` benchmarks append into a caller-owned destination slice. Every traversal case is allocation-free in the current measurement.
+
+| Operation | Case | ns/op | B/op | allocs/op |
+|---|---|---:|---:|---:|
+| `Array.Refs` | no refs | 3.148 | 0 | 0 |
+| `Array.Refs` | child refs | 2.678 | 0 | 0 |
+| `TypedMap.Refs` | child refs | 27.66 | 0 | 0 |
+| `Map.Refs` | no refs | 2.137 | 0 | 0 |
+| `Map.Refs` | child refs | 31.73 | 0 | 0 |
+| `Struct.Refs` | no refs | 2.149 | 0 | 0 |
+| `Struct.Refs` | child refs | 2.231 | 0 | 0 |
+
+## 6. Interpreter execution primitives
+
+Each `BenchmarkInterpreter_Run` row is the time to execute a whole bytecode program, not the latency of a single opcode. Setup, reset, and result validation stay outside the timer.
+
+| Operation | Threaded | Fused | JITWarm | B/op | allocs/op |
+|---|---:|---:|---:|---:|---:|
+| `i32.const_nop_returns_i32` | 16.60 ns | 16.82 ns | 23.05 ns | 0 | 0 |
+| `i32.const_i32.const_drop_returns_i32` | 20.64 ns | 20.09 ns | 21.94 ns | 0 | 0 |
+| `i32.const_dup_returns_i32_i32` | 19.31 ns | 19.36 ns | 21.89 ns | 0 | 0 |
+| `i32.const_i32.const_swap_returns_i32_i32` | 20.36 ns | **20.23 ns** | 23.41 ns | 0 | 0 |
+| `i32.const_i32.const_i32.const_select_returns_i32` | 21.55 ns | **21.51 ns** | 23.48 ns | 0 | 0 |
+| `br_i32.const_i32.const_returns_i32` | 16.99 ns | **16.30 ns** | 22.91 ns | 0 | 0 |
+| `i32.const_br_if_i32.const_i32.const_returns_i32` | 20.58 ns | **17.55 ns** | 21.92 ns | 0 | 0 |
+| `i32.const_br_table_i32.const_i32.const_returns_i32` | 20.37 ns | **19.74 ns** | 23.68 ns | 0 | 0 |
+| `const.get_call_i32.const_return_returns_i32` | 31.67 ns | **21.23 ns** | 23.89 ns | 0 | 0 |
+| `const.get_call_i32.const_i32.const_return_returns_i32_i32` | 33.19 ns | **21.47 ns** | 24.69 ns | 0 | 0 |
+| `i32.const_const.get_return_call_local.get_i32.const_i32.add_return_returns_i32` | 37.31 ns | **22.88 ns** | — | 0 | 0 |
+| `i32.const_yield_reports_yield` | 166.0 ns | 171.8 ns | 214.8 ns | 0 | 0 |
+| `const.get_call_through_yield_i32.const_i32.add_return_returns_i32` | 86.24 ns | **84.27 ns** | — | 112 | 1 |
+| `const.get_call_coro.done_i32.const_yield_return_returns_i1` | 53.31 ns | **53.12 ns** | — | 112 | 1 |
+| `const.get_call_coro.value_i32.const_yield_return_returns_i32` | 64.21 ns | 64.79 ns | — | 112 | 1 |
+| `i32.const_global.set_global.get_returns_i32` | 21.08 ns | — | — | 0 | 0 |
+
+## 7. Benchmark interpretation
+
+Within minivm, the strongest signal is the threaded-to-native gap on tight arithmetic:
+`IterativeFib` runs 510.6 ns threaded versus 40.5 ns under `default`, and `Sieve`
+11.40 µs versus 1.64 µs. That gap does not appear on call-heavy or allocation-heavy
+kernels, where `threaded` is often the fastest minivm tier.
+
+In the interpreter tier the six losses cluster by shape. CPython leads `NQueens`,
+`NBody`, `Fannkuch`, and `BinaryTrees` - all dominated by allocating and discarding
+short-lived objects, where CPython's free lists beat a reference-counted heap on top
+of Go's allocator. That is the clearest remaining target, and it is a memory-management
+problem rather than a dispatch problem.
+
+In the native tier, Wazero is ahead on five of the six kernels it shares. minivm's
+native tier only lowers a subset of opcodes and falls back to threaded execution for
+the rest, so kernels touching unlowered opcodes never stay native. `jit`'s eager
+policy also compiles paths that adaptive `default` correctly declines, which is why
+it loses badly on `RecursiveFib(20)`.
+
+Allocation results are bounded: object-heavy kernels such as `StructTreeWalk` and
+`BinaryTrees` stay at 768 B/op and 8 allocs/op. `StringBuild` is no longer an outlier
+at 85,408 B/op; its remaining 4,107 allocs/op come from the per-token UTF-32 array and
+string cells rather than from joining.
+
+## 8. Benchmark fixture inventory
+
+| Benchmark | Fixture | Main signal |
+|---|---|---|
+| `IterativeFib` | n=30 | integer arithmetic, locals, loops, branches |
+| `Sieve` | n=256 | typed-array allocation and indexed mutation |
+| `RecursiveFib` | n=20,35 | call frames, recursion, returns |
+| `IndirectRecursiveFib` | fixed recursive workload | first-class function references |
+| `ClosureCounter` | 128 iterations | closure creation, captures, calls |
+| `NQueens` | n=7 | recursive backtracking and array state |
+| `Fannkuch` | n=6 | recursive permutation search and array slices |
+| `TypedArraySum` | 256 elements | indexed loads and accumulation |
+| `AllocationGraph` | depth=128 | allocation, linking, traversal, release |
+| `PermutationFlips` | size=24, depth=64 | boxed array allocation and mutation |
+| `StructTreeWalk` | depth=9 | struct allocation and recursive traversal |
+| `BinaryTrees` | depth=4..6 | recursive object construction and checksum |
+| `SortStress` | n=128, rounds=2 | integer arithmetic and in-place sorting |
+| `StringBuild` | 512 tokens | string allocation, concat, length, UTF-32 encoding |
+| `BranchTree` | 96 nodes, input=37 | comparisons and branch-heavy control flow |
+| `NBody` | 5 bodies, 100 steps | f64 arithmetic and function calls |
+| `SpectralNorm` | n=24, 2 iterations | f64 division and nested loops |
+| `Mandelbrot` | 16×16, max_iter=50 | tight f64 loop and early return |
+| `MatMul` | n=16 | f64 multiply-accumulate |
+
+## 9. Methodology
+
+- Canonical workloads validate their fixed result/checksum before timing and validate the result after timing.
+- Program construction, bytecode verification, JIT warmup, reset, cleanup, and expected-result computation stay outside the measured operation unless they are the benchmark's named operation.
+- Inputs are deterministic.
+- Canonical comparison tables use `-benchtime=300ms -count=3` and report the median of three sequential samples.
+- Direct interpreter/API tables use a `100ms × 3` protocol.
+- Every runtime in a comparison table ran the same fixture in the same command and passed the same correctness check.
+- `make benchmark-core` remains the repository-wide smoke command, but the full command includes many non-runtime benchmarks and can exceed interactive command limits.
+- `RecursiveFib(35)` is excluded from the comparison tables: at roughly 1.2 s per operation the slower external runtimes make a `count=3` sweep impractical.
+- CPython's `B/op` and `allocs/op` reflect only the Go side of the harness, so only its `ns/op` is comparable.
+- Cross-runtime comparisons must not be inferred from an incomplete run.
+
+## 10. Reproduction commands
 
 ### Canonical VM kernels
 
 ```bash
 cd benchmarks
-go test -run='^$' -bench='.' -benchmem -benchtime=100ms -count=1 ./...
+go test -run='^$' \
+  -bench='^(BenchmarkControl|BenchmarkCall|BenchmarkMemory|BenchmarkNumeric)' \
+  -benchmem -benchtime=100ms -count=3 ./...
 ```
 
-### Interpreter/API benchmarks
+### Recursive Fibonacci
+
+```bash
+cd benchmarks
+go test -run='^$' \
+  -bench='^BenchmarkCall_RecursiveFib/(20|35)$' \
+  -benchmem -benchtime=100ms -count=3 ./...
+```
+
+### Interpreter/API
 
 ```bash
 go test -run='^$' \
-  -bench='^(BenchmarkNew|BenchmarkInterpreter_(Reset|Push|Pop|PopBoxed|Peek|Alloc|Retain|Release)|BenchmarkPool_(Get|Put))$' \
-  -benchmem -benchtime=300ms -count=3 ./interp
+  -bench='^(BenchmarkNew|BenchmarkInterpreter_(Reset|Push|Pop|PopBoxed|Peek|Alloc|Retain|Release|StructGetLocalFusion|ArrayGetContainerFusion)|BenchmarkPool_(Get|Put))$' \
+  -benchmem -benchtime=100ms -count=3 ./interp
 ```
 
 ### Reference traversal
 
 ```bash
-go test -run='^$' -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
-  -benchmem -benchtime=300ms -count=3 ./types
+go test -run='^$' \
+  -bench='^Benchmark(Array|Struct|TypedMap|Map)_Refs$' \
+  -benchmem -benchtime=100ms -count=3 ./types
 ```
 
-## Go mode comparison
+### External comparison
 
-The canonical kernel snapshot below is the main comparison surface for minivm. It shows how `default`, `threaded`, and `jit` behave on the same workloads.
+```bash
+cd benchmarks
+# RecursiveFib/35 is excluded: at ~1.2 s/op the slower runtimes make count=3 impractical.
+go test -tags=compare -run='^$' \
+  -bench='^(BenchmarkControl|BenchmarkMemory|BenchmarkNumeric|BenchmarkCall_(ClosureCounter|NQueens|Fannkuch|IndirectRecursiveFib))' \
+  -benchmem -benchtime=300ms -count=3 .
+go test -tags=compare -run='^$' \
+  -bench='^BenchmarkCall_RecursiveFib$/^20$' \
+  -benchmem -benchtime=300ms -count=3 .
+```
 
-- **Numeric kernels are strongest in the adaptive tier.** SpectralNorm, Mandelbrot, and MatMul are best in `default` or `jit` mode.
-- **Threaded mode is the interpreter baseline.** It is the cleanest way to measure dispatch and ownership costs without native specialization.
-- **Object reuse keeps allocation-heavy kernels bounded.** BinaryTrees and StructTreeWalk use 768 B/op and 8 allocs/op in threaded mode.
-- **StringBuild is still the clearest allocation-heavy hotspot.** It remains a useful target for future work.
-
-The comparison is intentionally narrow. Different execution modes change how quickly a workload reaches native code or stays on threaded dispatch, but they still share the same value model, safety boundaries, and benchmark fixtures.
-
-## VM execution modes
-
-| Mode | Construction | Meaning |
-|---|---|---|
-| `default` | `interp.New(prog)` | adaptive execution; hot entries may become native |
-| `threaded` | `interp.New(prog, interp.WithThreshold(-1))` | generated threaded execution with JIT disabled |
-| `jit` | `interp.New(prog, interp.WithThreshold(0))` | eager profiling/compilation policy |
-
-A `jit` benchmark name does **not** by itself prove native execution. Native entry must be confirmed by the runtime or profiler. On platforms without a native backend, execution remains threaded.
-
-## Canonical kernel snapshot
-
-The complete kernel sweep below is a current snapshot, not a statistical regression gate. It was measured with `-benchtime=100ms -count=1`.
-
-| Workload | default | threaded | jit |
-|---|---:|---:|---:|
-| RecursiveFib(20) | 39.7 µs | 326.0 µs | 390.4 µs |
-| RecursiveFib(35) | 49.6 ms | 424.8 ms | 532.6 ms |
-| IndirectRecursiveFib | 491 µs | 577 µs | 693 µs |
-| ClosureCounter | 3.26 µs | 2.51 µs | 3.24 µs |
-| NQueens | 154 µs | 321 µs | 154 µs |
-| IterativeFib | 27.6 ns | 508 ns | 44.6 ns |
-| Sieve | 1.54 µs | 11.1 µs | 1.54 µs |
-| TypedArraySum | 294 ns | 3.59 µs | 497 ns |
-| AllocationGraph | 6.85 µs | 5.06 µs | 6.86 µs |
-| PermutationFlips | 124 µs | 77.7 µs | 113 µs |
-| StructTreeWalk | 178 µs | **159 µs** | 177 µs |
-| BinaryTrees | 1.34 ms | **1.23 ms** | 1.34 ms |
-| SortStress | 73.6 µs | 320 µs | 73.1 µs |
-| StringBuild | 628 µs | 616 µs | 536 µs |
-| BranchTree | 253 ns | 588 ns | 253 ns |
-| NBody | 99.2 µs | 313 µs | 99.6 µs |
-| SpectralNorm | 41.9 µs | 278 µs | 42.3 µs |
-| Mandelbrot | 49.2 µs | 140 µs | 49.6 µs |
-| MatMul | 38.2 µs | 175 µs | 38.0 µs |
-
-Fannkuch `default` and `jit` are omitted from this table because their correctness assertion currently fails; see #184.
-
-## Interpreter and API costs
-
-These benchmarks measure named public operations. Setup and paired operations stay outside the reported operation interval where the benchmark defines them that way.
-
-| Area | Operation | ns/op | B/op | allocs/op |
-|---|---|---:|---:|---:|
-| Construction | empty program | 3,409 | 35,338 | 29 |
-| Construction | program, JIT disabled | 3,430 | 35,416 | 32 |
-| Construction | program, JIT enabled | 3,445 | 35,416 | 32 |
-| Reset | scalar state | 28.3 | 0 | 0 |
-| Reset | heap state | 38.5 | 8 | 1 |
-| Stack | Push scalar | 20.2 | 0 | 0 |
-| Stack | Push reference | 43.7 | 16 | 1 |
-| Stack | Pop | 8.75 | 0 | 0 |
-| Stack | PopBoxed | 7.74 | 0 | 0 |
-| Stack | Peek | 1.83 | 0 | 0 |
-| Heap | Alloc | 37.6 | 16 | 1 |
-| Heap | Retain | 19.9 | 0 | 0 |
-| Heap | Release | 18.3 | 0 | 0 |
-| Pool | Get, hit | 34.0 | 0 | 0 |
-| Pool | Get, miss | 3,251 | 35,192 | 26 |
-| Pool | Put | 116.5 | 0 | 0 |
-
-The important signal here is not that every operation is tiny; it is that the hot reuse path is allocation-free. Pool misses and interpreter construction naturally pay for fresh runtime state.
-
-## Threaded execution
-
-Representative complete `Run` cases use `WithTick(1)` and `WithThreshold(-1)`. Setup opcodes are included in the timed run; reset and result validation are not.
-
-| Case | ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| i32.const_nop_returns_i32 | 17.55 | 0 | 0 |
-| i32.const_returns_i32 | 17.55 | 0 | 0 |
-| i32.add | 19.86 | 0 | 0 |
-| i64.add | 19.86 | 0 | 0 |
-| f32.add | 19.86 | 0 | 0 |
-| f64.add | 19.86 | 0 | 0 |
-| i32.to_i64_s | 19.86 | 0 | 0 |
-| br | 18.15 | 0 | 0 |
-| br_if | 20.54 | 0 | 0 |
-| br_table | 20.37 | 0 | 0 |
-| direct bytecode call | 30.97 | 0 | 0 |
-
-These are whole-program cases, not isolated opcode latency measurements.
-
-## JIT activation boundary
-
-`ColdBackedge` measures a 256-iteration loop with a deliberately high threshold. The function remains below the sample threshold and therefore uses the ordinary generated branch handler.
-
-| Case | ns/op | B/op | allocs/op |
-|---|---:|---:|---:|
-| cold unconditional backedge | 2,039 | 0 | 0 |
-
-The benchmark protects the cold path: backedge observation is sampled periodically instead of adding a callback or header scan to every cold loop iteration.
-
-## Reference traversal
-
-`types.Traceable.Refs` accepts caller-provided storage, keeping the canonical traversal cases allocation-free.
-
-| Value | Case | ns/op | B/op | allocs/op |
-|---|---|---:|---:|---:|
-| array | no child refs | 2.69 | 0 | 0 |
-| array | child refs | 2.38 | 0 | 0 |
-| struct | no child refs | 1.81 | 0 | 0 |
-| struct | child refs | 1.92 | 0 | 0 |
-| typed map | child refs | 24.47 | 0 | 0 |
-| dynamic map | no child refs | 1.84 | 0 | 0 |
-| dynamic map | child refs | 26.70 | 0 | 0 |
-
-## What the numbers mean
-
-### Strong areas
-
-- Stable numeric loops benefit most from the adaptive native tier.
-- Threaded struct workloads now have almost no allocation overhead after pooling.
-- Reference traversal is allocation-free when callers reuse storage.
-
-### Current opportunities
-
-1. **StringBuild** — the highest allocation volume and the clearest remaining hotspot.
-2. **NBody / NQueens** — threaded mode is slower than the adaptive tier, suggesting execution-path rather than allocation work.
-3. **BinaryTrees** — threaded and adaptive modes are already close, so remaining cost should be profiled before changing RC or struct construction.
-4. **Fannkuch correctness** — `default` and `jit` need investigation independently of performance work (#184).
-
-Do not optimize from a single ratio. First reproduce the row, then profile the dominant path, then compare a focused before/after run.
-
-## Methodology
-
-- Canonical workloads have correctness checks with fixed results or checksums.
-- The compare suite performs correctness validation before timing and uses untimed warmup/allocation preparation where the fixture requires it. It is supplementary to the main Go mode comparisons.
-- Focused comparison tables use `-benchtime=300ms -count=3` and report the median of three sequential samples.
-- The complete kernel snapshot uses `-benchtime=100ms -count=1`; it is a snapshot, not a regression gate.
-- minivm `default`, `threaded`, and `jit` differ through execution thresholds.
-- External parsing, compilation, module creation, and lookup stay outside timers where the runtime API permits.
-- Optional external runtime comparisons launch the foreign runtime once per benchmark process, run the workload inside the foreign timer, and verify the expected result before timing.
-- Cross-runtime comparison is optional and requires the `compare` build tag.
-
-### Comparison runtimes
-
-| Runtime | Version |
-|---|---|
-| CPython | 3.13.x |
-| wazero | v1.12.0 |
-| gopher-lua | v1.1.2 |
-| Tengo | v2.17.0 |
-| Goja | v0.0.0-20260311135729-065cd970411c |
-| gpython | v0.2.0 |
-| Yaegi | v0.16.1 |
-
-## Benchmark ownership
+## 11. Ownership
 
 | Location | Responsibility |
 |---|---|
 | `interp/*_test.go` | interpreter construction, execution, reset, stack/heap, pool, JIT lifecycle |
 | `types/*_test.go` | reference traversal contracts |
-| `benchmarks/` | runtime-neutral kernels and optional external comparisons |
+| `benchmarks/` | runtime-neutral kernel workloads and optional external comparisons |
 
-A benchmark should have a correctness test owned by the same public behavior or canonical fixture. Service-specific workloads do not define VM performance baselines.
-
-## Running the suite
-
-| Command | Purpose |
-|---|---|
-| `make benchmark-pr` | fast pull-request smoke suite |
-| `make benchmark-core` | local canonical benchmark run |
-| `make benchmark-nightly` | repeated scheduled suite |
-| `make benchmark-compare` | optional external runtime comparison appendix |
-
-For performance claims, keep benchmark processes sequential and record the host, Go version, command, and sample count. Use repeated measurements and `benchstat` before declaring a regression or improvement.
-
-## Benchmark reading guide
-
-**Start with “Performance at a glance.”** It shows minivm against the most relevant Go implementations and then summarizes its current runtime profile.
-
-**Use the external reference appendix for broader context.** Those runtimes are supplementary comparisons, not the primary performance baseline.
-
-**Use “Canonical kernel snapshot” for execution-tier behavior.** It shows where `default`, `threaded`, and `jit` differ.
-
-**Use “Interpreter and API costs” for micro-optimization.** These rows identify the cost of individual runtime operations.
-
-**Use “Methodology” before publishing numbers.** Absolute timings only make sense with their machine, command, sample count, and benchmark semantics.
-
-## Related documentation
-
-- `docs/profile.md` — runtime counters and profiling
-- `docs/jit-internals.md` — ARM64 trace JIT behavior
-- `docs/instruction-set.md` — opcode semantics and JIT support
-- `docs/compatibility.md` — supported platforms
-- GitHub issue **#184** — Fannkuch `default`/`jit` correctness failure
+A benchmark belongs next to the public behavior it measures. Every benchmark fixture should retain a correctness check and deterministic input.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -19,12 +19,6 @@ only `IterativeFib` (1.30x); Wazero is ahead on `Sieve`, `TypedArraySum`,
 eager policy is slower than adaptive `default` on call-heavy kernels - 382.17 µs
 versus 39.60 µs on `RecursiveFib(20)` - so `default` is the tier to quote.
 
-**`StringBuild`**, this corpus's weakest kernel, moved from 1.63x slower than CPython
-to parity (1.04x) after `string.concat` stopped interning every intermediate and
-began sharing one append-only buffer. The same change cut the kernel from
-1,724,160 B/op to 85,408 B/op, a 20.2x reduction, and made `threaded` 1.62x faster
-in absolute terms.
-
 > **Environment**: August 13, 2026 - Apple M4 Pro - darwin/arm64 - Go 1.26.2 - CPython 3.13
 >
 > **Statistics**: every comparison table below is the median of `-benchtime=300ms -count=3`.
@@ -409,9 +403,9 @@ policy also compiles paths that adaptive `default` correctly declines, which is 
 it loses badly on `RecursiveFib(20)`.
 
 Allocation results are bounded: object-heavy kernels such as `StructTreeWalk` and
-`BinaryTrees` stay at 768 B/op and 8 allocs/op. `StringBuild` is no longer an outlier
-at 85,408 B/op; its remaining 4,107 allocs/op come from the per-token UTF-32 array and
-string cells rather than from joining.
+`BinaryTrees` stay at 768 B/op and 8 allocs/op. `StringBuild` holds 85,408 B/op, and
+its 4,107 allocs/op come from the per-token UTF-32 array and string cells rather than
+from joining.
 
 ## 8. Benchmark fixture inventory
 

--- a/docs/fusion.md
+++ b/docs/fusion.md
@@ -50,7 +50,7 @@ Threaded patterns are not a cross-backend registry. An ARM64 specialization is a
 
 RC elimination is local and proven by each closed lowering. A slot or constant source may be borrowed only when its ref is fully consumed inside the fused sequence. `REF_NULL` may omit its balanced retain/release, and `DUP` may avoid creating temporary ownership when its duplicate is consumed locally.
 
-Borrowed refs never enter the VM stack, frame/global/upvalue storage, calls, yields, or control-flow boundaries. String constants remain standalone because loading interns them. Declared I64 slots retain numeric ownership semantics even when a large current value is heap-promoted.
+Borrowed refs never enter the VM stack, frame/global/upvalue storage, calls, yields, or control-flow boundaries. String constants remain standalone because the constant pool deduplicates them at load. Declared I64 slots retain numeric ownership semantics even when a large current value is heap-promoted.
 
 ## Generation and Checks
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -205,7 +205,7 @@ The built-in codec builds and caches one conversion plan per Go type.
 | `uint`, `uint64`, `uintptr` | `I64` | raw bits preserved |
 | `float32` | `F32` | |
 | `float64` | `F64` | |
-| `string` | `String` ref | heap-allocated and interned by the interpreter |
+| `string` | `String` ref | heap-allocated by the interpreter; equal contents need not share a ref |
 | `[]bool` | `I1Array` | one byte per element |
 | `[]int8`, `[]uint8`, `[]byte` | `I8Array` | raw bits preserved |
 | `[]int16`, `[]int32`, `[]uint16`, `[]uint32` | `I32Array` | raw bits preserved for unsigned values |

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -213,7 +213,8 @@ The built-in codec builds and caches one conversion plan per Go type.
 | `[]float32` | `F32Array` | |
 | `[]float64` | `F64Array` | |
 | other `[]T` | `*Array` ref | generic fallback |
-| `map[K]V` | `*Map` ref | heap-allocated |
+| `map[K]V` with a primitive or `string` key | `*TypedMap[K]` ref | key type drives the concrete map; content-keyed |
+| other `map[K]V` | `*Map` ref | heap ref identity keys |
 | data-only struct | `*Struct` ref | exported fields only |
 | struct with methods or unexported fields | `*HostObject` ref | preserves methods or hidden state |
 | defined scalar with methods | underlying scalar | keeps primitive fast path |

--- a/docs/instruction-set.md
+++ b/docs/instruction-set.md
@@ -249,8 +249,8 @@ Do not group multiple opcodes in one row. Keep this table in opcode-value order 
 | Strings | `STRING_NEW_UTF32` | `string.new_utf32` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Strings | `STRING_LEN` | `string.len` | ✅ | 🔲 | native typed-array-length-style length read |
 | Strings | `STRING_CONCAT` | `string.concat` | ⬜ | 🔲 | allocation stays interpreter-owned |
-| Strings | `STRING_EQ` | `string.eq` | ◐ | 🔲 | native boxed compare; two owned operands fall back |
-| Strings | `STRING_NE` | `string.ne` | ◐ | 🔲 | native boxed compare; two owned operands fall back |
+| Strings | `STRING_EQ` | `string.eq` | ⬜ | 🔲 | content compare stays threaded |
+| Strings | `STRING_NE` | `string.ne` | ⬜ | 🔲 | content compare stays threaded |
 | Strings | `STRING_LT` | `string.lt` | ⬜ | 🔲 | string comparisons stay threaded |
 | Strings | `STRING_GT` | `string.gt` | ⬜ | 🔲 | string comparisons stay threaded |
 | Strings | `STRING_LE` | `string.le` | ⬜ | 🔲 | string comparisons stay threaded |
@@ -303,9 +303,15 @@ Coroutine tail calls preserve the current coroutine. On completion, `CORO_VALUE`
 
 `ARRAY_APPEND` moves values into the array. `ARRAY_DELETE` moves the removed element to the stack. `ARRAY_GET` and `ARRAY_SLICE` retain copied ref elements. `ARRAY_SLICE` consumes the source array ref; use `DUP` first to keep it.
 
+### Strings
+
+Every string comparison, `string.eq` and `string.ne` included, compares content. Two strings with equal content compare equal whatever heap refs they occupy, so a computed join equals the literal it spells. All six comparisons require string operands and trap `ErrTypeMismatch` on any other ref; use `REF_EQ`, `REF_NE`, or `REF_IS_NULL` to test identity or null.
+
+`string.concat` allocates a fresh ref and never mutates a string already published. Successive joins share one append-only byte buffer, so accumulating a string in a loop costs no repeated prefix copy.
+
 ### Maps
 
-Map keys use primitive value identity for `i1`, `i8`, `i32`, `i64`, `f32`, and `f64`. Ref keys use heap ref identity. Missing keys read as the element zero value. `MAP_LOOKUP` also returns an `i1` presence flag.
+Map keys use primitive value identity for `i1`, `i8`, `i32`, `i64`, `f32`, and `f64`. A map whose declared key type is `string` keys by content. Every other ref key uses heap ref identity. Missing keys read as the element zero value. `MAP_LOOKUP` also returns an `i1` presence flag.
 
 ### Structured Errors
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -103,9 +103,11 @@ a copy. Two rules keep this safe without consulting reference counts:
   trace clone starts its own. A committed append must never rewrite bytes a
   captured string already published.
 
-The buffer keeps its backing array alive until the next join replaces it. That
-bounds the retention at one buffer, which is smaller than the per-join copies it
-replaces.
+`tail` keeps its current backing array alive until the next join replaces it, and
+a reallocating append leaves earlier refs owning the array they were published
+from. Retained storage is therefore not bounded to one buffer: every still
+reachable string holds its own backing array, exactly as separately copied
+strings would.
 
 ## Traceable Values
 

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -88,6 +88,25 @@ transfer, a guard exit stub, or a trap-fallback/module-completion redeem — tak
 exactly one retain first, so net counts stay exact and symmetric on every path,
 including deopts. See `docs/jit-internals.md` (Reference Ownership).
 
+## Shared String Buffers
+
+`string.concat` results share one append-only byte buffer per `Interpreter`.
+When a join's left operand ends exactly where that buffer ends, the right
+operand is appended past that end and the result is published as a **new** heap
+ref viewing the longer prefix; any other left operand starts a fresh buffer from
+a copy. Two rules keep this safe without consulting reference counts:
+
+- A published string is never mutated. Growth only writes above every published
+  length, so each ref keeps its own content however many holders it has, and a
+  reallocating append leaves earlier refs pointing at the old array.
+- The buffer is per-interpreter state, so `Reset` clears it and a speculative
+  trace clone starts its own. A committed append must never rewrite bytes a
+  captured string already published.
+
+The buffer keeps its backing array alive until the next join replaces it. That
+bounds the retention at one buffer, which is smaller than the per-join copies it
+replaces.
+
 ## Traceable Values
 
 Heap objects that can contain refs implement `types.Traceable`.

--- a/docs/value-representation.md
+++ b/docs/value-representation.md
@@ -215,7 +215,9 @@ Arrays, structs, maps, closures, host objects, and iterators that hold refs must
 
 ## Strings, Arrays, Maps, and Iterators
 
-Strings created by interpreter opcodes and the marshaler are interned per `Interpreter`. Equal string contents share one heap ref while live.
+Strings are plain heap values with no identity invariant: equal contents may occupy different heap refs. Every string comparison compares content, and a map declared with a `string` key type keys by content, so nothing depends on two equal strings sharing a ref. Only the constant pool deduplicates, and only at load time, so identical string literals in one program still share one ref.
+
+`string.concat` results share one append-only byte buffer per `Interpreter`. A join whose left operand ends exactly where that buffer ends is published as a new ref viewing the longer prefix; bytes below any published length are never rewritten, so each string keeps its own content regardless of reference count.
 
 `TypeI1` and `TypeI8` are first-class stack kinds, not element-only types.
 

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -794,18 +794,6 @@ func constHandler(current step, input value) jen.Code {
 		jen.Switch(jen.Add(boxed).Dot("Kind").Call()).Block(
 			jen.Case(jen.Qual("github.com/siyul-park/minivm/types", "KindRef")).Block(
 				jen.Id("addr").Op(":=").Add(boxed).Dot("Ref").Call(),
-				jen.If(
-					jen.List(jen.Id("str"), jen.Id("ok")).Op(":=").Id("c").Dot("heap").Index(jen.Id("addr")).Assert(jen.Qual("github.com/siyul-park/minivm/types", "String")),
-					jen.Id("ok"),
-				).Block(
-					jen.Id("text").Op(":=").String().Call(jen.Id("str")),
-					jen.Return(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(
-						jen.If(jen.Id("i").Dot("sp").Op("==").Len(jen.Id("i").Dot("stack"))).Block(jen.Panic(jen.Id("ErrStackOverflow"))),
-						jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp")).Op("=").Qual("github.com/siyul-park/minivm/types", "BoxRef").Call(jen.Int().Call(jen.Id("i").Dot("intern").Call(jen.Id("text")))),
-						jen.Id("i").Dot("sp").Op("++"),
-						jen.Id("i").Dot("fr").Dot("ip").Op("+=").Lit(width(current.op)),
-					)),
-				),
 				jen.Return(jen.Func().Params(jen.Id("i").Op("*").Id("Interpreter")).Block(owned...)),
 			),
 		),
@@ -3580,6 +3568,7 @@ func mapClear() jen.Code {
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int64")))).Block(jen.Id("m").Dot("Clear").Call(jen.Func().Params(jen.Id("value").Add(jen.Id("types").Dot("Boxed"))).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value"))))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32")))).Block(jen.Id("m").Dot("Clear").Call(jen.Func().Params(jen.Id("value").Add(jen.Id("types").Dot("Boxed"))).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value"))))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.Id("m").Dot("Clear").Call(jen.Func().Params(jen.Id("value").Add(jen.Id("types").Dot("Boxed"))).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value"))))),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.Id("m").Dot("Clear").Call(jen.Func().Params(jen.Id("value").Add(jen.Id("types").Dot("Boxed"))).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("value"))))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.Id("m").Dot("Clear").Call(jen.Func().Params(jen.Id("entry").Add(jen.Id("types").Dot("MapEntry"))).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("entry").Dot("Key")),
 					jen.Id("i").Dot("releaseBox").Call(jen.Id("entry").Dot("Value"))))),
 				jen.Default().Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch")))),
@@ -3606,6 +3595,8 @@ func mapDelete() jen.Code {
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Delete").Call(jen.Id("key").Dot("F32").Call())),
 					jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Delete").Call(jen.Id("key").Dot("F64").Call())),
+					jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Delete").Call(jen.String().Call(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("key"))))),
 					jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.Var().Add(jen.List(jen.Id("k"))).Add(jen.Id("types").Dot("MapKey")),
 					jen.List(jen.Id("keyRef")).Op(":=").List(jen.Lit(0)),
@@ -3652,6 +3643,8 @@ func mapGet() jen.Code {
 					jen.If(jen.Id("ok")).Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("value"))).Else().Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("m").Dot("Zero")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("value"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Get").Call(jen.Id("key").Dot("F64").Call())),
 					jen.If(jen.Id("ok")).Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("value"))).Else().Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("m").Dot("Zero")))),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("value"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Get").Call(jen.String().Call(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("key"))))),
+					jen.If(jen.Id("ok")).Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("value"))).Else().Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("m").Dot("Zero")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.Var().Add(jen.List(jen.Id("k"))).Add(jen.Id("types").Dot("MapKey")),
 					jen.List(jen.Id("keyRef")).Op(":=").List(jen.Lit(0)),
 					jen.List(jen.Id("drop")).Op(":=").List(jen.Id("false")),
@@ -3684,7 +3677,7 @@ func mapIter() jen.Code {
 			jen.List(jen.Id("ref")).Op(":=").List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))),
 			jen.If(jen.Id("ref").Dot("Kind").Call().Op("!=").Add(jen.Id("types").Dot("KindRef"))).Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch"))),
 			jen.List(jen.Id("addr")).Op(":=").List(jen.Id("ref").Dot("Ref").Call()),
-			jen.Switch(jen.Id("i").Dot("heap").Index(jen.Id("addr")).Assert(jen.Type())).Block(jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int8"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("bool"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int32"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int64"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64"))), jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(),
+			jen.Switch(jen.Id("i").Dot("heap").Index(jen.Id("addr")).Assert(jen.Type())).Block(jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int8"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("bool"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int32"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int64"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64"))), jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string"))), jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(),
 				jen.Default().Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch")))),
 			jen.List(jen.Id("iter")).Op(":=").List(jen.Id("types").Dot("NewMapIterator").Call(jen.Id("types").Dot("Ref").Call(jen.Id("addr")), jen.Id("i").Dot("heap").Index(jen.Id("addr")))),
 			jen.Id("iter").Dot("Next").Call(),
@@ -3721,6 +3714,9 @@ func mapKeys() jen.Code {
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("keyType")).Op("=").List(jen.Id("m").Dot("Typ").Dot("Key")),
 					jen.List(jen.Id("elems")).Op("=").List(jen.Id("make").Call(jen.Index().Add(jen.Id("types").Dot("Boxed")), jen.Lit(0), jen.Id("m").Dot("Len").Call())),
 					jen.Id("m").Dot("Range").Call(jen.Func().Params(jen.Id("k").Add(jen.Id("float64")), jen.Id("_").Add(jen.Id("types").Dot("Boxed"))).Block(jen.List(jen.Id("elems")).Op("=").List(jen.Id("append").Call(jen.Id("elems"), jen.Id("types").Dot("BoxF64").Call(jen.Id("k"))))))),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("keyType")).Op("=").List(jen.Id("m").Dot("Typ").Dot("Key")),
+					jen.List(jen.Id("elems")).Op("=").List(jen.Id("make").Call(jen.Index().Add(jen.Id("types").Dot("Boxed")), jen.Lit(0), jen.Id("m").Dot("Len").Call())),
+					jen.Id("m").Dot("Range").Call(jen.Func().Params(jen.Id("k").Add(jen.Id("string")), jen.Id("_").Add(jen.Id("types").Dot("Boxed"))).Block(jen.List(jen.Id("elems")).Op("=").List(jen.Id("append").Call(jen.Id("elems"), jen.Id("types").Dot("BoxRef").Call(jen.Id("i").Dot("alloc").Call(jen.Id("types").Dot("String").Call(jen.Id("k"))))))))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.List(jen.Id("keyType")).Op("=").List(jen.Id("m").Dot("Typ").Dot("Key")),
 					jen.List(jen.Id("elems")).Op("=").List(jen.Id("make").Call(jen.Index().Add(jen.Id("types").Dot("Boxed")), jen.Lit(0), jen.Id("m").Dot("Len").Call())),
 					jen.Id("m").Dot("Range").Call(jen.Func().Params(jen.Id("_").Add(jen.Id("types").Dot("MapKey")), jen.Id("entry").Add(jen.Id("types").Dot("MapEntry"))).Block(jen.Id("i").Dot("retainBox").Call(jen.Id("entry").Dot("Key")),
@@ -3746,6 +3742,7 @@ func mapLen() jen.Code {
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("int64")))).Block(jen.List(jen.Id("n")).Op("=").List(jen.Id("m").Dot("Len").Call())),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32")))).Block(jen.List(jen.Id("n")).Op("=").List(jen.Id("m").Dot("Len").Call())),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("n")).Op("=").List(jen.Id("m").Dot("Len").Call())),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("n")).Op("=").List(jen.Id("m").Dot("Len").Call())),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.List(jen.Id("n")).Op("=").List(jen.Id("m").Dot("Len").Call())),
 				jen.Default().Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch")))),
 			jen.Id("i").Dot("release").Call(jen.Id("addr")),
@@ -3773,6 +3770,8 @@ func mapLookup() jen.Code {
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32")))).Block(jen.List(jen.Id("result"), jen.Id("found")).Op("=").List(jen.Id("m").Dot("Get").Call(jen.Id("key").Dot("F32").Call())),
 					jen.If(jen.Op("!").Add(jen.Id("found"))).Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("m").Dot("Zero")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("result"), jen.Id("found")).Op("=").List(jen.Id("m").Dot("Get").Call(jen.Id("key").Dot("F64").Call())),
+					jen.If(jen.Op("!").Add(jen.Id("found"))).Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("m").Dot("Zero")))),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("result"), jen.Id("found")).Op("=").List(jen.Id("m").Dot("Get").Call(jen.String().Call(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("key"))))),
 					jen.If(jen.Op("!").Add(jen.Id("found"))).Block(jen.List(jen.Id("result")).Op("=").List(jen.Id("m").Dot("Zero")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.Var().Add(jen.List(jen.Id("k"))).Add(jen.Id("types").Dot("MapKey")),
 					jen.List(jen.Id("keyRef")).Op(":=").List(jen.Lit(0)),
@@ -3826,6 +3825,8 @@ func mapNew() jen.Code {
 					jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Set").Call(jen.Id("key").Dot("F32").Call(), jen.Id("value"))),
 						jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
 					jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Set").Call(jen.Id("key").Dot("F64").Call(), jen.Id("value"))),
+						jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
+					jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Set").Call(jen.String().Call(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("key"))), jen.Id("value"))),
 						jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
 					jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.Var().Add(jen.List(jen.Id("k"))).Add(jen.Id("types").Dot("MapKey")),
 						jen.List(jen.Id("entry")).Op(":=").List(jen.Id("types").Dot("MapEntry").Values(jen.Dict{jen.Id("Value"): jen.Id("value")})),
@@ -3891,6 +3892,8 @@ func mapSet() jen.Code {
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float32")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Set").Call(jen.Id("key").Dot("F32").Call(), jen.Id("value"))),
 					jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("float64")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Set").Call(jen.Id("key").Dot("F64").Call(), jen.Id("value"))),
+					jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
+				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("TypedMap").Index(jen.Id("string")))).Block(jen.List(jen.Id("old"), jen.Id("ok")).Op(":=").List(jen.Id("m").Dot("Set").Call(jen.String().Call(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("key"))), jen.Id("value"))),
 					jen.If(jen.Id("ok")).Block(jen.Id("i").Dot("releaseBox").Call(jen.Id("old")))),
 				jen.Case(jen.Op("*").Add(jen.Id("types").Dot("Map"))).Block(jen.Var().Add(jen.List(jen.Id("k"))).Add(jen.Id("types").Dot("MapKey")),
 					jen.List(jen.Id("entry")).Op(":=").List(jen.Id("types").Dot("MapEntry").Values(jen.Dict{jen.Id("Value"): jen.Id("value")})),
@@ -4143,14 +4146,35 @@ func selectOp() jen.Code {
 			jen.Id("i").Dot("fr").Dot("ip").Op("++"))))
 }
 
+// stringConcat joins the two operand strings. Results share one append-only
+// byte buffer: when the left operand's text ends exactly where the buffer ends,
+// the right operand is appended past that end and the join is published as a new
+// cell viewing the longer prefix. Bytes below any published length are never
+// rewritten, so every existing string keeps its own content whatever its
+// reference count, and an accumulating join costs no prefix copy. Any other left
+// operand starts a fresh buffer from a copy.
 func stringConcat() jen.Code {
 	return jen.Func().Params(jen.Id("c").Add(jen.Op("*").Add(jen.Id("threader")))).Params(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter"))))).Block(jen.Id("c").Dot("ip").Op("++"),
-		jen.Return(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter")))).Block(jen.If(jen.Id("i").Dot("sp").Op("<").Add(jen.Lit(2))).Block(jen.Id("panic").Call(jen.Id("ErrStackUnderflow"))),
-			jen.List(jen.Id("v1")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1))))),
-			jen.List(jen.Id("v2")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(2))))),
+		jen.Return(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter")))).Block(
+			jen.If(jen.Id("i").Dot("sp").Op("<").Add(jen.Lit(2))).Block(jen.Id("panic").Call(jen.Id("ErrStackUnderflow"))),
+			jen.List(jen.Id("right"), jen.Id("left")).Op(":=").List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1))), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(2)))),
+			jen.If(jen.Id("left").Dot("Kind").Call().Op("!=").Add(jen.Id("types").Dot("KindRef")).Op("||").Id("right").Dot("Kind").Call().Op("!=").Add(jen.Id("types").Dot("KindRef"))).Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch"))),
+			jen.List(jen.Id("leftAddr"), jen.Id("rightAddr")).Op(":=").List(jen.Id("left").Dot("Ref").Call(), jen.Id("right").Dot("Ref").Call()),
+			jen.List(jen.Id("leftText"), jen.Id("leftOK")).Op(":=").List(jen.Id("i").Dot("heap").Index(jen.Id("leftAddr")).Assert(jen.Id("types").Dot("String"))),
+			jen.If(jen.Op("!").Add(jen.Id("leftOK"))).Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch"))),
+			jen.List(jen.Id("rightText"), jen.Id("rightOK")).Op(":=").List(jen.Id("i").Dot("heap").Index(jen.Id("rightAddr")).Assert(jen.Id("types").Dot("String"))),
+			jen.If(jen.Op("!").Add(jen.Id("rightOK"))).Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch"))),
+			jen.If(jen.Len(jen.Id("i").Dot("tail")).Op("!=").Len(jen.Id("leftText")).Op("||").Qual("unsafe", "SliceData").Call(jen.Id("i").Dot("tail")).Op("!=").Qual("unsafe", "StringData").Call(jen.String().Call(jen.Id("leftText")))).Block(
+				jen.List(jen.Id("i").Dot("tail")).Op("=").List(jen.Id("append").Call(jen.Id("make").Call(jen.Index().Add(jen.Id("byte")), jen.Lit(0), jen.Len(jen.Id("leftText")).Op("+").Add(jen.Len(jen.Id("rightText")))), jen.Id("leftText").Op("..."))),
+			),
+			jen.List(jen.Id("i").Dot("tail")).Op("=").List(jen.Id("append").Call(jen.Id("i").Dot("tail"), jen.Id("rightText").Op("..."))),
+			jen.List(jen.Id("text")).Op(":=").List(jen.Id("types").Dot("String").Call(jen.Qual("unsafe", "String").Call(jen.Qual("unsafe", "SliceData").Call(jen.Id("i").Dot("tail")), jen.Len(jen.Id("i").Dot("tail"))))),
+			jen.Id("i").Dot("release").Call(jen.Id("rightAddr")),
+			jen.Id("i").Dot("release").Call(jen.Id("leftAddr")),
 			jen.Id("i").Dot("sp").Op("--"),
-			jen.List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))).Op("=").List(jen.Id("types").Dot("BoxRef").Call(jen.Id("int").Call(jen.Id("i").Dot("intern").Call(jen.Id("string").Call(jen.Id("v2").Op("+").Add(jen.Id("v1"))))))),
-			jen.Id("i").Dot("fr").Dot("ip").Op("++"))))
+			jen.List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))).Op("=").List(jen.Id("types").Dot("BoxRef").Call(jen.Id("i").Dot("alloc").Call(jen.Id("text")))),
+			jen.Id("i").Dot("fr").Dot("ip").Op("++"),
+		)))
 }
 
 func stringEncodeUtf32() jen.Code {
@@ -4164,10 +4188,8 @@ func stringEncodeUtf32() jen.Code {
 func stringEq() jen.Code {
 	return jen.Func().Params(jen.Id("c").Add(jen.Op("*").Add(jen.Id("threader")))).Params(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter"))))).Block(jen.Id("c").Dot("ip").Op("++"),
 		jen.Return(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter")))).Block(jen.If(jen.Id("i").Dot("sp").Op("<").Add(jen.Lit(2))).Block(jen.Id("panic").Call(jen.Id("ErrStackUnderflow"))),
-			jen.List(jen.Id("v1")).Op(":=").List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))),
-			jen.List(jen.Id("v2")).Op(":=").List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(2)))),
-			jen.Id("i").Dot("releaseBox").Call(jen.Id("v1")),
-			jen.Id("i").Dot("releaseBox").Call(jen.Id("v2")),
+			jen.List(jen.Id("v1")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1))))),
+			jen.List(jen.Id("v2")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(2))))),
 			jen.Id("i").Dot("sp").Op("--"),
 			jen.List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))).Op("=").List(jen.Id("types").Dot("BoxI1").Call(jen.Id("v2").Op("==").Add(jen.Id("v1")))),
 			jen.Id("i").Dot("fr").Dot("ip").Op("++"))))
@@ -4238,10 +4260,8 @@ func stringLt() jen.Code {
 func stringNe() jen.Code {
 	return jen.Func().Params(jen.Id("c").Add(jen.Op("*").Add(jen.Id("threader")))).Params(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter"))))).Block(jen.Id("c").Dot("ip").Op("++"),
 		jen.Return(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter")))).Block(jen.If(jen.Id("i").Dot("sp").Op("<").Add(jen.Lit(2))).Block(jen.Id("panic").Call(jen.Id("ErrStackUnderflow"))),
-			jen.List(jen.Id("v1")).Op(":=").List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))),
-			jen.List(jen.Id("v2")).Op(":=").List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(2)))),
-			jen.Id("i").Dot("releaseBox").Call(jen.Id("v1")),
-			jen.Id("i").Dot("releaseBox").Call(jen.Id("v2")),
+			jen.List(jen.Id("v1")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1))))),
+			jen.List(jen.Id("v2")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("String")).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(2))))),
 			jen.Id("i").Dot("sp").Op("--"),
 			jen.List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))).Op("=").List(jen.Id("types").Dot("BoxI1").Call(jen.Id("v2").Op("!=").Add(jen.Id("v1")))),
 			jen.Id("i").Dot("fr").Dot("ip").Op("++"))))
@@ -4251,7 +4271,7 @@ func stringNewUtf32() jen.Code {
 	return jen.Func().Params(jen.Id("c").Add(jen.Op("*").Add(jen.Id("threader")))).Params(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter"))))).Block(jen.Id("c").Dot("ip").Op("++"),
 		jen.Return(jen.Func().Params(jen.Id("i").Add(jen.Op("*").Add(jen.Id("Interpreter")))).Block(jen.If(jen.Id("i").Dot("sp").Op("==").Add(jen.Lit(0))).Block(jen.Id("panic").Call(jen.Id("ErrStackUnderflow"))),
 			jen.List(jen.Id("val")).Op(":=").List(jen.Id("unboxRef").Index(jen.Id("types").Dot("TypedArray").Index(jen.Id("int32"))).Call(jen.Id("i"), jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1))))),
-			jen.List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))).Op("=").List(jen.Id("types").Dot("BoxRef").Call(jen.Id("int").Call(jen.Id("i").Dot("intern").Call(jen.Id("string").Call(jen.Id("types").Dot("String").Call(jen.Id("val"))))))),
+			jen.List(jen.Id("i").Dot("stack").Index(jen.Id("i").Dot("sp").Op("-").Add(jen.Lit(1)))).Op("=").List(jen.Id("types").Dot("BoxRef").Call(jen.Id("i").Dot("alloc").Call(jen.Id("types").Dot("String").Call(jen.String().Call(jen.Id("val")))))),
 			jen.Id("i").Dot("fr").Dot("ip").Op("++"))))
 }
 

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -49,21 +49,27 @@ type Interpreter struct {
 	module      *types.Function
 	dynamic     map[int]bool
 
-	frames   []frame
-	fr       *frame
-	stack    []types.Boxed
-	heap     []types.Value
-	base     int
-	target   int
-	interned map[string]types.Ref
-	owners   map[types.Value]int
-	free     []int
-	rc       []int
-	trial    []int
-	work     []int
-	refbuf   []types.Ref
-	arrays   pool[*types.Array]
-	structs  pool[*types.Struct]
+	frames  []frame
+	fr      *frame
+	stack   []types.Boxed
+	heap    []types.Value
+	base    int
+	target  int
+	owners  map[types.Value]int
+	free    []int
+	rc      []int
+	trial   []int
+	work    []int
+	refbuf  []types.Ref
+	arrays  pool[*types.Array]
+	structs pool[*types.Struct]
+
+	// tail is the append-only byte buffer the most recent string.concat
+	// published from. A join whose left operand ends exactly where tail ends
+	// extends it and publishes a new ref over the longer prefix; bytes below any
+	// published length are never rewritten, so every string already handed out
+	// keeps its own content whatever its reference count.
+	tail []byte
 
 	fp  int
 	sp  int
@@ -263,7 +269,6 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 		frames:      make([]frame, opt.frame),
 		stack:       make([]types.Boxed, opt.stack),
 		heap:        make([]types.Value, 0, opt.heap),
-		interned:    make(map[string]types.Ref),
 		owners:      make(map[types.Value]int),
 		free:        make([]int, 0, opt.heap),
 		rc:          make([]int, 0, opt.heap),
@@ -277,6 +282,11 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 	// Retain each constant root and nested edge as it becomes visible because a
 	// later constant may allocate and trigger GC. recount normalizes the final
 	// baseline after the whole constant pool has been boxed.
+	//
+	// dedup gives identical string literals one shared cell. Nothing depends on
+	// that sharing - every string comparison and string map key compares content
+	// - so it is a load-time pool economy only, and the index dies with the loop.
+	dedup := make(map[string]types.Ref)
 	for j, v := range prog.Constants {
 		var val types.Boxed
 		switch v := v.(type) {
@@ -304,12 +314,17 @@ func New(prog *program.Program, opts ...func(*option)) *Interpreter {
 			if addr := int(v); i.alive(addr) {
 				i.retain(addr)
 			}
-		default:
-			if s, ok := v.(types.String); ok {
-				val = types.BoxRef(int(i.intern(string(s))))
+		case types.String:
+			ref, seen := dedup[string(v)]
+			if seen {
+				i.retain(int(ref))
 			} else {
-				val = types.BoxRef(i.alloc(v))
+				ref = types.Ref(i.alloc(v))
+				dedup[string(v)] = ref
 			}
+			val = types.BoxRef(int(ref))
+		default:
+			val = types.BoxRef(i.alloc(v))
 			for _, ref := range i.refs(v) {
 				if addr := int(ref); i.alive(addr) {
 					i.retain(addr)
@@ -586,9 +601,6 @@ func (i *Interpreter) Alloc(val types.Value) (addr int, err error) {
 	if i.owner(val) >= 0 {
 		return 0, ErrTypeMismatch
 	}
-	if s, ok := val.(types.String); ok {
-		return int(i.intern(string(s))), nil
-	}
 	addr = i.alloc(val)
 	i.own(addr, val)
 	if fn, ok := val.(*types.Function); ok {
@@ -747,6 +759,7 @@ func (i *Interpreter) Reset() {
 	i.rc = rc[:i.base]
 	i.recount()
 	i.free = i.free[:0]
+	i.tail = nil
 
 	i.seed()
 	i.pace()
@@ -1755,7 +1768,7 @@ func (i *Interpreter) box(val types.Value) types.Boxed {
 	case types.Ref:
 		return types.BoxRef(int(v))
 	case types.String:
-		return types.BoxRef(int(i.intern(string(v))))
+		return types.BoxRef(i.alloc(v))
 	default:
 		addr := i.alloc(v)
 		return types.BoxRef(addr)
@@ -1933,18 +1946,6 @@ func (i *Interpreter) structField(addr, at int) types.Boxed {
 	default:
 		panic(ErrTypeMismatch)
 	}
-}
-
-// intern returns a heap ref for s. Interpreters are single-threaded; callers
-// must not use one Interpreter concurrently from multiple goroutines.
-func (i *Interpreter) intern(s string) types.Ref {
-	if ref, ok := i.interned[s]; ok {
-		i.retain(int(ref))
-		return ref
-	}
-	ref := types.Ref(i.alloc(types.String(s)))
-	i.interned[s] = ref
-	return ref
 }
 
 func (i *Interpreter) unbox(val types.Boxed) types.Value {
@@ -2410,9 +2411,6 @@ func (i *Interpreter) reclaim(addr int, v types.Value) {
 func (i *Interpreter) finalize(addr int, v types.Value) {
 	if _, ok := v.(*types.Function); ok {
 		i.remove(addr)
-	}
-	if s, ok := v.(types.String); ok && i.interned[string(s)] == types.Ref(addr) {
-		delete(i.interned, string(s))
 	}
 	// External finalizers belong to committed execution, never speculative
 	// trace capture.

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1141,6 +1141,44 @@ var runTests = []struct {
 		values: []types.Value{types.I1(true)},
 	},
 	{
+		name: "const.get const.get string.concat const.get string.eq compares content, not ref identity",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_EQ),
+		}, program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThere"))),
+		values: []types.Value{types.I1(true)},
+	},
+	{
+		name: "const.get const.get string.concat const.get string.ne compares content, not ref identity",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_NE),
+		}, program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThere"))),
+		values: []types.Value{types.I1(false)},
+	},
+	{
+		name: "const.get const.get string.concat string.concat reuses the shared buffer without disturbing the shorter join",
+		program: program.New([]instr.Instruction{
+			// Keep the first join live in a local, extend a copy of it, then
+			// compare the local against its original content: an append that
+			// rewrote published bytes would change what the local reads.
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.LOCAL_SET, 0),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.DROP),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_EQ),
+		}, program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThere")),
+			program.WithLocals(types.TypeString)),
+		values: []types.Value{types.I1(true)},
+	},
+	{
+		name: "ref.null const.get string.eq on a non-string operand traps type mismatch",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.REF_NULL), instr.New(instr.CONST_GET, 0), instr.New(instr.STRING_EQ),
+		}, program.WithConstants(types.String("Go"))),
+		err: ErrTypeMismatch,
+	},
+	{
 		name: "const.get const.get string.lt returns i1",
 		program: program.New([]instr.Instruction{instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_LT)},
 			program.WithConstants(types.String("Go"), types.String("No"))),
@@ -1634,6 +1672,26 @@ var runTests = []struct {
 			instr.New(instr.I32_CONST, 1), instr.New(instr.I32_CONST, 10), instr.New(instr.I32_CONST, 2), instr.New(instr.I32_CONST, 20), instr.New(instr.I32_CONST, 2), instr.New(instr.MAP_NEW, 0),
 			instr.New(instr.I32_CONST, 1), instr.New(instr.MAP_GET),
 		}, program.WithTypes(types.NewMapType(types.TypeI32, types.TypeI32))),
+		values: []types.Value{types.I32(10)},
+	},
+	{
+		name: "const.get i32.const map.new const.get const.get string.concat map.get keys a string map by content",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 2), instr.New(instr.I32_CONST, 10), instr.New(instr.I32_CONST, 1), instr.New(instr.MAP_NEW, 0),
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.MAP_GET),
+		}, program.WithTypes(types.NewMapType(types.TypeString, types.TypeI32)),
+			program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThere"))),
+		values: []types.Value{types.I32(10)},
+	},
+	{
+		name: "const.get const.get string.concat i32.const map.new const.get map.get keys a string map stored under a computed key",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.I32_CONST, 10), instr.New(instr.I32_CONST, 1), instr.New(instr.MAP_NEW, 0),
+			instr.New(instr.CONST_GET, 2), instr.New(instr.MAP_GET),
+		}, program.WithTypes(types.NewMapType(types.TypeString, types.TypeI32)),
+			program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThere"))),
 		values: []types.Value{types.I32(10)},
 	},
 	{
@@ -3148,14 +3206,13 @@ func TestInterpreter_Run(t *testing.T) {
 	})
 
 	type parityState struct {
-		code     types.ErrorCode
-		ip       int
-		fp       int
-		sp       int
-		stack    []types.Boxed
-		globals  []types.Boxed
-		rc       map[int]int
-		interned int
+		code    types.ErrorCode
+		ip      int
+		fp      int
+		sp      int
+		stack   []types.Boxed
+		globals []types.Boxed
+		rc      map[int]int
 	}
 
 	huge := int64(1) << 50
@@ -3192,6 +3249,21 @@ func TestInterpreter_Run(t *testing.T) {
 				instr.New(instr.I64_ADD),
 				instr.New(instr.DROP),
 			}, program.WithLocals(types.TypeI64)),
+		},
+		{
+			// string.eq compares content and string.concat shares an append-only
+			// buffer, so neither lowers natively any more. Both paths must still
+			// agree on the result and on every refcount.
+			name: "string join and content equality preserve state",
+			prog: program.New([]instr.Instruction{
+				instr.New(instr.CONST_GET, 0), instr.New(instr.LOCAL_SET, 0),
+				instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+				instr.New(instr.LOCAL_SET, 0),
+				instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+				instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_EQ),
+				instr.New(instr.DROP),
+			}, program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThereThere")),
+				program.WithLocals(types.TypeString)),
 		},
 		{
 			name: "local ref drop preserves ownership",
@@ -3263,14 +3335,13 @@ func TestInterpreter_Run(t *testing.T) {
 				}
 
 				state := parityState{
-					code:     ErrorCode(err),
-					ip:       i.fr.ip,
-					fp:       i.fp,
-					sp:       i.sp,
-					stack:    append([]types.Boxed(nil), i.stack[:i.sp]...),
-					globals:  append([]types.Boxed(nil), i.globals...),
-					rc:       make(map[int]int),
-					interned: len(i.interned),
+					code:    ErrorCode(err),
+					ip:      i.fr.ip,
+					fp:      i.fp,
+					sp:      i.sp,
+					stack:   append([]types.Boxed(nil), i.stack[:i.sp]...),
+					globals: append([]types.Boxed(nil), i.globals...),
+					rc:      make(map[int]int),
 				}
 				for ref, count := range i.rc[1:] {
 					if count != 0 {

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1172,6 +1172,33 @@ var runTests = []struct {
 		values: []types.Value{types.I1(true)},
 	},
 	{
+		name:    "const.get const.get string.concat handles empty operands",
+		program: program.New([]instr.Instruction{instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT)}, program.WithConstants(types.String(""), types.String(""))),
+		values:  []types.Value{types.String("")},
+	},
+	{
+		name: "const.get const.get string.concat reallocation preserves the earlier join",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.LOCAL_SET, 0),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.DROP),
+			instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 3), instr.New(instr.STRING_EQ),
+		}, program.WithConstants(
+			types.String("abc"), types.String("def"), types.String("0123456789abcdef"), types.String("abcdef")),
+			program.WithLocals(types.TypeString)),
+		values: []types.Value{types.I1(true)},
+	},
+	{
+		name: "const.get const.get string.concat uses a fresh buffer for a prefix that is not the tail",
+		program: program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT), instr.New(instr.DROP),
+			instr.New(instr.CONST_GET, 0), instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_CONCAT),
+			instr.New(instr.CONST_GET, 3), instr.New(instr.STRING_EQ),
+		}, program.WithConstants(types.String("a"), types.String("b"), types.String("c"), types.String("ac"))),
+		values: []types.Value{types.I1(true)},
+	},
+	{
 		name: "ref.null const.get string.eq on a non-string operand traps type mismatch",
 		program: program.New([]instr.Instruction{
 			instr.New(instr.REF_NULL), instr.New(instr.CONST_GET, 0), instr.New(instr.STRING_EQ),
@@ -1901,6 +1928,20 @@ var runTests = []struct {
 }
 
 func TestInterpreter_Run(t *testing.T) {
+	t.Run("string.concat reads the result after releasing both last operand references", func(t *testing.T) {
+		prog := program.New([]instr.Instruction{instr.New(instr.STRING_CONCAT)})
+		i := New(prog, WithThreshold(-1))
+		defer i.Close()
+
+		require.NoError(t, i.Push(types.String("left")))
+		require.NoError(t, i.Push(types.String("right")))
+		require.NoError(t, i.Run(context.Background()))
+
+		value, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.String("leftright"), value)
+	})
+
 	t.Run("covers every runtime opcode", func(t *testing.T) {
 		covered := make(map[instr.Opcode]struct{})
 		names := make(map[string]struct{})

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -1928,20 +1928,6 @@ var runTests = []struct {
 }
 
 func TestInterpreter_Run(t *testing.T) {
-	t.Run("string.concat reads the result after releasing both last operand references", func(t *testing.T) {
-		prog := program.New([]instr.Instruction{instr.New(instr.STRING_CONCAT)})
-		i := New(prog, WithThreshold(-1))
-		defer i.Close()
-
-		require.NoError(t, i.Push(types.String("left")))
-		require.NoError(t, i.Push(types.String("right")))
-		require.NoError(t, i.Run(context.Background()))
-
-		value, err := i.Pop()
-		require.NoError(t, err)
-		require.Equal(t, types.String("leftright"), value)
-	})
-
 	t.Run("covers every runtime opcode", func(t *testing.T) {
 		covered := make(map[instr.Opcode]struct{})
 		names := make(map[string]struct{})
@@ -2011,6 +1997,51 @@ func TestInterpreter_Run(t *testing.T) {
 		defer i.Close()
 
 		require.NoError(t, i.Run(context.Background()))
+	})
+
+	t.Run("string.concat reads the result after releasing both last operand references", func(t *testing.T) {
+		prog := program.New([]instr.Instruction{instr.New(instr.STRING_CONCAT)})
+		i := New(prog, WithThreshold(-1))
+		defer i.Close()
+
+		require.NoError(t, i.Push(types.String("left")))
+		require.NoError(t, i.Push(types.String("right")))
+		require.NoError(t, i.Run(context.Background()))
+
+		value, err := i.Pop()
+		require.NoError(t, err)
+		require.Equal(t, types.String("leftright"), value)
+	})
+
+	t.Run("releases every string.concat intermediate", func(t *testing.T) {
+		// Each join consumes both operands and publishes one result, so an
+		// accumulating loop holds one live string at a time. A join that kept an
+		// operand ref leaks one slot per iteration and exhausts a bounded heap.
+		b := program.NewBuilder()
+		loop := b.Label()
+		done := b.Label()
+		b.Locals(types.TypeString, types.TypeI32)
+		b.ConstGet(types.String("")).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 4*heapRunway).Emit(instr.I32_GE_S).BrIf(done)
+		b.Emit(instr.LOCAL_GET, 0).ConstGet(types.String("x")).Emit(instr.STRING_CONCAT).Emit(instr.LOCAL_SET, 0)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.STRING_LEN)
+		prog, err := b.Build()
+		require.NoError(t, err)
+		require.NoError(t, program.Verify(prog))
+
+		i := New(prog, WithHeapLimit(heapRunway))
+		defer i.Close()
+
+		require.NoError(t, i.Run(context.Background()))
+
+		got, err := i.PopBoxed()
+		require.NoError(t, err)
+		require.Equal(t, types.BoxI32(4*heapRunway), got)
 	})
 
 	t.Run("STRUCT_GET fused on a declared struct local traps type mismatch when the runtime field's kind diverges from the declared field's kind", func(t *testing.T) {
@@ -3290,21 +3321,6 @@ func TestInterpreter_Run(t *testing.T) {
 				instr.New(instr.I64_ADD),
 				instr.New(instr.DROP),
 			}, program.WithLocals(types.TypeI64)),
-		},
-		{
-			// string.eq compares content and string.concat shares an append-only
-			// buffer, so neither lowers natively any more. Both paths must still
-			// agree on the result and on every refcount.
-			name: "string join and content equality preserve state",
-			prog: program.New([]instr.Instruction{
-				instr.New(instr.CONST_GET, 0), instr.New(instr.LOCAL_SET, 0),
-				instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
-				instr.New(instr.LOCAL_SET, 0),
-				instr.New(instr.LOCAL_GET, 0), instr.New(instr.CONST_GET, 1), instr.New(instr.STRING_CONCAT),
-				instr.New(instr.CONST_GET, 2), instr.New(instr.STRING_EQ),
-				instr.New(instr.DROP),
-			}, program.WithConstants(types.String("Hi"), types.String("There"), types.String("HiThereThere")),
-				program.WithLocals(types.TypeString)),
 		},
 		{
 			name: "local ref drop preserves ownership",

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -638,13 +638,13 @@ func (l arm64Lowerer) steps(ctx *lowering, ops []step) (bool, bool) {
 			ok = l.refNull(ctx)
 		case instr.REF_IS_NULL:
 			ok = l.refIsNull(ctx, op)
-		case instr.REF_EQ, instr.REF_NE, instr.STRING_EQ, instr.STRING_NE:
-			// Ref and interned-string equality are boxed-word compares. With at
-			// most one owned operand the compare stays native; two owned
-			// operands fall back terminally because releasing both natively
-			// risks a double release when the second release deopts after the
-			// first already decremented a refcount inline.
-			terminal, okEq := l.refEq(ctx, op, op.op == instr.REF_NE || op.op == instr.STRING_NE)
+		case instr.REF_EQ, instr.REF_NE:
+			// Ref equality is a boxed-word compare. With at most one owned
+			// operand the compare stays native; two owned operands fall back
+			// terminally because releasing both natively risks a double release
+			// when the second release deopts after the first already
+			// decremented a refcount inline.
+			terminal, okEq := l.refEq(ctx, op, op.op == instr.REF_NE)
 			if !okEq {
 				return false, false
 			}
@@ -3068,9 +3068,9 @@ func (l arm64Lowerer) refIsNull(ctx *lowering, op step) bool {
 	return true
 }
 
-// refEq lowers REF_EQ/REF_NE and STRING_EQ/STRING_NE as a boxed-word compare
-// (strings are interned, so string equality is ref equality). At most one
-// operand may own its retain: a single owned operand releases like refIsNull,
+// refEq lowers REF_EQ/REF_NE as a boxed-word compare. string.eq and string.ne
+// compare content rather than ref identity, so they are not lowered here. At
+// most one operand may own its retain: a single owned operand releases like refIsNull,
 // while two owned operands report a terminal fallback because the second
 // release could deopt after the first already decremented a refcount inline.
 func (l arm64Lowerer) refEq(ctx *lowering, op step, negate bool) (bool, bool) {

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -2307,10 +2307,8 @@ func TestARM64_StructSetLoop(t *testing.T) {
 	})
 }
 
-// RefEqLoop protects the native boxed-word equality for REF_EQ/REF_NE and
-// STRING_EQ/STRING_NE: with at most one owned operand the compare stays
-// native, and with two owned operands it falls back terminally. Every
-// sub-case diffs results and exact refcounts against a threaded twin.
+// RefEqLoop protects the native boxed-word equality for REF_EQ/REF_NE.
+// Every sub-case diffs results and exact refcounts against a threaded twin.
 func TestARM64_RefEqLoop(t *testing.T) {
 	if runtime.GOARCH != "arm64" {
 		t.Skip("native JIT is only available on arm64")
@@ -2381,57 +2379,6 @@ func TestARM64_RefEqLoop(t *testing.T) {
 		require.NoError(t, err)
 		return prog
 	}
-
-	t.Run("deferred string equality stays native", func(t *testing.T) {
-		prog := eqLoop(func(b *program.Builder) {
-			b.Locals(types.TypeString, types.TypeI32, types.TypeI32)
-			b.ConstGet(types.String("hot")).Emit(instr.LOCAL_SET, 0)
-		}, func(b *program.Builder) {
-			b.Emit(instr.LOCAL_GET, 0).ConstGet(types.String("hot"))
-		}, instr.STRING_EQ)
-		runParity(t, prog, types.BoxI32(24))
-	})
-
-	t.Run("deferred string inequality with distinct literals", func(t *testing.T) {
-		prog := eqLoop(func(b *program.Builder) {
-			b.Locals(types.TypeString, types.TypeI32, types.TypeI32)
-			b.ConstGet(types.String("hot")).Emit(instr.LOCAL_SET, 0)
-		}, func(b *program.Builder) {
-			b.Emit(instr.LOCAL_GET, 0).ConstGet(types.String("cold"))
-		}, instr.STRING_NE)
-		runParity(t, prog, types.BoxI32(24))
-	})
-
-	t.Run("one owned operand releases in place", func(t *testing.T) {
-		stringArray := types.NewArrayType(types.TypeString)
-		prog := eqLoop(func(b *program.Builder) {
-			arrTyp := b.Type(stringArray)
-			b.Locals(stringArray, types.TypeI32, types.TypeI32)
-			b.Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrTyp)).Emit(instr.LOCAL_SET, 0)
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).ConstGet(types.String("hot")).Emit(instr.ARRAY_SET)
-		}, func(b *program.Builder) {
-			// The array element load retains its result, so the compare's left
-			// operand owns a retain the native path must release in place.
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).Emit(instr.ARRAY_GET)
-			b.ConstGet(types.String("hot"))
-		}, instr.STRING_EQ)
-		runParity(t, prog, types.BoxI32(24))
-	})
-
-	t.Run("two owned operands fall back terminally", func(t *testing.T) {
-		stringArray := types.NewArrayType(types.TypeString)
-		prog := eqLoop(func(b *program.Builder) {
-			arrTyp := b.Type(stringArray)
-			b.Locals(stringArray, types.TypeI32, types.TypeI32)
-			b.Emit(instr.I32_CONST, 2).Emit(instr.ARRAY_NEW_DEFAULT, uint64(arrTyp)).Emit(instr.LOCAL_SET, 0)
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).ConstGet(types.String("hot")).Emit(instr.ARRAY_SET)
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).ConstGet(types.String("hot")).Emit(instr.ARRAY_SET)
-		}, func(b *program.Builder) {
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).Emit(instr.ARRAY_GET)
-			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.ARRAY_GET)
-		}, instr.STRING_EQ)
-		runParity(t, prog, types.BoxI32(24))
-	})
 
 	t.Run("deferred ref equality stays native", func(t *testing.T) {
 		prog := eqLoop(func(b *program.Builder) {

--- a/interp/marshal.go
+++ b/interp/marshal.go
@@ -796,7 +796,7 @@ func (s *marshalState) boxRef(val types.Value) types.Boxed {
 	case types.Ref:
 		return types.BoxRef(int(v))
 	case types.String:
-		return types.BoxRef(int(s.interp.intern(string(v))))
+		return types.BoxRef(s.alloc(v))
 	default:
 		return types.BoxRef(s.alloc(val))
 	}
@@ -1151,6 +1151,23 @@ func (m *codec) marshalMap(mt *types.MapType) marshaler {
 					return nil, fmt.Errorf("map value: %w", err)
 				}
 				m.Set(keyFloat, value)
+			}
+		case *types.TypedMap[string]:
+			iter := v.MapRange()
+			for iter.Next() {
+				key, err := s.value(iter.Key())
+				if err != nil {
+					return nil, fmt.Errorf("map key: %w", err)
+				}
+				keyString, ok := key.(types.String)
+				if !ok {
+					return nil, fmt.Errorf("map key: %w: map key type=%s", ErrTypeMismatch, mt.Key)
+				}
+				value, err := s.boxAs(iter.Value(), mt.Elem)
+				if err != nil {
+					return nil, fmt.Errorf("map value: %w", err)
+				}
+				m.Set(string(keyString), value)
 			}
 		case *types.Map:
 			iter := v.MapRange()
@@ -1520,6 +1537,8 @@ func (m *codec) unmarshalMap(keyPlan, valPlan *conversion) unmarshaler {
 			size = m.Len()
 		case *types.TypedMap[float64]:
 			size = m.Len()
+		case *types.TypedMap[string]:
+			size = m.Len()
 		case *types.Map:
 			size = m.Len()
 		default:
@@ -1597,6 +1616,15 @@ func (m *codec) unmarshalMap(keyPlan, valPlan *conversion) unmarshaler {
 					return
 				}
 				set(types.F64(key), elemValue)
+			})
+		case *types.TypedMap[string]:
+			m.Range(func(key string, value types.Boxed) {
+				elemValue, err := s.codec.resolve(s.interp, value)
+				if err != nil {
+					mapErr = fmt.Errorf("map value: %w", err)
+					return
+				}
+				set(types.String(key), elemValue)
 			})
 		case *types.Map:
 			m.Range(func(mapKey types.MapKey, entry types.MapEntry) {

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -1086,17 +1086,6 @@ var (
 			switch r0.Kind() {
 			case types.KindRef:
 				addr := r0.Ref()
-				if str, ok := c.heap[addr].(types.String); ok {
-					text := string(str)
-					return func(i *Interpreter) {
-						if i.sp == len(i.stack) {
-							panic(ErrStackOverflow)
-						}
-						i.stack[i.sp] = types.BoxRef(int(i.intern(text)))
-						i.sp++
-						i.fr.ip += 3
-					}
-				}
 				return func(i *Interpreter) {
 					if i.sp == len(i.stack) {
 						panic(ErrStackOverflow)
@@ -3250,7 +3239,7 @@ var (
 					panic(ErrStackUnderflow)
 				}
 				val := unboxRef[types.TypedArray[int32]](i, i.stack[i.sp-1])
-				i.stack[i.sp-1] = types.BoxRef(int(i.intern(string(types.String(val)))))
+				i.stack[i.sp-1] = types.BoxRef(i.alloc(types.String(string(val))))
 				i.fr.ip++
 			}
 		},
@@ -3271,10 +3260,28 @@ var (
 				if i.sp < 2 {
 					panic(ErrStackUnderflow)
 				}
-				v1 := unboxRef[types.String](i, i.stack[i.sp-1])
-				v2 := unboxRef[types.String](i, i.stack[i.sp-2])
+				right, left := i.stack[i.sp-1], i.stack[i.sp-2]
+				if left.Kind() != types.KindRef || right.Kind() != types.KindRef {
+					panic(ErrTypeMismatch)
+				}
+				leftAddr, rightAddr := left.Ref(), right.Ref()
+				leftText, leftOK := i.heap[leftAddr].(types.String)
+				if !leftOK {
+					panic(ErrTypeMismatch)
+				}
+				rightText, rightOK := i.heap[rightAddr].(types.String)
+				if !rightOK {
+					panic(ErrTypeMismatch)
+				}
+				if len(i.tail) != len(leftText) || unsafe.SliceData(i.tail) != unsafe.StringData(string(leftText)) {
+					i.tail = append(make([]byte, 0, len(leftText)+len(rightText)), leftText...)
+				}
+				i.tail = append(i.tail, rightText...)
+				text := types.String(unsafe.String(unsafe.SliceData(i.tail), len(i.tail)))
+				i.release(rightAddr)
+				i.release(leftAddr)
 				i.sp--
-				i.stack[i.sp-1] = types.BoxRef(int(i.intern(string(v2 + v1))))
+				i.stack[i.sp-1] = types.BoxRef(i.alloc(text))
 				i.fr.ip++
 			}
 		},
@@ -3284,10 +3291,8 @@ var (
 				if i.sp < 2 {
 					panic(ErrStackUnderflow)
 				}
-				v1 := i.stack[i.sp-1]
-				v2 := i.stack[i.sp-2]
-				i.releaseBox(v1)
-				i.releaseBox(v2)
+				v1 := unboxRef[types.String](i, i.stack[i.sp-1])
+				v2 := unboxRef[types.String](i, i.stack[i.sp-2])
 				i.sp--
 				i.stack[i.sp-1] = types.BoxI1(v2 == v1)
 				i.fr.ip++
@@ -3299,10 +3304,8 @@ var (
 				if i.sp < 2 {
 					panic(ErrStackUnderflow)
 				}
-				v1 := i.stack[i.sp-1]
-				v2 := i.stack[i.sp-2]
-				i.releaseBox(v1)
-				i.releaseBox(v2)
+				v1 := unboxRef[types.String](i, i.stack[i.sp-1])
+				v2 := unboxRef[types.String](i, i.stack[i.sp-2])
 				i.sp--
 				i.stack[i.sp-1] = types.BoxI1(v2 != v1)
 				i.fr.ip++
@@ -4453,6 +4456,11 @@ var (
 						if ok {
 							i.releaseBox(old)
 						}
+					case *types.TypedMap[string]:
+						old, ok := m.Set(string(unboxRef[types.String](i, key)), value)
+						if ok {
+							i.releaseBox(old)
+						}
 					case *types.Map:
 						var k types.MapKey
 						entry := types.MapEntry{Value: value}
@@ -4582,6 +4590,8 @@ var (
 					n = m.Len()
 				case *types.TypedMap[float64]:
 					n = m.Len()
+				case *types.TypedMap[string]:
+					n = m.Len()
 				case *types.Map:
 					n = m.Len()
 				default:
@@ -4643,6 +4653,13 @@ var (
 					}
 				case *types.TypedMap[float64]:
 					value, ok := m.Get(key.F64())
+					if ok {
+						result = value
+					} else {
+						result = m.Zero
+					}
+				case *types.TypedMap[string]:
+					value, ok := m.Get(string(unboxRef[types.String](i, key)))
 					if ok {
 						result = value
 					} else {
@@ -4762,6 +4779,11 @@ var (
 					if !found {
 						result = m.Zero
 					}
+				case *types.TypedMap[string]:
+					result, found = m.Get(string(unboxRef[types.String](i, key)))
+					if !found {
+						result = m.Zero
+					}
 				case *types.Map:
 					var k types.MapKey
 					keyRef := 0
@@ -4873,6 +4895,11 @@ var (
 					}
 				case *types.TypedMap[float64]:
 					old, ok := m.Set(key.F64(), value)
+					if ok {
+						i.releaseBox(old)
+					}
+				case *types.TypedMap[string]:
+					old, ok := m.Set(string(unboxRef[types.String](i, key)), value)
 					if ok {
 						i.releaseBox(old)
 					}
@@ -4990,6 +5017,11 @@ var (
 					if ok {
 						i.releaseBox(old)
 					}
+				case *types.TypedMap[string]:
+					old, ok := m.Delete(string(unboxRef[types.String](i, key)))
+					if ok {
+						i.releaseBox(old)
+					}
 				case *types.Map:
 					var k types.MapKey
 					keyRef := 0
@@ -5092,6 +5124,10 @@ var (
 					m.Clear(func(value types.Boxed) {
 						i.releaseBox(value)
 					})
+				case *types.TypedMap[string]:
+					m.Clear(func(value types.Boxed) {
+						i.releaseBox(value)
+					})
 				case *types.Map:
 					m.Clear(func(entry types.MapEntry) {
 						i.releaseBox(entry.Key)
@@ -5155,6 +5191,12 @@ var (
 					m.Range(func(k float64, _ types.Boxed) {
 						elems = append(elems, types.BoxF64(k))
 					})
+				case *types.TypedMap[string]:
+					keyType = m.Typ.Key
+					elems = make([]types.Boxed, 0, m.Len())
+					m.Range(func(k string, _ types.Boxed) {
+						elems = append(elems, types.BoxRef(i.alloc(types.String(k))))
+					})
 				case *types.Map:
 					keyType = m.Typ.Key
 					elems = make([]types.Boxed, 0, m.Len())
@@ -5208,7 +5250,7 @@ var (
 				}
 				addr := ref.Ref()
 				switch i.heap[addr].(type) {
-				case *types.TypedMap[int8], *types.TypedMap[bool], *types.TypedMap[int32], *types.TypedMap[int64], *types.TypedMap[float32], *types.TypedMap[float64], *types.Map:
+				case *types.TypedMap[int8], *types.TypedMap[bool], *types.TypedMap[int32], *types.TypedMap[int64], *types.TypedMap[float32], *types.TypedMap[float64], *types.TypedMap[string], *types.Map:
 				default:
 					panic(ErrTypeMismatch)
 				}

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -313,7 +313,9 @@ func (t *tracer) clone(i *Interpreter) Interpreter {
 	out.trial = nil
 	out.work = nil
 	out.refbuf = nil
-	out.interned = map[string]types.Ref{}
+	// Speculative capture must not extend the committed buffer: a later
+	// committed append would rewrite bytes a captured string had published.
+	out.tail = nil
 	// Capture never serves a host ownership query, and every allocating opcode
 	// is unrecordable, so the clone only needs a writable index of its own.
 	out.owners = map[types.Value]int{}

--- a/types/map.go
+++ b/types/map.go
@@ -64,6 +64,7 @@ const (
 	mapIteratorI64
 	mapIteratorF32
 	mapIteratorF64
+	mapIteratorString
 	mapIteratorGeneric
 )
 
@@ -75,6 +76,7 @@ var (
 	_ Traceable = (*TypedMap[int64])(nil)
 	_ Traceable = (*TypedMap[float32])(nil)
 	_ Traceable = (*TypedMap[float64])(nil)
+	_ Traceable = (*TypedMap[string])(nil)
 	_ Traceable = (*MapIterator)(nil)
 	_ Iterator  = (*MapIterator)(nil)
 	_ Type      = (*MapType)(nil)
@@ -102,9 +104,14 @@ func NewMapForType(typ *MapType, capacity int) Value {
 		return NewTypedMap[float32](typ, capacity)
 	case KindF64:
 		return NewTypedMap[float64](typ, capacity)
-	default:
-		return NewMapWithCapacity(typ, capacity)
+	case KindRef:
+		// A declared string key has no identity to preserve, so it keys by
+		// content like every other typed key. Any other ref keys by heap ref.
+		if typ.Key.Equals(TypeString) {
+			return NewTypedMap[string](typ, capacity)
+		}
 	}
+	return NewMapWithCapacity(typ, capacity)
 }
 
 func NewMapWithCapacity(typ *MapType, capacity int) *Map {
@@ -142,6 +149,10 @@ func NewMapIterator(ref Ref, val Value) *MapIterator {
 		it.typ = NewIteratorType(m.Typ.Key)
 		it.kind = mapIteratorF64
 		it.iter = reflect.ValueOf(m.entries).MapRange()
+	case *TypedMap[string]:
+		it.typ = NewIteratorType(m.Typ.Key)
+		it.kind = mapIteratorString
+		it.iter = reflect.ValueOf(m.entries).MapRange()
 	case *Map:
 		it.typ = NewIteratorType(m.Typ.Key)
 		it.kind = mapIteratorGeneric
@@ -156,7 +167,7 @@ func NewMapType(key Type, elem Type) *MapType {
 		Elem:        elem,
 		KeyKind:     key.Kind(),
 		ElemKind:    elem.Kind(),
-		TraceKeys:   key.Kind() == KindRef,
+		TraceKeys:   key.Kind() == KindRef && !key.Equals(TypeString),
 		TraceValues: elem.Kind() == KindRef || elem.Kind() == KindI64,
 	}
 }
@@ -310,6 +321,8 @@ func (it *MapIterator) Next() bool {
 		it.current = F32(float32(it.iter.Key().Float()))
 	case mapIteratorF64:
 		it.current = F64(it.iter.Key().Float())
+	case mapIteratorString:
+		it.current = String(it.iter.Key().String())
 	case mapIteratorGeneric:
 		key := it.iter.Key().Interface().(MapKey)
 		entry := it.iter.Value().Interface().(MapEntry)
@@ -414,6 +427,8 @@ func formatKey(k any) string {
 		return F32(v).String()
 	case float64:
 		return F64(v).String()
+	case string:
+		return String(v).String()
 	default:
 		return fmt.Sprint(v)
 	}

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -43,7 +43,7 @@ func TestNewMapForType(t *testing.T) {
 		{typ: types.NewMapType(types.TypeF32, types.TypeI32), want: (*types.TypedMap[float32])(nil)},
 		{typ: types.NewMapType(types.TypeF64, types.TypeI32), want: (*types.TypedMap[float64])(nil)},
 		{typ: types.NewMapType(types.TypeRef, types.TypeI32), want: (*types.Map)(nil)},
-		{typ: types.NewMapType(types.TypeString, types.TypeI32), want: (*types.Map)(nil)},
+		{typ: types.NewMapType(types.TypeString, types.TypeI32), want: (*types.TypedMap[string])(nil)},
 		{typ: types.NewMapType(structType, types.TypeI32), want: (*types.Map)(nil)},
 	}
 	for _, tt := range tests {
@@ -61,13 +61,13 @@ func TestNewMapIterator(t *testing.T) {
 }
 
 func TestNewMapType(t *testing.T) {
-	t.Run("reference key and i64 value", func(t *testing.T) {
+	t.Run("string key and i64 value", func(t *testing.T) {
 		typ := types.NewMapType(types.TypeString, types.TypeI64)
 		require.Equal(t, types.TypeString, typ.Key)
 		require.Equal(t, types.TypeI64, typ.Elem)
 		require.Equal(t, types.KindRef, typ.KeyKind)
 		require.Equal(t, types.KindI64, typ.ElemKind)
-		require.True(t, typ.TraceKeys)
+		require.False(t, typ.TraceKeys)
 		require.True(t, typ.TraceValues)
 	})
 
@@ -230,7 +230,7 @@ func TestTypedMap_String(t *testing.T) {
 	t.Run("fallback key", func(t *testing.T) {
 		m := types.NewTypedMap[string](types.NewMapType(types.TypeString, types.TypeI32), 0)
 		m.Set("foo", types.BoxI32(2))
-		require.Equal(t, "map[string]i32{foo: 2}", m.String())
+		require.Equal(t, "map[string]i32{\"foo\": 2}", m.String())
 	})
 }
 


### PR DESCRIPTION
- Removed the interned string map and replaced it with an append-only byte buffer for string concatenation, ensuring that string references maintain their content regardless of reference count.
- Updated the allocation and comparison logic for strings to utilize the new buffer, improving performance and memory efficiency.
- Enhanced the interpreter's handling of string equality and inequality to compare content rather than reference identity.
- Added support for typed maps with string keys, allowing for more efficient key management and retrieval.
- Updated tests to cover new string handling behavior and ensure correctness in various scenarios involving string operations and typed maps.

close #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for string-keyed maps, including lookup, insertion, deletion, iteration, clearing, marshaling, and unmarshaling.
  - String comparisons now use content equality rather than object identity.
  - Improved string concatenation with efficient buffer reuse while preserving published strings.

- **Documentation**
  - Expanded benchmark results and methodology.
  - Clarified string ownership, memory behavior, map key semantics, host integration, and execution support.

- **Bug Fixes**
  - Fixed computed string-key lookups and string handling across execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->