### PR TITLE
refactor(interp): resolve typed array element layout from one table

### DIFF
--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -3286,18 +3286,63 @@ func (l arm64Lowerer) stringLen(ctx *lowering, op step) bool {
 	return true
 }
 
+// elemShape describes how a typed array stores one element: the concrete heap
+// itab a container must carry, the byte offset its element data begins at, the
+// log2 element width, and whether a loaded element is an unboxed payload. The
+// primitive arrays pack their payloads and share a slice header at offset zero;
+// a ref array stores boxed elements after its own header.
+type elemShape struct {
+	itab  uintptr
+	base  int16
+	scale uint8
+	raw   bool
+}
+
+// elemShapes is the one place the element storage layout is written down.
+// arrayGet, arraySet, arrayLen, and the planner's hoist eligibility all resolve
+// through it, so a new element kind is one row rather than an edit to each.
+var elemShapes = []struct {
+	kind  types.Kind
+	shape elemShape
+}{
+	{types.KindI1, elemShape{itab: heapArrayI1, raw: true}},
+	{types.KindI8, elemShape{itab: heapArrayI8, raw: true}},
+	{types.KindI32, elemShape{itab: heapArrayI32, scale: 2, raw: true}},
+	{types.KindI64, elemShape{itab: heapArrayI64, scale: 3, raw: true}},
+	{types.KindF32, elemShape{itab: heapArrayF32, scale: 2, raw: true}},
+	{types.KindF64, elemShape{itab: heapArrayF64, scale: 3, raw: true}},
+	{types.KindRef, elemShape{itab: heapArrayRef, base: int16(arrayElems)}},
+}
+
+// elemShapeOf resolves the storage shape of an element kind.
+func elemShapeOf(kind types.Kind) (elemShape, bool) {
+	for _, row := range elemShapes {
+		if row.kind == kind {
+			return row.shape, true
+		}
+	}
+	return elemShape{}, false
+}
+
+// elemShapeByItab resolves the storage shape of a container's concrete itab.
+func elemShapeByItab(want uintptr) (elemShape, bool) {
+	for _, row := range elemShapes {
+		if row.shape.itab == want {
+			return row.shape, true
+		}
+	}
+	return elemShape{}, false
+}
+
 func (l arm64Lowerer) arrayLen(ctx *lowering, op step) bool {
 	if ctx.count() < 1 || ctx.values[len(ctx.values)-1].kind != types.KindRef {
 		return false
 	}
-	base := int16(0)
-	switch op.shape.itab {
-	case heapArrayI1, heapArrayI8, heapArrayI32, heapArrayI64, heapArrayF32, heapArrayF64:
-	case heapArrayRef:
-		base = int16(arrayElems)
-	default:
+	shape, ok := elemShapeByItab(op.shape.itab)
+	if !ok {
 		return false
 	}
+	base := shape.base
 	owned := ctx.values[len(ctx.values)-1].backing == backingStack
 	pre := ctx.pre()
 	ref, ok := l.box(ctx, ctx.values[len(ctx.values)-1])
@@ -3327,39 +3372,11 @@ func (l arm64Lowerer) arrayGet(ctx *lowering, op step) bool {
 		return false
 	}
 	kind := op.seen.Kind()
-	var want uintptr
-	var base int16
-	var scale uint8
-	var raw bool
-	switch kind {
-	case types.KindI1:
-		want = heapArrayI1
-		raw = true
-	case types.KindI8:
-		want = heapArrayI8
-		raw = true
-	case types.KindI32:
-		want = heapArrayI32
-		scale = 2
-		raw = true
-	case types.KindI64:
-		want = heapArrayI64
-		scale = 3
-		raw = true
-	case types.KindF32:
-		want = heapArrayF32
-		scale = 2
-		raw = true
-	case types.KindF64:
-		want = heapArrayF64
-		scale = 3
-		raw = true
-	case types.KindRef:
-		want = heapArrayRef
-		base = int16(arrayElems)
-	default:
+	shape, ok := elemShapeOf(kind)
+	if !ok {
 		return false
 	}
+	want, base, scale, raw := shape.itab, shape.base, shape.scale, shape.raw
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false
 	}
@@ -3450,32 +3467,11 @@ func (l arm64Lowerer) arraySet(ctx *lowering, op step) (bool, bool) {
 	}
 	container := ctx.values[len(ctx.values)-3]
 	kind := ctx.values[len(ctx.values)-1].kind
-	var want uintptr
-	var base int16
-	var scale uint8
-	switch kind {
-	case types.KindI1:
-		want = heapArrayI1
-	case types.KindI8:
-		want = heapArrayI8
-	case types.KindI32:
-		want = heapArrayI32
-		scale = 2
-	case types.KindI64:
-		want = heapArrayI64
-		scale = 3
-	case types.KindF32:
-		want = heapArrayF32
-		scale = 2
-	case types.KindF64:
-		want = heapArrayF64
-		scale = 3
-	case types.KindRef:
-		want = heapArrayRef
-		base = int16(arrayElems)
-	default:
+	shape, ok := elemShapeOf(kind)
+	if !ok {
 		return false, false
 	}
+	want, base, scale := shape.itab, shape.base, shape.scale
 	if op.shape.itab != 0 && op.shape.itab != want {
 		return false, false
 	}

--- a/interp/jit_plan.go
+++ b/interp/jit_plan.go
@@ -741,14 +741,10 @@ func hoistable(fn *types.Function, blocks []block) *hoist {
 				if depth > len(stack) || step.op == instr.ARRAY_SET && step.terminal {
 					return
 				}
-				switch step.shape.itab {
-				case itab(types.TypedArray[bool](nil)),
-					itab(types.TypedArray[int8](nil)),
-					itab(types.TypedArray[int32](nil)),
-					itab(types.TypedArray[int64](nil)),
-					itab(types.TypedArray[float32](nil)),
-					itab(types.TypedArray[float64](nil)):
-				default:
+				// Only the primitive typed arrays hoist: a ref array's
+				// elements carry ownership, which a cached slice header
+				// cannot account for.
+				if shape, ok := elemShapeByItab(step.shape.itab); !ok || !shape.raw {
 					return
 				}
 				local := stack[len(stack)-depth]


### PR DESCRIPTION
Stage 3 (second half) of the JIT lowering rework. Stacked on #199.

## Change

The element storage layout — which heap itab a container must carry, where its element data starts, how wide an element is, and whether a loaded element is an unboxed payload — was written out longhand in **four** places:

| Site | What it spelled out |
|---|---|
| `arrayGet` | full `kind → (itab, base, scale, raw)` switch |
| `arraySet` | the same switch again, minus `raw` |
| `arrayLen` | the itab set, with base offsets |
| `hoistable` (planner) | the itab set again, to mean "primitive typed array" |

`elemShapes` is now the one place that layout is written down, with `elemShapeOf` resolving by element kind and `elemShapeByItab` by concrete container itab. A new element kind is one row instead of an edit to each site, and the four sites can no longer disagree about a kind's width or base offset.

`hoistable`'s rule also reads directly now — it hoists only when the shape resolves **and its elements are raw**, because a ref array's elements carry ownership a cached slice header cannot account for. That was previously expressed by listing six itabs and omitting the seventh, leaving the reason implicit.

No behavior change: the table reproduces the same kind and itab sets, with the same base offsets and scales, that the four copies named.

## The guard combinator was evaluated and rejected

The plan called for a second extraction here — one guarded-access combinator for `arrayGet`/`arraySet` and `structGet`/`structSet`. I looked at it and did not do it, deliberately:

- `arraySet` queues **three** side exits (shape, bounds, value); `arrayGet` queues a different set
- `arraySet` runs a hoisted fast path **before** the guards and returns early from inside it
- the two differ in return arity — `(bool, bool)` vs `bool`
- the orderings that differ are exactly the ones the refcount invariants depend on

A combinator covering all of that would take more parameters than it removes, in the code where a mistake is a use-after-free rather than a style problem. The repetition here is real but shallow; the abstraction would be deep and speculative.

`arrayGetKnown` and `arrayKind` are also left alone — both dispatch on the concrete Go type of a live heap value rather than on an itab, which is a different mechanism.

## Test plan

- [x] `go test -race ./...`
- [x] `make lint`, `make check-generated`

Refs #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)