### PR TITLE
refactor(instr): carry call, local-write, and container-store as opcode flags

### DIFF
--- a/instr/type.go
+++ b/instr/type.go
@@ -17,7 +17,33 @@ type Type struct {
 	Widths   []int
 	Pop      []Kind
 	Push     []Kind
+	Flags    Flag
 }
+
+// Flag records the properties of an opcode that consumers outside the decoder
+// keep asking about. They are static facts about the instruction, so they live
+// with the rest of its metadata rather than being re-derived from opcode lists
+// at each use site.
+type Flag uint8
+
+const (
+	// FlagCall transfers control into another function.
+	FlagCall Flag = 1 << iota
+	// FlagLocalWrite assigns the local slot named by the first operand.
+	FlagLocalWrite
+	// FlagContainerStore writes an element or field into a heap container.
+	FlagContainerStore
+)
+
+// IsCall reports whether op transfers control into another function.
+func IsCall(op Opcode) bool { return TypeOf(op).Flags&FlagCall != 0 }
+
+// WritesLocal reports whether op assigns the local slot its first operand names.
+func WritesLocal(op Opcode) bool { return TypeOf(op).Flags&FlagLocalWrite != 0 }
+
+// StoresContainer reports whether op writes an element or field into a heap
+// container.
+func StoresContainer(op Opcode) bool { return TypeOf(op).Flags&FlagContainerStore != 0 }
 
 var types = map[Opcode]Type{
 	NOP:         {Mnemonic: "nop"},
@@ -33,9 +59,9 @@ var types = map[Opcode]Type{
 
 	SELECT: {Mnemonic: "select"},
 
-	CALL:        {Mnemonic: "call"},
+	CALL:        {Mnemonic: "call", Flags: FlagCall},
 	RETURN:      {Mnemonic: "return"},
-	RETURN_CALL: {Mnemonic: "return_call"},
+	RETURN_CALL: {Mnemonic: "return_call", Flags: FlagCall},
 
 	YIELD:      {Mnemonic: "yield", Pop: []Kind{KindAny}, Push: []Kind{KindAny}},
 	RESUME:     {Mnemonic: "resume", Pop: []Kind{KindAny, KindRef}, Push: []Kind{KindRef}},
@@ -47,8 +73,8 @@ var types = map[Opcode]Type{
 	GLOBAL_TEE: {Mnemonic: "global.tee", Widths: []int{2}},
 
 	LOCAL_GET: {Mnemonic: "local.get", Widths: []int{1}},
-	LOCAL_SET: {Mnemonic: "local.set", Widths: []int{1}, Pop: []Kind{KindAny}},
-	LOCAL_TEE: {Mnemonic: "local.tee", Widths: []int{1}},
+	LOCAL_SET: {Mnemonic: "local.set", Widths: []int{1}, Pop: []Kind{KindAny}, Flags: FlagLocalWrite},
+	LOCAL_TEE: {Mnemonic: "local.tee", Widths: []int{1}, Flags: FlagLocalWrite},
 
 	CONST_GET: {Mnemonic: "const.get", Widths: []int{2}},
 
@@ -245,7 +271,7 @@ var types = map[Opcode]Type{
 
 	ARRAY_LEN:    {Mnemonic: "array.len", Pop: []Kind{KindRef}, Push: []Kind{KindI32}},
 	ARRAY_GET:    {Mnemonic: "array.get", Pop: []Kind{KindI32, KindRef}, Push: []Kind{KindAny}},
-	ARRAY_SET:    {Mnemonic: "array.set", Pop: []Kind{KindAny, KindI32, KindRef}},
+	ARRAY_SET:    {Mnemonic: "array.set", Pop: []Kind{KindAny, KindI32, KindRef}, Flags: FlagContainerStore},
 	ARRAY_FILL:   {Mnemonic: "array.fill", Pop: []Kind{KindI32, KindAny, KindI32, KindRef}},
 	ARRAY_COPY:   {Mnemonic: "array.copy", Pop: []Kind{KindI32, KindI32, KindRef, KindI32, KindRef}},
 	ARRAY_APPEND: {Mnemonic: "array.append"},
@@ -256,7 +282,7 @@ var types = map[Opcode]Type{
 	STRUCT_NEW_DEFAULT: {Mnemonic: "struct.new_default", Widths: []int{2}, Push: []Kind{KindRef}},
 
 	STRUCT_GET: {Mnemonic: "struct.get", Pop: []Kind{KindI32, KindRef}, Push: []Kind{KindAny}},
-	STRUCT_SET: {Mnemonic: "struct.set", Pop: []Kind{KindAny, KindI32, KindRef}},
+	STRUCT_SET: {Mnemonic: "struct.set", Pop: []Kind{KindAny, KindI32, KindRef}, Flags: FlagContainerStore},
 
 	MAP_NEW:         {Mnemonic: "map.new", Widths: []int{2}},
 	MAP_NEW_DEFAULT: {Mnemonic: "map.new_default", Widths: []int{2}, Pop: []Kind{KindI32}, Push: []Kind{KindRef}},

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -830,7 +830,7 @@ func (l arm64Lowerer) fuse(ctx *lowering, ops []step, idx int) int {
 		width += operand
 	}
 	if consumer.ip != source.ip+width || source.op != instr.CONST_GET ||
-		(consumer.op != instr.CALL && consumer.op != instr.RETURN_CALL) {
+		!instr.IsCall(consumer.op) {
 		return 0
 	}
 	constant := int(source.args[0])
@@ -4556,7 +4556,7 @@ func lower(ctx *lowering, plan plan) bool {
 	ctx.leaf = true
 	for _, block := range plan.blocks {
 		for _, step := range block.steps {
-			if step.op == instr.CALL || step.op == instr.RETURN_CALL {
+			if instr.IsCall(step.op) {
 				ctx.leaf = false
 			}
 		}

--- a/interp/jit_plan.go
+++ b/interp/jit_plan.go
@@ -271,7 +271,7 @@ func staticPlan(input *compileInput) ([]plan, error) {
 			inst := instr.Instruction(input.function.Code[ip:])
 			next := ip + inst.Width()
 			step := step{op: inst.Opcode(), args: args(inst), fn: input.address, ip: ip}
-			if (inst.Opcode() == instr.CALL || inst.Opcode() == instr.RETURN_CALL) && len(flow) > 0 {
+			if instr.IsCall(inst.Opcode()) && len(flow) > 0 {
 				callee := flow[len(flow)-1]
 				if callee.calleeKnown {
 					step.callee = callee.callee
@@ -667,7 +667,7 @@ func carried(fn *types.Function, blocks []block) []int {
 			}
 		}
 		for _, step := range block.steps {
-			if step.op == instr.CALL || step.op == instr.RETURN_CALL {
+			if instr.IsCall(step.op) {
 				return nil
 			}
 			if !inside {
@@ -717,12 +717,11 @@ func hoistable(fn *types.Function, blocks []block) *hoist {
 	banned := make([]bool, len(locals))
 	for _, block := range blocks {
 		for _, step := range block.steps {
-			switch step.op {
-			case instr.CALL, instr.RETURN_CALL:
+			if instr.IsCall(step.op) {
 				return nil
-			case instr.LOCAL_SET, instr.LOCAL_TEE:
-				local := int(step.args[0])
-				if local < len(banned) {
+			}
+			if instr.WritesLocal(step.op) {
+				if local := int(step.args[0]); local < len(banned) {
 					banned[local] = true
 				}
 			}
@@ -1061,8 +1060,7 @@ func wire(p *plan, roots map[anchor]int) {
 func noSpill(blocks []block) bool {
 	for _, block := range blocks {
 		for _, step := range block.steps {
-			switch step.op {
-			case instr.ARRAY_SET, instr.STRUCT_SET:
+			if instr.StoresContainer(step.op) {
 				return true
 			}
 		}
@@ -1504,7 +1502,7 @@ func localTypes(fn *types.Function) []types.Type {
 func callFree(code []byte) bool {
 	for ip := 0; ip < len(code); {
 		inst := instr.Instruction(code[ip:])
-		if inst.Opcode() == instr.CALL || inst.Opcode() == instr.RETURN_CALL {
+		if instr.IsCall(inst.Opcode()) {
 			return false
 		}
 		ip += inst.Width()

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -240,7 +240,7 @@ func (t *tracer) capture(i *Interpreter, a anchor) (result captureResult) {
 
 		t.finish(&clone, &st, op)
 		tr.ops = append(tr.ops, st)
-		if op == instr.CALL || op == instr.RETURN_CALL {
+		if instr.IsCall(op) {
 			hasCall = true
 		}
 		// A backward edge to a different header starts a distinct loop trace.
@@ -749,7 +749,7 @@ func (t *tracer) headers(i *Interpreter, addr int) []int {
 }
 
 func (t *tracer) unrecordableReason(i *Interpreter, op instr.Opcode) prof.CaptureReason {
-	if (op == instr.CALL || op == instr.RETURN_CALL) && i.sp > 0 {
+	if instr.IsCall(op) && i.sp > 0 {
 		if i.stack[i.sp-1].Kind() != types.KindRef {
 			return prof.CaptureReasonNone
 		}


### PR DESCRIPTION
Stage 1 of the JIT lowering rework. Stacked on #197.

## Change

Three static facts about an opcode were re-derived from inline opcode lists at every use site:

- **is it a call** — `op == CALL || op == RETURN_CALL`, written out in **eight** places across the planner, the lowerer, and the tracer
- **does it assign a local** — `LOCAL_SET, LOCAL_TEE`
- **does it store into a heap container** — `ARRAY_SET, STRUCT_SET`

`instr.Type` already carries an opcode's mnemonic, operand widths, and stack effect, so these belong there too. Added a `Flags` field with `FlagCall`, `FlagLocalWrite`, `FlagContainerStore`, and the predicates `IsCall`, `WritesLocal`, `StoresContainer`.

`callFree`, `noSpill`, `hoistable`, `carried`, the static planner's call-target tracking, the lowerer's leaf detection and call fusion, and two tracer sites now share them. Adding an opcode that calls or stores no longer means finding every list that should have mentioned it.

Multi-way switches that dispatch *on* the opcode keep their `case CALL, RETURN_CALL:` arms — those select behaviour per opcode rather than asking a yes/no question, and an `if` reads worse inside them.

No behavior change: the flags reproduce exactly the opcode sets the inline lists named.

## A correction to the plan this came from

The audit behind this work claimed **"stack effects are implemented three times"** and that a follow-up stage should unify them. That is wrong, and I am recording it rather than acting on it:

- `program/verify.go:551-563` consumes `instr.Type.Pop`/`Push` generically
- `interp/jit_plan.go:1421-1432` — `applyStep` has **the same generic fallback at its tail**
- `internal/cmd/geninterp/lower.go:653` reads `instr.TypeOf(consumer).Push`

All three already read the table. `applyStep`'s 22 bespoke cases are exactly the provenance-tracking (`backing`, `slot`, declared struct/array type, known constant) and dynamic-arity opcodes — which is precisely the escape `instr.Type`'s own doc carves out: *"When both Pop and Push are nil the opcode has no statically fixed effect."*

So there is no third implementation to remove, and that stage is dropped.

## Test plan

- [x] `go test -race ./...`
- [x] `make lint`, `make check-generated`

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)