### PR TITLE
perf(interp): read a scalar map key without boxing it

### DIFF
--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -284,11 +284,11 @@ Rules:
 - use a concrete Go destination type to recover Go-native values
 - bytecode can recover dynamic type with `REF_TEST` and `REF_CAST`
 
-A map declared with a primitive or `string` key type becomes a `*TypedMap[K]` indexed by value. Any other key type — `interface{}`, a named interface, a struct, an array, a pointer — produces a generic `*Map`.
+A map declared with a primitive or `string` key type becomes a `*TypedMap[K]` indexed by value. A pointer key follows the type it points at, so `map[*int32]V` is a `*TypedMap[int32]` keyed by the pointed-to value, and a nil pointer key fails with `ErrTypeMismatch` because it has no such value. Any other key type — `interface{}`, a named interface, a struct, an array, a pointer to one of those — produces a generic `*Map`.
 
-Either way a marshaled entry is indexed exactly as `MAP_GET` and `MAP_SET` index it, because conversion and the opcodes share `(*Interpreter).mapKey`: scalars by value, strings by content, every other reference by heap address. A guest lookup with an equal key finds the entry.
+Either way a marshaled entry is indexed exactly as `MAP_GET` and `MAP_SET` index it: a typed map stores the key as its Go value, a generic map goes through `(*Interpreter).mapKey`, and both agree — scalars by value, strings by content, every other reference by heap address. A guest lookup with an equal key finds the entry.
 
-A struct, array, or pointer key is therefore reachable only through the same reference, since the VM has no content equality for those. Prefer a scalar or string key, or build the map inside the VM.
+A struct or array key, or a pointer to one, is therefore reachable only through the same reference, since the VM has no content equality for those. Prefer a scalar or string key, or build the map inside the VM.
 
 ## Structs and Methods
 

