### PR TITLE
perf(interp): cache every conversion a compile reaches

### DIFF
--- a/interp/codec.go
+++ b/interp/codec.go
@@ -176,13 +176,21 @@ func (r *registry) entry(t reflect.Type) *conversion {
 }
 
 // conversion returns t's compiled form, building and caching it on first use.
+// Every type the build reached is cached with it, so a type used only inside
+// another one compiles once rather than once per referencing type. The set is
+// published only after the build succeeds, because compile holds an incomplete
+// conversion for every type still in flight.
 func (r *Registry) conversion(t reflect.Type) (*conversion, error) {
 	if p, ok := r.conversions.Load(t); ok {
 		return p.(*conversion), nil
 	}
-	p, err := r.compile(t, make(map[reflect.Type]*conversion))
+	seen := make(map[reflect.Type]*conversion)
+	p, err := r.compile(t, seen)
 	if err != nil {
 		return nil, err
+	}
+	for typ, c := range seen {
+		r.conversions.LoadOrStore(typ, c)
 	}
 	actual, _ := r.conversions.LoadOrStore(t, p)
 	return actual.(*conversion), nil

--- a/interp/codec_test.go
+++ b/interp/codec_test.go
@@ -64,6 +64,12 @@ type codecPair struct {
 	Count int32
 }
 
+type codecShared struct{ A, B int32 }
+
+type codecFirst struct{ Shared codecShared }
+
+type codecSecond struct{ Shared codecShared }
+
 func TestNewRegistry(t *testing.T) {
 	t.Run("standard library defaults", func(t *testing.T) {
 		i := interp.New(program.New(nil))
@@ -559,6 +565,49 @@ func TestRegistry_Marshal(t *testing.T) {
 		require.ErrorIs(t, err, interp.ErrUnsupportedMarshalType)
 	})
 
+	t.Run("shared nested type", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		first, err := r.Marshal(i, codecFirst{})
+		require.NoError(t, err)
+		second, err := r.Marshal(i, codecSecond{})
+		require.NoError(t, err)
+
+		// A struct type is built once per compile, so the two outer types hold
+		// the same one only when the nested type was compiled once.
+		lhs := first.Type().(*types.StructType)
+		rhs := second.Type().(*types.StructType)
+		require.Same(t, lhs.Fields[0].Type, rhs.Fields[0].Type)
+	})
+
+	t.Run("shared nested type across interpreters", func(t *testing.T) {
+		r := interp.NewRegistry()
+		i1 := interp.New(program.New(nil))
+		defer i1.Close()
+		i2 := interp.New(program.New(nil))
+		defer i2.Close()
+
+		var wg sync.WaitGroup
+		var err1, err2 error
+		var v1, v2 types.Value
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			v1, err1 = r.Marshal(i1, codecFirst{})
+		}()
+		go func() {
+			defer wg.Done()
+			v2, err2 = r.Marshal(i2, codecSecond{})
+		}()
+		wg.Wait()
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.IsType(t, &types.Struct{}, v1)
+		require.IsType(t, &types.Struct{}, v2)
+	})
 }
 
 func TestRegistry_Unmarshal(t *testing.T) {


### PR DESCRIPTION
Closes #209.

## Summary

`Registry` documents itself as resolving one conversion per Go type, but only the type passed to `Marshal`/`Unmarshal` reached the cache. `conversion()` did the `LoadOrStore`; `compile()` tracked in-flight types in a local `seen` map purely so a recursive type terminates, and dropped it on return.

So a type reached only as a struct field, array/slice element, map key or value, or function parameter/return was recompiled once per referencing top-level type — each walk allocating a fresh `*conversion`, its closures, and a fresh `*types.StructType`. Not a runtime correctness bug (the compiled forms are equivalent), but it contradicts the documented contract and the waste scales with how widely a shared type is embedded.

## What changed

`conversion()` publishes the whole `seen` set once the top-level compile returns without error. That is the only production change; `compile`, `structure`, `layout`, `methods`, and `function` are untouched.

### Why publication waits for success

`compile()` inserts a placeholder `*conversion` into `seen` **before** compiling children, so a recursive type reaches its own entry instead of recursing forever. That placeholder has nil `value`/`box`/`set` until `complete()` fills it on the way out. Publishing from inside `compile()` would hand a concurrent reader on another interpreter a conversion with nil function pointers.

After a successful top-level compile, every entry in `seen` is complete:

- no error is swallowed on the compile path — `structure`, `layout`, `methods`, and `function` all propagate a child failure — so a partial graph never reaches publication;
- `compile()` deletes the failing type from `seen` and the error reaches `conversion()`, which returns before the loop;
- a mutually recursive entry is safe to publish alone: its closures hold the other `*conversion` by pointer, and that pointer is complete at publish time regardless of map ordering;
- `sync.Map` supplies the store-before-load edge that makes the completed writes visible to another goroutine — the same guarantee the existing top-level store relied on.

Two goroutines racing on the same type still each compile it and one `LoadOrStore` loses, leaving that goroutine's graph pointing at its own equivalent instances. That is exactly what the top level already did.

## Performance

Compiling two structs that share a nested type, fresh registry per iteration, Apple M4 Pro, `-count=6`:

```go
type inner struct{ A int32; B int64; Name string; Tags []string; Meta map[string]int32 }
func (v *inner) Bump(n int32) int32 { v.A += n; return v.A }
type outerA struct{ I inner }
type outerB struct{ I inner }

i := interp.New(program.New(nil)); r := interp.NewRegistry()
r.Marshal(i, &outerA{}); r.Marshal(i, &outerB{}); i.Close()
```

| | ns/op | B/op | allocs/op |
|---|---|---|---|
| before | 8150 | 45498 | 214 |
| after | 7220 | 43760 | 186 |

A minimal `struct{ A, B int32 }` nested type saves 7 allocs; the saving scales with the nested type's size. The benchmark is throwaway — compile is a one-time path, not worth a permanent guard — so it is recorded here rather than committed.

`BenchmarkInterpreter_Marshal` and `BenchmarkInterpreter_Unmarshal` measure the warm path and are unchanged, as are the `make benchmark-pr` kernels: nothing on an executed instruction path moved.

## Tests

Two sub-cases on the existing `TestRegistry_Marshal`. The cache is private, so the invariant is asserted through public behavior: `types.NewStructType` does not intern, so a second compile of a nested struct yields a distinct `*types.StructType`, and `(*types.Struct).Type()` exposes the compiled one.

- `shared nested type` — marshal two outer types sharing a nested struct through one `Registry`, assert the nested `*types.StructType` is the same instance. Fails before the change, passes after.
- `shared nested type across interpreters` — two goroutines, one `Registry`, a separate `Interpreter` each, marshaling the two outer types concurrently. The point is the `-race` run over the new publication loop.

Threaded, fused, optimized, and JIT modes are not applicable: the change touches only compile-time caching in the codec.

## Docs

None. `docs/host-integration.md` already states the behavior this change makes true, and no public API, invariant, command, or convention changes.

## Test plan

- [x] `go test -race -run TestRegistry_Marshal ./interp`
- [x] `go test -race ./interp ./types`
- [x] `make test`
- [x] `make lint`
- [x] `make check-generated`
- [x] `go test -bench 'Marshal|Unmarshal' -benchmem ./interp` — warm path unmoved
- [x] `make benchmark-pr` — kernels unmoved
- [ ] `make coverage-check` — fails locally from a goenv split (`compile: version "go1.26.2" does not match go tool version "go1.25.0"`), unrelated to this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversion caching for nested data types.
  * Ensured nested structures are reused consistently within a registry.
  * Improved safety when marshaling data concurrently across interpreters.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->