--- a/interp/codec_test.go
+++ b/interp/codec_test.go
@@ -2,6 +2,7 @@ package interp_test
 
 import (
 	"context"
+	"math"
 	"reflect"
 	"sync"
 	"testing"
@@ -63,6 +64,8 @@ type codecPair struct {
 	Delay codecMillis
 	Count int32
 }
+
+type codecWide int32
 
 type codecShared struct{ A, B int32 }
 
@@ -459,6 +462,12 @@ func TestRegistry_Marshal(t *testing.T) {
 			key:   instr.New(instr.I32_CONST, 1),
 			want:  types.I32(7),
 		},
+		{
+			name:  "i64 key past the boxed payload",
+			value: map[int64]int32{1 << 50: 7},
+			key:   instr.New(instr.I64_CONST, 1<<50),
+			want:  types.I32(7),
+		},
 	} {
 		t.Run("map key reachable from a guest lookup: "+tt.name, func(t *testing.T) {
 			prog := program.New(
@@ -479,6 +488,85 @@ func TestRegistry_Marshal(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+
+	t.Run("a scalar key is stored without a heap reference", func(t *testing.T) {
+		// One heap slot is the permanent null, so this interpreter can allocate
+		// nothing: a key routed through a slot would exhaust the heap here.
+		i := interp.New(program.New(nil), interp.WithHeapLimit(1))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		value, err := r.Marshal(i, map[int64]int32{1 << 50: 7})
+		require.NoError(t, err)
+
+		got, ok := value.(*types.TypedMap[int64]).Get(1 << 50)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(7), got)
+	})
+
+	t.Run("every scalar key kind keeps its Go value", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		bools, err := r.Marshal(i, map[bool]int32{true: 1})
+		require.NoError(t, err)
+		gotBool, ok := bools.(*types.TypedMap[bool]).Get(true)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(1), gotBool)
+
+		bytes, err := r.Marshal(i, map[int8]int32{-3: 2})
+		require.NoError(t, err)
+		gotByte, ok := bytes.(*types.TypedMap[int8]).Get(-3)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(2), gotByte)
+
+		words, err := r.Marshal(i, map[int32]int32{math.MinInt32: 3})
+		require.NoError(t, err)
+		gotWord, ok := words.(*types.TypedMap[int32]).Get(math.MinInt32)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(3), gotWord)
+
+		longs, err := r.Marshal(i, map[int64]int32{math.MinInt64: 4})
+		require.NoError(t, err)
+		gotLong, ok := longs.(*types.TypedMap[int64]).Get(math.MinInt64)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(4), gotLong)
+
+		floats, err := r.Marshal(i, map[float32]int32{-1.5: 5})
+		require.NoError(t, err)
+		gotFloat, ok := floats.(*types.TypedMap[float32]).Get(-1.5)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(5), gotFloat)
+
+		doubles, err := r.Marshal(i, map[float64]int32{-1.5: 6})
+		require.NoError(t, err)
+		gotDouble, ok := doubles.(*types.TypedMap[float64]).Get(-1.5)
+		require.True(t, ok)
+		require.Equal(t, types.BoxI32(6), gotDouble)
+	})
+
+	t.Run("a map key wider than its declared type overflows", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry(interp.WithMarshaler(
+			reflect.TypeFor[codecWide](), types.TypeI32,
+			interp.MarshalerFunc(func(*interp.Encoder, unsafe.Pointer) (types.Value, error) {
+				return types.I64(math.MaxInt32 + 1), nil
+			})))
+		defer i.Close()
+
+		_, err := r.Marshal(i, map[codecWide]int32{0: 7})
+		require.ErrorIs(t, err, interp.ErrValueOverflow)
+	})
+
+	t.Run("a nil pointer key has no scalar value", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		_, err := r.Marshal(i, map[*int32]int32{nil: 7})
+		require.ErrorIs(t, err, interp.ErrTypeMismatch)
+	})
 
 	t.Run("a marshaled alias keeps its target alive", func(t *testing.T) {
 		i := interp.New(program.New(nil))

--- a/interp/encode.go
+++ b/interp/encode.go
@@ -556,17 +556,35 @@ func marshalMap(t reflect.Type, mt *types.MapType, key, elem *conversion) func(*
 func mapWriter(mt *types.MapType, key *conversion) func(*Encoder, types.Value, unsafe.Pointer, types.Boxed) error {
 	switch mt.KeyKind {
 	case types.KindI1:
-		return typedMap(key, func(_ *Encoder, b types.Boxed) bool { return b.Bool() })
+		return typedMap(key, func(val types.Value) (bool, error) {
+			n, err := keyInt(val, mt.Key)
+			return n != 0, err
+		})
 	case types.KindI8:
-		return typedMap(key, func(_ *Encoder, b types.Boxed) int8 { return b.I8() })
+		return typedMap(key, func(val types.Value) (int8, error) {
+			n, err := keyInt(val, mt.Key)
+			return int8(n), err
+		})
 	case types.KindI32:
-		return typedMap(key, func(_ *Encoder, b types.Boxed) int32 { return b.I32() })
+		return typedMap(key, func(val types.Value) (int32, error) {
+			n, err := keyInt(val, mt.Key)
+			if err != nil {
+				return 0, err
+			}
+			if n < math.MinInt32 || n > math.MaxInt32 {
+				return 0, fmt.Errorf("%w: %d overflows i32", ErrValueOverflow, n)
+			}
+			return int32(n), nil
+		})
 	case types.KindI64:
-		return typedMap(key, func(e *Encoder, b types.Boxed) int64 { return e.interp.unboxI64(b) })
+		return typedMap(key, func(val types.Value) (int64, error) { return keyInt(val, mt.Key) })
 	case types.KindF32:
-		return typedMap(key, func(_ *Encoder, b types.Boxed) float32 { return b.F32() })
+		return typedMap(key, func(val types.Value) (float32, error) {
+			f, err := keyFloat(val, mt.Key)
+			return float32(f), err
+		})
 	case types.KindF64:
-		return typedMap(key, func(_ *Encoder, b types.Boxed) float64 { return b.F64() })
+		return typedMap(key, func(val types.Value) (float64, error) { return keyFloat(val, mt.Key) })
 	}
 	if mt.Key.Equals(types.TypeString) {
 		return func(e *Encoder, m types.Value, p unsafe.Pointer, value types.Boxed) error {
@@ -605,13 +623,39 @@ func mapWriter(mt *types.MapType, key *conversion) func(*Encoder, types.Value, u
 	}
 }
 
-func typedMap[K comparable](key *conversion, conv func(*Encoder, types.Boxed) K) func(*Encoder, types.Value, unsafe.Pointer, types.Boxed) error {
+// typedMap stores one entry of a map that holds its keys as Go values. The key
+// is read as a standalone value and narrowed straight to K: routing it through a
+// slot first would allocate a heap reference for an i64 too large to box and then
+// drop it, since such a map never stores a key as a reference.
+func typedMap[K comparable](key *conversion, narrow func(types.Value) (K, error)) func(*Encoder, types.Value, unsafe.Pointer, types.Boxed) error {
 	return func(e *Encoder, m types.Value, p unsafe.Pointer, value types.Boxed) error {
-		boxed, err := key.box(e, p)
+		val, err := key.value(e, p)
 		if err != nil {
 			return err
 		}
-		m.(*types.TypedMap[K]).Set(conv(e, boxed), value)
+		k, err := narrow(val)
+		if err != nil {
+			return err
+		}
+		m.(*types.TypedMap[K]).Set(k, value)
 		return nil
 	}
+}
+
+// keyInt and keyFloat read a map key as the VM scalar its declared key type
+// fixed, naming that type when the compiled conversion produced another.
+func keyInt(val types.Value, typ types.Type) (int64, error) {
+	n, ok := asInt(val)
+	if !ok {
+		return 0, fmt.Errorf("%w: source=%T target=%s", ErrTypeMismatch, val, typ)
+	}
+	return n, nil
+}
+
+func keyFloat(val types.Value, typ types.Type) (float64, error) {
+	f, ok := asFloat(val)
+	if !ok {
+		return 0, fmt.Errorf("%w: source=%T target=%s", ErrTypeMismatch, val, typ)
+	}
+	return f, nil
 }

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -8776,6 +8776,11 @@ func BenchmarkInterpreter_Marshal(b *testing.B) {
 	for idx := range 16 {
 		entries[string(rune('a'+idx))] = int32(idx)
 	}
+	// Keys past the boxed payload, the shape a slot round trip allocates for.
+	counters := make(map[int64]int32, 16)
+	for idx := range 16 {
+		counters[1<<50+int64(idx)] = int32(idx)
+	}
 
 	for _, tt := range []struct {
 		name  string
@@ -8785,6 +8790,7 @@ func BenchmarkInterpreter_Marshal(b *testing.B) {
 		{name: "struct", value: marshalBenchData{Count: 7, Ratio: 2.5, Name: "x", Flag: true}},
 		{name: "slice", value: elems},
 		{name: "map", value: entries},
+		{name: "map i64 key", value: counters},
 		{name: "methods", value: &marshalBenchMethods{Count: 7}},
 	} {
 		b.Run(tt.name, func(b *testing.B) {


### PR DESCRIPTION
## Summary

`typedMap` built each map key with `key.box` and narrowed the box straight back to `K` on the next line. A map whose declared key kind is a scalar stores the key as a Go value, so the slot form was dead on arrival.

For `KindI64` it also allocated: `boxI64` takes a heap reference for any `int64` outside the boxed payload, and `unboxI64` released it one statement later. Every large-magnitude key of a `map[int64]V`, `map[uint64]V`, `map[int]V`, `map[uint]V`, or `map[uintptr]V` cost one `Alloc` plus one `Release` for a value the map never holds as a reference, and such a map could exhaust a limited heap outright. The allocation also left a stale address in `Encoder.owned`, which `unboxI64` frees without removing, so a later failure made `discard()` release an already-reclaimed slot.

`typedMap` now reads the key through `key.value`, which never allocates for a leaf conversion, and narrows the returned value to `K` through the existing `asInt`/`asFloat` readers. Each kind reproduces what `boxAs` plus the matching `Boxed` accessor produced, including the i32 bounds check that a registered marshaler declaring a narrower VM type can still trip. The string and ref branches of `mapWriter` are unchanged — the ref branch needs the box, because `mapKey` keys by heap address.

## Behavior change

A nil pointer key. `map[*int32]V` compiles to `TypedMap[int32]`, and `key.box` answered `BoxedNull`, which read back as the key `0` and collided with a real `0` key. `key.value` answers `Null`, which `asInt` rejects, so the entry now reports `ErrTypeMismatch` — what the string branch already did for a nil `*string` key. `docs/host-integration.md` documented pointer keys as producing a generic `*Map`, which was wrong for a pointer to a primitive; that paragraph is corrected.

## Benchmark

`BenchmarkInterpreter_Marshal` gains a `map i64 key` row, 16 keys past the boxed payload; the existing rows measure only string keys.

`goos: darwin, goarch: arm64, cpu: Apple M4 Pro, -benchtime=300ms -count=6`

| BenchmarkInterpreter_Marshal | ns/op | B/op | allocs/op |
|---|---|---|---|
| map i64 key, before | 1497 | 1328 | 32 |
| map i64 key, after | 1077 | 1080 | 27 |

`map`, `struct`, `slice`, `scalar`, and `methods` are unmoved, as are the `benchmark-pr` kernels: no executed instruction path changes.

Collapsing the string branch into `typedMap` was measured and rejected — the extra indirect call per entry cost about 2% on the string-key row (1108 → 1132 ns/op, best of 10 at `-benchtime=500ms`).

## Test plan

- [x] `go test -race -run 'TestRegistry_Marshal|TestRegistry_Unmarshal' ./interp`
- [x] `go test -race ./interp ./types`
- [x] `make test`
- [x] `make lint`
- [x] `make check-generated`
- [x] `go test -run='^$' -bench 'BenchmarkInterpreter_(Marshal|Unmarshal)' -benchmem ./interp`
- [x] `make benchmark-pr`
- [ ] `make coverage-check` — fails from the local goenv go1.25/1.26 split (`compile: version "go1.26.2" does not match go tool version "go1.25.0"`), unrelated to this change

New coverage in `TestRegistry_Marshal`: a large i64 key marshaled under `WithHeapLimit(1)` (red before this change with `heap exhausted`), one round trip per scalar key kind, the nil pointer key, a key wider than its declared VM type, and a guest `MAP_GET` lookup of a key past the boxed payload.

Closes #210
