### PR TITLE
feat(interp)!: expose a Go struct the VM cannot copy as a live view

### DIFF
--- a/cli/repl.go
+++ b/cli/repl.go
@@ -311,9 +311,9 @@ func (r *REPL) clear() {
 }
 
 // save writes the current program to path in Program.String() format,
-// which program.Parse can read back. A *interp.HostFunction has no textual
-// form, so a program holding one cannot round-trip; reject the save before
-// producing an unreadable file.
+// which program.Parse can read back. A host value has no textual form, so a
+// program holding one cannot round-trip; reject the save before producing an
+// unreadable file.
 func (r *REPL) save(path string) error {
 	if path == "" {
 		return fmt.Errorf("usage: .save <file>")
@@ -322,8 +322,9 @@ func (r *REPL) save(path string) error {
 		return fmt.Errorf(".save disabled: no filesystem configured")
 	}
 	for i, c := range r.constants {
-		if _, ok := c.(*interp.HostFunction); ok {
-			return fmt.Errorf("cannot save: constant %d is a host function (no textual form)", i)
+		switch c.(type) {
+		case *interp.HostFunction, *interp.HostStruct:
+			return fmt.Errorf("cannot save: constant %d is a host value (no textual form)", i)
 		}
 	}
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,6 +145,7 @@ Each `Interpreter` is single-goroutine-owned during use. `Pool` lets multiple go
 - Values that contain refs must implement `types.Traceable`.
 - Large `i64` values may spill to the heap while preserving bytecode semantics.
 - Strings carry no identity invariant: every comparison and every map keyed by a string compares content, so equal contents may occupy different refs. Only the constant pool deduplicates, at load time.
+- A host value never owns a VM reference. A Go field holding a `types.Value` stays out of a `HostStruct` layout, and a field write copies what the VM value holds rather than storing the slot, so a host value implements no `types.Traceable` and reclaims nothing.
 
 See `memory-model.md` and `value-representation.md` for the detailed rules.
 
@@ -199,7 +200,7 @@ See `pass-system.md` for optimizer levels and rewrite rules.
 | Architecture support | Keep ARM64 stable; add other backends only with clear user and benchmark value |
 | Benchmarks | Keep benchmark claims tied to `docs/benchmarks.md` |
 | Program format | Keep `instr` and `program` compact and Go-native |
-| Host integration | Keep `HostFunction`, `Marshal`, and `Unmarshal` explicit about ownership |
+| Host integration | Keep `HostFunction`, `HostStruct`, `Marshal`, and `Unmarshal` explicit about ownership |
 | Resource policy | Keep context, fuel, hooks, stack, heap, frame limits, and host policy easy to reason about |
 
 ## Maintenance Notes

--- a/docs/guides/repl.md
+++ b/docs/guides/repl.md
@@ -48,7 +48,7 @@ Enter one assembly instruction per line. The REPL executes the accumulated progr
 
 `.load` replaces state rather than merging it. Merging would require renumbering constant and type indexes embedded in instructions.
 
-`.save` refuses programs holding an `*interp.HostFunction` constant, because that value has no textual representation.
+`.save` refuses programs holding a host value constant — an `*interp.HostFunction` or an `*interp.HostStruct` — because neither has a textual representation.
 
 ## Debugging
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -215,8 +215,9 @@ The built-in codec compiles and caches one conversion per Go type. Compilation i
 | other `[]T` | `*Array` ref | generic fallback |
 | `map[K]V` with a primitive or `string` key | `*TypedMap[K]` ref | key type drives the concrete map; content-keyed |
 | other `map[K]V` | `*Map` ref | heap ref identity keys |
-| struct | `*Struct` ref | exported fields, then exported methods of `*T` |
-| defined scalar with methods | underlying scalar | keeps primitive fast path |
+| struct | `*Struct` ref | exported fields, in declaration order |
+| struct with methods or unexported fields | `*HostStruct` ref | live view of the Go struct |
+| defined scalar or string with methods | underlying scalar or `string` | keeps primitive fast path |
 | `*T` | `T` or `Null` | nil pointer becomes `Null` |
 | `func(...)` | `*HostFunction` ref | final `error` return is host-only |
 | `interface{}` / `any` | `ref` | dynamic value |
@@ -237,7 +238,7 @@ A Go function marshals to `*HostFunction`.
 
 A final `error` return is treated as a host error. If it returns non-nil, the VM call fails with that error.
 
-An exact first `context.Context` parameter is host-only and omitted from the VM function signature. When guest code calls the marshaled function, minivm passes the active `Interpreter.Context`; a nil active context is normalized to `context.Background()`. The same rule applies to exported host-object methods. A `context.Context` in any other position is converted as an ordinary VM argument.
+An exact `context.Context` parameter is host-only and omitted from the VM function signature, wherever it appears. When guest code calls the marshaled function, minivm passes the active `Interpreter.Context`; a nil active context is normalized to `context.Background()`. Position does not matter because a method expression carries its receiver first, and the context that follows it is no less host-only for that.
 
 ```go
 add := func(a, b int32) (int32, error) {
@@ -292,12 +293,17 @@ A struct or array key, or a pointer to one, is therefore reachable only through 
 
 ## Structs and Methods
 
-A Go struct marshals to a native `*types.Struct`: exported data fields become
-real slots in declaration order, followed by one slot per exported method of
-the pointer receiver, each holding a bound `*HostFunction`. Fields with no VM
-representation are skipped, and a method whose name a field already took is
-dropped. A pointer to a defined scalar with methods reserves field `0` as
-`Value`.
+A Go struct whose state a copy can reproduce marshals to a native
+`*types.Struct`: exported data fields become real slots in declaration order,
+and a field with no VM representation is skipped.
+
+A struct carrying **unexported fields**, or one with any method on `*T`,
+marshals to a `*interp.HostStruct` instead — a live view of the Go struct rather
+than a snapshot of it. A copy would lose that state: unexported fields have no
+slot, and a mutation a pointer receiver makes lands on the copy. The view
+reports the same VM struct type a copy would have reported, so guest code reads
+and writes it with `STRUCT_GET` and `STRUCT_SET` exactly as it reads a native
+struct, and those reads and writes address the Go memory in place.
 
 ```go
 type Counter struct {
@@ -305,29 +311,35 @@ type Counter struct {
     count int
 }
 
-func (c *Counter) Bump() int32 { c.count++; return int32(c.count) }
+func (c *Counter) Bump(n int32) int32 { c.count += int(n); return int32(c.count) }
 
-// vm.Marshal(&Counter{Name: "a"}) yields *types.Struct{Name, Bump}
+c := &Counter{Name: "a"}
+obj, _ := vm.Marshal(c)                 // *interp.HostStruct{Name}
+bump, _ := vm.Marshal((*Counter).Bump)  // *interp.HostFunction
 ```
 
-Because the result is a native struct, `STRUCT_GET` and `STRUCT_SET` read and
-write it directly and the fused and JIT paths apply, with no separate host
-representation to fall back from.
+Methods are not fields. A method is an ordinary Go function, so a **method
+expression** marshals through the same path any `func` does, with the receiver
+as its first parameter. Called with the host value, it mutates the value the
+caller marshaled; called with any other VM value, the receiver decodes into a
+fresh Go value and the call still runs, with the mutation staying on that copy.
+A **method value** — `c.Bump`, already bound — marshals just as well and takes
+no receiver parameter.
 
-Unexported state stays reachable without being visible: each bound method
-closes over the Go receiver, so a method that reads or mutates a private field
-behaves exactly as it does in Go. When the marshaled value is a pointer,
-methods bind to the caller's pointer and Go-side state stays live and
-observable in Go; when it is a value, they bind to the copy the conversion
-allocates.
+A host view never owns a VM reference, so a Go field whose type is a
+`types.Value` stays out of the layout. Writing a field copies what the VM value
+holds into the Go field rather than storing the slot, so a reference the write
+carried is released rather than retained.
 
-VM writes to a data slot change the VM struct only. They do not reach the Go
-value, and a bound method does not observe them. `Unmarshal` recovers exported
-fields; unexported state is not recoverable from the VM value.
+When the marshaled value is a pointer, the view addresses the caller's value and
+Go-side state stays observable in Go; when it is a value, it addresses the copy
+the conversion allocates. `Unmarshal` recovers the whole Go value from a host
+view, unexported state included, and falls back to the structural decode for any
+other VM value.
 
-Binding allocates one heap reference per method. If the heap is exhausted part
-way through, the references already bound are released and `Marshal` returns
-`ErrHeapExhausted`.
+An `interp.Interpreter` is passed into each field access rather than captured, so
+a host view reached from a program constant is safe to share across pooled
+interpreters.
 
 ## Unmarshal
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -257,7 +257,7 @@ result, err := add(2, 3)
 
 The Go and VM signatures must map to equal VM function types. A final Go `error` return is host-only: VM traps and bridge errors are returned there. Without a final `error`, those failures panic. Calls must not overlap another `Run` or callable-wrapper call on the same interpreter. Wrappers use the interpreter heap and become invalid when their referenced function no longer survives normal `Release`, `Reset`, or `Close` ownership rules.
 
-When a VM function, closure, or live function ref is unmarshaled into a Go function wrapper, an exact first `context.Context` parameter is host-only and omitted from the VM signature. The wrapper passes it to VM execution, so cancellation and `Interpreter.Context` use the caller's context. A nil caller context and wrappers without a context parameter use `context.Background()`. A `context.Context` in any other position is converted as an ordinary VM argument.
+When a VM function, closure, or live function ref is unmarshaled into a Go function wrapper, an exact `context.Context` parameter is host-only and omitted from the VM signature, wherever it appears. The wrapper passes it to VM execution, so cancellation and `Interpreter.Context` use the caller's context. A nil caller context and wrappers without a context parameter use `context.Background()`.
 
 VM-native scalar types can reduce conversion overhead.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -65,7 +65,7 @@ ARM64 instruction factories are the sole shared-family exception. `TestEncoder_E
 | `cli` | 6 | 6 | 0 | 0 |
 | `debug` | 12 | 12 | 0 | 0 |
 | `instr` | 44 | 44 | 0 | 0 |
-| `interp` | 59 | 59 | 0 | 0 |
+| `interp` | 64 | 64 | 0 | 0 |
 | `optimize` | 4 | 4 | 0 | 0 |
 | `pass` | 9 | 9 | 0 | 0 |
 | `prof` | 22 | 22 | 0 | 0 |
@@ -354,6 +354,11 @@ ARM64 instruction factories are the sole shared-family exception. `TestEncoder_E
 | `interp/host.go` | `TestHostFunction_Kind` | ✅ |
 | `interp/host.go` | `TestHostFunction_String` | ✅ |
 | `interp/host.go` | `TestHostFunction_Type` | ✅ |
+| `interp/host.go` | `TestHostStruct_Field` | ✅ |
+| `interp/host.go` | `TestHostStruct_Kind` | ✅ |
+| `interp/host.go` | `TestHostStruct_SetField` | ✅ |
+| `interp/host.go` | `TestHostStruct_String` | ✅ |
+| `interp/host.go` | `TestHostStruct_Type` | ✅ |
 | `interp/host.go` | `TestNewHostFunction` | ✅ |
 | `interp/interp.go` | `TestInterpreter_Alloc` | ✅ |
 | `interp/interp.go` | `TestInterpreter_Close` | ✅ |

--- a/docs/value-representation.md
+++ b/docs/value-representation.md
@@ -193,6 +193,7 @@ User-defined heap types do not add new `Kind` values. They use `KindRef` like ot
 | `types.Ref` | `KindRef` | `TypeAny` | heap index wrapper |
 | `types.String` | `KindRef` | `TypeString` | heap value |
 | arrays, structs, maps, functions, closures, host values | `KindRef` | type-specific | heap values |
+| `HostStruct` | `KindRef` | the `*StructType` a copy would have had | live view of a Go struct; owns no refs |
 
 If a heap value contains refs, it must implement `Traceable`. If a heap value owns external resources, it may implement `io.Closer`.
 

--- a/internal/cmd/geninterp/lower.go
+++ b/internal/cmd/geninterp/lower.go
@@ -4334,6 +4334,7 @@ func structSet() jen.Code {
 						jen.Id("i").Dot("releaseBox").Call(jen.Id("old")),
 						jen.List(jen.Id("s").Dot("Data").Index(jen.Id("idx"))).Op("=").List(jen.Id("uint64").Call(jen.Id("val")))),
 					jen.Default().Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch"))))),
+				jen.Case(jen.Op("*").Add(jen.Id("HostStruct"))).Block(jen.If(jen.List(jen.Id("err")).Op(":=").List(jen.Id("s").Dot("SetField").Call(jen.Id("i"), jen.Id("idx"), jen.Id("val"))), jen.Id("err").Op("!=").Add(jen.Id("nil"))).Block(jen.Id("panic").Call(jen.Id("err")))),
 				jen.Default().Block(jen.Id("panic").Call(jen.Id("ErrTypeMismatch")))),
 			jen.Id("i").Dot("release").Call(jen.Id("addr")),
 			jen.List(jen.Id("i").Dot("sp")).Op("-=").List(jen.Lit(3)),

--- a/interp/codec.go
+++ b/interp/codec.go
@@ -45,10 +45,14 @@ type registry struct {
 // form Marshal returns and an interface slot stores, while box produces a slot
 // of vm, allocating a heap ref when the slot needs one. set is the reverse of
 // both, because a slot resolves to a value before it is written back.
+//
+// host marks a conversion whose value is a live view of the Go value rather than
+// a copy of it, which is what lets a pointer to it stay the caller's pointer.
 type conversion struct {
 	typ  reflect.Type
 	kind reflect.Kind
 	vm   types.Type
+	host bool
 
 	value func(*Encoder, unsafe.Pointer) (types.Value, error)
 	box   func(*Encoder, unsafe.Pointer) (types.Boxed, error)
@@ -60,13 +64,6 @@ type field struct {
 	name       string
 	offset     uintptr
 	conversion *conversion
-}
-
-// method binds one exported method of the receiver type as a VM function field.
-type method struct {
-	name  string
-	index int
-	typ   *types.FunctionType
 }
 
 var (
@@ -299,7 +296,7 @@ func (r *Registry) structure(p *conversion, seen map[reflect.Type]*conversion) e
 		return nil
 
 	case reflect.Func:
-		fn, err := r.function(t, 0, seen)
+		fn, err := r.function(t, seen)
 		if err != nil {
 			return err
 		}
@@ -313,8 +310,9 @@ func (r *Registry) structure(p *conversion, seen map[reflect.Type]*conversion) e
 		if err != nil {
 			return err
 		}
-		p.vm = types.NewArrayType(elem.vm)
-		p.value = marshalArray(t, p.vm.(*types.ArrayType), elem)
+		at := types.NewArrayType(elem.vm)
+		p.vm = at
+		p.value = marshalArray(t, at, elem)
 		p.set = unmarshalArray(t, elem)
 		return nil
 
@@ -334,12 +332,24 @@ func (r *Registry) structure(p *conversion, seen map[reflect.Type]*conversion) e
 		return nil
 
 	case reflect.Struct:
-		vm, fields, methods, err := r.layout(t, seen)
+		// A copy of this struct would lose state no VM value carries -
+		// unexported fields have no slot, and a pointer receiver's mutation
+		// lands on the copy - so it is exposed as a live view instead.
+		p.host = reflect.PointerTo(t).NumMethod() > 0
+		for idx := 0; idx < t.NumField() && !p.host; idx++ {
+			p.host = t.Field(idx).PkgPath != ""
+		}
+		vm, fields, err := r.layout(t, seen, p.host)
 		if err != nil {
 			return err
 		}
 		p.vm = vm
-		p.value = marshalStruct(t, vm, fields, methods)
+		if p.host {
+			p.value = marshalHostStruct(t, vm, fields)
+			p.set = unmarshalHost(t, unmarshalStruct(fields))
+			return nil
+		}
+		p.value = marshalStruct(vm, fields)
 		p.set = unmarshalStruct(fields)
 		return nil
 	}
@@ -347,72 +357,51 @@ func (r *Registry) structure(p *conversion, seen map[reflect.Type]*conversion) e
 }
 
 // layout compiles a Go struct into a VM struct type: exported data fields in
-// declaration order, then the exported methods of the pointer receiver. A field
-// whose type has no VM representation is skipped, and a method name already
-// taken by a field is dropped.
-func (r *Registry) layout(t reflect.Type, seen map[reflect.Type]*conversion) (*types.StructType, []field, []method, error) {
+// declaration order. A field whose type has no VM representation is skipped,
+// and a host layout also skips a field holding a VM value, because a host value
+// never owns a VM reference.
+func (r *Registry) layout(t reflect.Type, seen map[reflect.Type]*conversion, host bool) (*types.StructType, []field, error) {
 	var slots []types.StructField
 	var fields []field
-	names := make(map[string]bool)
 
 	for idx := range t.NumField() {
 		f := t.Field(idx)
 		if f.PkgPath != "" {
 			continue
 		}
+		if host {
+			// A host value never owns a VM reference, so a Go field that holds
+			// one stays out of the layout.
+			if _, ok := natives[f.Type]; ok || f.Type.Implements(typeValue) {
+				continue
+			}
+		}
 		child, err := r.compile(f.Type, seen)
 		if err != nil {
-			return nil, nil, nil, fmt.Errorf("struct field %s: %w", f.Name, err)
+			return nil, nil, fmt.Errorf("struct field %s: %w", f.Name, err)
 		}
 		slots = append(slots, types.NewStructField(child.vm, types.FieldWithName(f.Name)))
 		fields = append(fields, field{name: f.Name, offset: f.Offset, conversion: child})
-		names[f.Name] = true
 	}
-
-	methods, err := r.methods(t, names, seen)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	for _, m := range methods {
-		slots = append(slots, types.NewStructField(m.typ, types.FieldWithName(m.name)))
-	}
-	return types.NewStructType(slots...), fields, methods, nil
+	return types.NewStructType(slots...), fields, nil
 }
 
-// methods compiles the exported methods of *t, skipping any name already used
-// and any signature with no VM mapping.
-func (r *Registry) methods(t reflect.Type, names map[string]bool, seen map[reflect.Type]*conversion) ([]method, error) {
-	ptr := reflect.PointerTo(t)
-	var out []method
-	for idx := range ptr.NumMethod() {
-		m := ptr.Method(idx)
-		if !m.IsExported() || names[m.Name] {
+// function compiles a Go function signature into a VM function type. An exact
+// context.Context parameter and a trailing error return stay on the host side,
+// so they do not appear in the VM signature. Position does not matter for the
+// context: a method expression carries its receiver first, and the context that
+// follows is no less host-only for it.
+func (r *Registry) function(t reflect.Type, seen map[reflect.Type]*conversion) (*types.FunctionType, error) {
+	var params []types.Type
+	for idx := range t.NumIn() {
+		if t.In(idx) == typeContext {
 			continue
 		}
-		fn, err := r.function(m.Func.Type(), 1, seen)
-		if err != nil {
-			return nil, fmt.Errorf("method %s: %w", m.Name, err)
-		}
-		out = append(out, method{name: m.Name, index: idx, typ: fn})
-		names[m.Name] = true
-	}
-	return out, nil
-}
-
-// function compiles a Go function signature into a VM function type, skipping
-// the first skip parameters, an exact leading context.Context, and a trailing
-// error return, all of which stay on the host side.
-func (r *Registry) function(t reflect.Type, skip int, seen map[reflect.Type]*conversion) (*types.FunctionType, error) {
-	if skip < t.NumIn() && t.In(skip) == typeContext {
-		skip++
-	}
-	params := make([]types.Type, t.NumIn()-skip)
-	for idx := range params {
-		p, err := r.compile(t.In(idx+skip), seen)
+		p, err := r.compile(t.In(idx), seen)
 		if err != nil {
 			return nil, fmt.Errorf("function param %d: %w", idx, err)
 		}
-		params[idx] = p.vm
+		params = append(params, p.vm)
 	}
 	outs := t.NumOut()
 	if outs > 0 && t.Out(outs-1).Implements(typeError) {

--- a/interp/codec_test.go
+++ b/interp/codec_test.go
@@ -21,8 +21,13 @@ type marshalCustom int32
 type marshalContextKey byte
 
 type marshalHostFields struct {
-	Count int32
+	Count  int32
+	hidden int32
 }
+
+func (v *marshalHostFields) mark(n int32) { v.hidden = n }
+
+func (v marshalHostFields) marked() int32 { return v.hidden }
 
 func (v *marshalHostFields) Bump(n int32) int32 {
 	v.Count += n
@@ -68,6 +73,16 @@ type codecPair struct {
 type codecWide int32
 
 type codecShared struct{ A, B int32 }
+
+// codecHeld holds a VM value next to an exported field, so a host layout has to
+// leave the VM-valued field out rather than own the reference it names.
+type codecHeld struct {
+	Count int32
+	Held  types.Value
+	tag   int32
+}
+
+func (h *codecHeld) Tag() int32 { return h.tag }
 
 type codecFirst struct{ Shared codecShared }
 
@@ -227,18 +242,22 @@ func TestRegistry_Marshal(t *testing.T) {
 		require.Equal(t, ctx, got)
 	})
 
-	t.Run("bound method receives active context", func(t *testing.T) {
+	t.Run("a method receives the active context", func(t *testing.T) {
 		setup := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer setup.Close()
-		value, err := r.Marshal(setup, marshalHostFields{})
+		obj, err := r.Marshal(setup, marshalHostFields{})
 		require.NoError(t, err)
-		host := value.(*types.Struct)
-		method := host.Field(host.Typ.FieldIndex("Context"))
-		fn, err := setup.Load(method.Ref())
+		fn, err := r.Marshal(setup, (*marshalHostFields).Context)
 		require.NoError(t, err)
 
-		prog := program.New([]instr.Instruction{instr.New(instr.CONST_GET, 0), instr.New(instr.CALL)}, program.WithConstants(fn))
+		// The receiver is the first parameter, so guest code pushes the host
+		// value ahead of the function it calls.
+		prog := program.New([]instr.Instruction{
+			instr.New(instr.CONST_GET, 1),
+			instr.New(instr.CONST_GET, 0),
+			instr.New(instr.CALL),
+		}, program.WithConstants(fn, obj))
 		i := interp.New(prog)
 		defer i.Close()
 		ctx := context.WithValue(context.Background(), marshalContextKey(0), "value")
@@ -374,52 +393,57 @@ func TestRegistry_Marshal(t *testing.T) {
 		require.Equal(t, types.I64(src.UnixNano()), value)
 	})
 
-	t.Run("struct with methods", func(t *testing.T) {
+	t.Run("a struct with methods becomes a live view", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
 
 		value, err := r.Marshal(i, marshalHostFields{Count: 7})
 		require.NoError(t, err)
-		host, ok := value.(*types.Struct)
+		host, ok := value.(*interp.HostStruct)
 		require.True(t, ok)
-		require.Equal(t, types.BoxI32(7), host.Field(host.Typ.FieldIndex("Count")))
 
-		bound := host.Field(host.Typ.FieldIndex("Context"))
-		require.Equal(t, types.KindRef, bound.Kind())
-		fn, err := i.Load(bound.Ref())
-		require.NoError(t, err)
-		require.IsType(t, &interp.HostFunction{}, fn)
+		// The VM type is the one a copy would have had, methods included in
+		// neither: a method is a function of its own, not a field.
+		typ, ok := host.Type().(*types.StructType)
+		require.True(t, ok)
+		require.Len(t, typ.Fields, 1)
+		require.Equal(t, "Count", typ.Fields[0].Name)
+		require.Equal(t, types.KindRef, host.Kind())
 	})
 
-	t.Run("methods bind to the caller's pointer", func(t *testing.T) {
+	t.Run("a method reached through a host value mutates the caller", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
 		src := &marshalHostFields{}
 
-		value, err := r.Marshal(i, src)
+		obj, err := r.Marshal(i, src)
 		require.NoError(t, err)
-		st := value.(*types.Struct)
-		bound, err := i.Load(st.Field(st.Typ.FieldIndex("Bump")).Ref())
+		fn, err := r.Marshal(i, (*marshalHostFields).Bump)
 		require.NoError(t, err)
-		_, err = bound.(*interp.HostFunction).Fn(i, []types.Boxed{types.BoxI32(2)})
+		recv, err := i.Alloc(obj)
+		require.NoError(t, err)
+
+		_, err = fn.(*interp.HostFunction).Fn(i, []types.Boxed{types.BoxRef(recv), types.BoxI32(2)})
 		require.NoError(t, err)
 		require.Equal(t, int32(2), src.Count)
 	})
 
-	t.Run("a marshaled value binds methods to its own copy", func(t *testing.T) {
+	t.Run("a marshaled value views the conversion's copy", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
 		src := marshalHostFields{}
 
-		value, err := r.Marshal(i, src)
+		obj, err := r.Marshal(i, src)
 		require.NoError(t, err)
-		st := value.(*types.Struct)
-		bound, err := i.Load(st.Field(st.Typ.FieldIndex("Bump")).Ref())
+		fn, err := r.Marshal(i, (*marshalHostFields).Bump)
 		require.NoError(t, err)
-		_, err = bound.(*interp.HostFunction).Fn(i, []types.Boxed{types.BoxI32(2)})
+		recv, err := i.Alloc(obj)
+		require.NoError(t, err)
+
+		_, err = fn.(*interp.HostFunction).Fn(i, []types.Boxed{types.BoxRef(recv), types.BoxI32(2)})
 		require.NoError(t, err)
 		require.Zero(t, src.Count)
 	})
@@ -566,6 +590,54 @@ func TestRegistry_Marshal(t *testing.T) {
 
 		_, err := r.Marshal(i, map[*int32]int32{nil: 7})
 		require.ErrorIs(t, err, interp.ErrTypeMismatch)
+	})
+
+	t.Run("a host layout leaves out a field holding a VM value", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		value, err := r.Marshal(i, &codecHeld{Count: 7, Held: types.I32(1)})
+		require.NoError(t, err)
+		typ, ok := value.(*interp.HostStruct).Type().(*types.StructType)
+		require.True(t, ok)
+
+		// A host value never owns a VM reference, so Held has no slot even
+		// though it is exported and would otherwise convert.
+		require.Len(t, typ.Fields, 1)
+		require.Equal(t, "Count", typ.Fields[0].Name)
+	})
+
+	t.Run("a registered marshaler wins over the host rule", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry(interp.WithMarshaler(
+			reflect.TypeFor[codecHeld](), types.TypeI32,
+			interp.MarshalerFunc(func(_ *interp.Encoder, p unsafe.Pointer) (types.Value, error) {
+				return types.I32((*codecHeld)(p).Count), nil
+			})))
+		defer i.Close()
+
+		value, err := r.Marshal(i, codecHeld{Count: 7})
+		require.NoError(t, err)
+		require.Equal(t, types.I32(7), value)
+	})
+
+	t.Run("a method runs against a struct guest code built", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+		fn, err := r.Marshal(i, (*marshalHostFields).Bump)
+		require.NoError(t, err)
+
+		// Not a host value: the receiver decodes into a fresh Go struct, so the
+		// call still runs and the mutation stays on that copy.
+		typ := types.NewStructType(types.NewStructField(types.TypeI32, types.FieldWithName("Count")))
+		recv, err := i.Alloc(types.NewStruct(typ, types.BoxI32(5)))
+		require.NoError(t, err)
+
+		got, err := fn.(*interp.HostFunction).Fn(i, []types.Boxed{types.BoxRef(recv), types.BoxI32(2)})
+		require.NoError(t, err)
+		require.Equal(t, []types.Boxed{types.BoxI32(7)}, got)
 	})
 
 	t.Run("a marshaled alias keeps its target alive", func(t *testing.T) {
@@ -802,12 +874,15 @@ func TestRegistry_Unmarshal(t *testing.T) {
 		require.Equal(t, context.Background(), got)
 	})
 
-	t.Run("VM function non-first context", func(t *testing.T) {
+	t.Run("VM function context in any position is host-only", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
+		// The VM signature carries the i32 alone: a context.Context stays on
+		// the host side wherever it sits, so a method expression whose receiver
+		// comes first is no different from a plain leading context.
 		fn := types.NewFunctionBuilder(&types.FunctionType{
-			Params: []types.Type{types.TypeI32, types.TypeAny}, Returns: []types.Type{types.TypeI32},
+			Params: []types.Type{types.TypeI32}, Returns: []types.Type{types.TypeI32},
 		}).Emit(instr.New(instr.LOCAL_GET, 0), instr.New(instr.RETURN)).MustBuild()
 
 		var call func(int32, context.Context) (int32, error)
@@ -924,16 +999,19 @@ func TestRegistry_Unmarshal(t *testing.T) {
 		require.Equal(t, time.Unix(0, 123), dst)
 	})
 
-	t.Run("struct with methods round-trips exported fields", func(t *testing.T) {
+	t.Run("a host value round-trips unexported state", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
-		value, err := r.Marshal(i, marshalHostFields{Count: 7})
+		src := marshalHostFields{Count: 7}
+		src.mark(3)
+		value, err := r.Marshal(i, src)
 		require.NoError(t, err)
 		var dst marshalHostFields
 
 		require.NoError(t, r.Unmarshal(i, value, &dst))
-		require.Equal(t, marshalHostFields{Count: 7}, dst)
+		require.Equal(t, src, dst)
+		require.Equal(t, int32(3), dst.marked())
 	})
 
 	t.Run("invalid target", func(t *testing.T) {

--- a/interp/decode.go
+++ b/interp/decode.go
@@ -106,6 +106,24 @@ func unmarshalValue(t reflect.Type) func(*Decoder, types.Value, unsafe.Pointer) 
 	}
 }
 
+// unmarshalHost recovers the Go value a host value stands for, unexported state
+// included, and decodes structurally from any other VM value. Both halves
+// matter: a method reached through a host value mutates the caller's value,
+// while the same conversion applied to a struct guest code built still runs.
+func unmarshalHost(t reflect.Type, structural func(*Decoder, types.Value, unsafe.Pointer) error) func(*Decoder, types.Value, unsafe.Pointer) error {
+	return func(d *Decoder, val types.Value, p unsafe.Pointer) error {
+		value, err := d.registry.resolve(d.interp, val)
+		if err != nil {
+			return err
+		}
+		if src, ok := hosting(value, t); ok {
+			reflect.NewAt(t, p).Elem().Set(reflect.NewAt(t, src).Elem())
+			return nil
+		}
+		return structural(d, value, p)
+	}
+}
+
 // unmarshalPointer allocates the pointee and decodes into it, leaving a nil
 // pointer for a null value.
 func unmarshalPointer(elem *conversion) func(*Decoder, types.Value, unsafe.Pointer) error {
@@ -113,6 +131,19 @@ func unmarshalPointer(elem *conversion) func(*Decoder, types.Value, unsafe.Point
 		if types.IsNull(val) {
 			*(*unsafe.Pointer)(p) = nil
 			return nil
+		}
+		if elem.host {
+			value, err := d.registry.resolve(d.interp, val)
+			if err != nil {
+				return err
+			}
+			// A pointer to a host value is the address it views, not a copy of
+			// it. This is what makes a method expression mutate the value the
+			// caller marshaled rather than a decoded duplicate.
+			if target, ok := hosting(value, elem.typ); ok {
+				*(*unsafe.Pointer)(p) = target
+				return nil
+			}
 		}
 		out := reflect.New(elem.typ)
 		if err := elem.set(d, val, out.UnsafePointer()); err != nil {
@@ -126,7 +157,6 @@ func unmarshalPointer(elem *conversion) func(*Decoder, types.Value, unsafe.Point
 // unmarshalFunc wraps a VM function as a Go function that marshals arguments,
 // runs the VM function on the same interpreter, then decodes the results.
 func unmarshalFunc(t reflect.Type, typ *types.FunctionType) func(*Decoder, types.Value, unsafe.Pointer) error {
-	ctxParam := t.NumIn() > 0 && t.In(0) == typeContext
 	failing := t.NumOut() > 0 && t.Out(t.NumOut()-1).Implements(typeError)
 
 	return func(d *Decoder, val types.Value, p unsafe.Pointer) error {
@@ -149,18 +179,16 @@ func unmarshalFunc(t reflect.Type, typ *types.FunctionType) func(*Decoder, types
 			}
 
 			ctx := context.Background()
-			offset := 0
-			if ctxParam {
-				if caller, _ := in[0].Interface().(context.Context); caller != nil {
-					ctx = caller
-				}
-				offset = 1
-			}
-
 			enc := &Encoder{interp: d.interp, registry: registry}
-			params := make([]types.Boxed, len(in)-offset)
-			for idx := range params {
-				arg := in[idx+offset]
+			params := make([]types.Boxed, 0, len(typ.Params))
+			for idx := range in {
+				arg := in[idx]
+				if t.In(idx) == typeContext {
+					if caller, _ := arg.Interface().(context.Context); caller != nil {
+						ctx = caller
+					}
+					continue
+				}
 				holder := reflect.New(arg.Type())
 				holder.Elem().Set(arg)
 				c, err := registry.conversion(arg.Type())
@@ -169,13 +197,13 @@ func unmarshalFunc(t reflect.Type, typ *types.FunctionType) func(*Decoder, types
 				}
 				value, err := c.value(enc, holder.UnsafePointer())
 				if err != nil {
-					return fail(fmt.Errorf("function param %d: %w", idx, err))
+					return fail(fmt.Errorf("function param %d: %w", len(params), err))
 				}
-				boxed, err := enc.boxAs(value, typ.Params[idx])
+				boxed, err := enc.boxAs(value, typ.Params[len(params)])
 				if err != nil {
-					return fail(fmt.Errorf("function param %d: %w", idx, err))
+					return fail(fmt.Errorf("function param %d: %w", len(params), err))
 				}
-				params[idx] = boxed
+				params = append(params, boxed)
 			}
 
 			returns, err := d.interp.invoke(ctx, val, params)

--- a/interp/encode.go
+++ b/interp/encode.go
@@ -214,37 +214,38 @@ func (e *Encoder) boxI64(n int64) (types.Boxed, error) {
 func (e *Encoder) wrap(fn reflect.Value, typ *types.FunctionType) *HostFunction {
 	registry := e.registry
 	sig := fn.Type()
-	ctxParam := sig.NumIn() > 0 && sig.In(0) == typeContext
 
 	return NewHostFunction(typ, func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error) {
 		if len(params) != len(typ.Params) {
 			return nil, fmt.Errorf("%w: got %d params, want %d", ErrTypeMismatch, len(params), len(typ.Params))
 		}
 		in := make([]reflect.Value, sig.NumIn())
-		offset := 0
-		if ctxParam {
-			ctx := i.Context()
-			if ctx == nil {
-				ctx = context.Background()
-			}
-			in[0] = reflect.ValueOf(ctx)
-			offset = 1
-		}
 		dec := &Decoder{interp: i, registry: registry}
-		for idx := range params {
-			arg := reflect.New(sig.In(idx + offset))
-			value, err := registry.resolve(i, params[idx])
-			if err != nil {
-				return nil, fmt.Errorf("function param %d: %w", idx, err)
+		at := 0
+		for idx := range in {
+			param := sig.In(idx)
+			if param == typeContext {
+				ctx := i.Context()
+				if ctx == nil {
+					ctx = context.Background()
+				}
+				in[idx] = reflect.ValueOf(ctx)
+				continue
 			}
-			c, err := registry.conversion(sig.In(idx + offset))
+			arg := reflect.New(param)
+			value, err := registry.resolve(i, params[at])
+			if err != nil {
+				return nil, fmt.Errorf("function param %d: %w", at, err)
+			}
+			c, err := registry.conversion(param)
 			if err != nil {
 				return nil, err
 			}
 			if err := c.set(dec, value, arg.UnsafePointer()); err != nil {
-				return nil, fmt.Errorf("function param %d: %w", idx, err)
+				return nil, fmt.Errorf("function param %d: %w", at, err)
 			}
-			in[idx+offset] = arg.Elem()
+			in[idx] = arg.Elem()
+			at++
 		}
 
 		out := fn.Call(in)
@@ -378,9 +379,8 @@ func marshalFunc(t reflect.Type, typ *types.FunctionType) func(*Encoder, unsafe.
 	}
 }
 
-// marshalStruct writes exported fields into a native VM struct, then binds the
-// exported methods of the pointer receiver into the trailing function slots.
-func marshalStruct(t reflect.Type, vm *types.StructType, fields []field, methods []method) func(*Encoder, unsafe.Pointer) (types.Value, error) {
+// marshalStruct writes exported fields into a native VM struct.
+func marshalStruct(vm *types.StructType, fields []field) func(*Encoder, unsafe.Pointer) (types.Value, error) {
 	return func(e *Encoder, p unsafe.Pointer) (types.Value, error) {
 		out := types.NewStruct(vm)
 		for idx, f := range fields {
@@ -394,20 +394,17 @@ func marshalStruct(t reflect.Type, vm *types.StructType, fields []field, methods
 				out.SetField(idx, boxed)
 			}
 		}
-		if len(methods) == 0 {
-			return out, nil
-		}
-
-		recv := reflect.NewAt(t, p)
-		for idx, m := range methods {
-			slot := len(fields) + idx
-			bound, err := e.alloc(e.wrap(recv.Method(m.index), m.typ))
-			if err != nil {
-				return nil, fmt.Errorf("bind method %s: %w", m.name, err)
-			}
-			out.SetField(slot, bound)
-		}
 		return out, nil
+	}
+}
+
+// marshalHostStruct exposes the Go struct at p as a live view instead of copying
+// it. The view keeps p after the call returns, which is what makes it live: an
+// unsafe.Pointer is pointer-shaped to the GC, so the Go struct stays alive for
+// as long as the VM holds the view.
+func marshalHostStruct(t reflect.Type, vm *types.StructType, fields []field) func(*Encoder, unsafe.Pointer) (types.Value, error) {
+	return func(e *Encoder, p unsafe.Pointer) (types.Value, error) {
+		return &HostStruct{typ: vm, fields: fields, registry: e.registry, rtyp: t, ptr: p}, nil
 	}
 }
 
@@ -526,6 +523,11 @@ func typedArray[T int8 | int32 | int64 | float32 | float64 | bool](
 // chosen once at compile time.
 func marshalMap(t reflect.Type, mt *types.MapType, key, elem *conversion) func(*Encoder, unsafe.Pointer) (types.Value, error) {
 	write := mapWriter(mt, key)
+	// A hosted entry keeps the address it was marshaled from, so it needs
+	// storage of its own rather than the scratch every other entry shares. Go
+	// map memory is not addressable, so such a view stands for a copy either
+	// way; what matters is that two entries are not the same copy.
+	shared := !key.host && !elem.host
 	return func(e *Encoder, p unsafe.Pointer) (types.Value, error) {
 		if target := *(*unsafe.Pointer)(p); target != nil {
 			if !e.enter(target) {
@@ -537,6 +539,9 @@ func marshalMap(t reflect.Type, mt *types.MapType, key, elem *conversion) func(*
 		out := types.NewMapForType(mt, rv.Len())
 		entryKey, entryValue := reflect.New(t.Key()).Elem(), reflect.New(t.Elem()).Elem()
 		for iter := rv.MapRange(); iter.Next(); {
+			if !shared {
+				entryKey, entryValue = reflect.New(t.Key()).Elem(), reflect.New(t.Elem()).Elem()
+			}
 			entryKey.SetIterKey(iter)
 			entryValue.SetIterValue(iter)
 			value, err := elem.box(e, entryValue.Addr().UnsafePointer())

--- a/interp/host.go
+++ b/interp/host.go
@@ -2,19 +2,41 @@ package interp
 
 import (
 	"fmt"
+	"reflect"
+	"unsafe"
 
 	"github.com/siyul-park/minivm/types"
 )
 
 // HostFunction exposes a Go function to the VM. The codec produces one for a
-// marshaled Go function and for every exported method it binds onto a struct,
-// and host code may build one directly with NewHostFunction.
+// marshaled Go function, and host code may build one directly with
+// NewHostFunction.
 type HostFunction struct {
 	Typ *types.FunctionType
 	Fn  func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error)
 }
 
-var _ types.Value = (*HostFunction)(nil)
+// HostStruct is a live view of a Go struct. The codec produces one for a struct
+// a copy cannot reproduce - one carrying unexported state, or one a pointer
+// receiver mutates - so a field the guest writes and a method the host calls
+// address the same memory.
+//
+// The pointer is what the GC traces, so the Go struct stays alive for as long as
+// the VM holds the view, and the Go type is what identifies it on the way back
+// out. Both are fixed at construction: there is no layout to re-validate on the
+// way into a field.
+type HostStruct struct {
+	typ      *types.StructType
+	fields   []field
+	registry *Registry
+	rtyp     reflect.Type
+	ptr      unsafe.Pointer
+}
+
+var (
+	_ types.Value = (*HostFunction)(nil)
+	_ types.Value = (*HostStruct)(nil)
+)
 
 func NewHostFunction(typ *types.FunctionType, fn func(i *Interpreter, params []types.Boxed) ([]types.Boxed, error)) *HostFunction {
 	return &HostFunction{Typ: typ, Fn: fn}
@@ -25,4 +47,62 @@ func (f *HostFunction) Type() types.Type { return f.Typ }
 
 func (f *HostFunction) String() string {
 	return fmt.Sprintf("%s\n<native>", f.Typ)
+}
+
+func (h *HostStruct) Kind() types.Kind { return types.KindRef }
+func (h *HostStruct) Type() types.Type { return h.typ }
+func (h *HostStruct) String() string   { return fmt.Sprintf("%s\n<native>", h.typ) }
+
+// Field reads the field at at out of the Go struct, in the form a VM slot of
+// that field's type holds. A field that needs a heap reference publishes one on
+// i, so the result is owned by the caller exactly as a *types.Struct field read
+// is. i is the interpreter executing the read, not the one that marshaled the
+// value, so a pooled interpreter reads through a shared view safely.
+func (h *HostStruct) Field(i *Interpreter, at int) (types.Boxed, error) {
+	if at < 0 || at >= len(h.fields) {
+		return 0, ErrSegmentationFault
+	}
+	f := &h.fields[at]
+	e := &i.enc
+	*e = Encoder{interp: i, registry: h.registry, owned: e.owned[:0]}
+	result, err := f.conversion.box(e, unsafe.Add(h.ptr, f.offset))
+	if err != nil {
+		// A conversion that failed partway has no result to own what it
+		// already published, so the read leaves the heap as it found it.
+		e.discard()
+		return 0, err
+	}
+	return result, nil
+}
+
+// SetField writes val into the Go struct. The Go field takes a copy of what val
+// holds rather than the slot itself, so a successful write consumes val: a
+// reference it carries is released instead of retained.
+func (h *HostStruct) SetField(i *Interpreter, at int, val types.Boxed) error {
+	if at < 0 || at >= len(h.fields) {
+		return ErrSegmentationFault
+	}
+	f := &h.fields[at]
+	value, err := h.registry.resolve(i, val)
+	if err != nil {
+		return err
+	}
+	d := &i.dec
+	*d = Decoder{interp: i, registry: h.registry}
+	if err := f.conversion.set(d, value, unsafe.Add(h.ptr, f.offset)); err != nil {
+		return err
+	}
+	i.releaseBox(val)
+	return nil
+}
+
+// hosting reports the Go value val stands for, when val is a host value over
+// rtyp. It is how a conversion recovers the value it handed the VM, including
+// the unexported state no VM representation carries.
+func hosting(val types.Value, rtyp reflect.Type) (unsafe.Pointer, bool) {
+	h, ok := val.(*HostStruct)
+	if !ok || h.rtyp != rtyp {
+		return nil, false
+	}
+	return h.ptr, true
 }

--- a/interp/host_test.go
+++ b/interp/host_test.go
@@ -4,9 +4,22 @@ import (
 	"testing"
 
 	"github.com/siyul-park/minivm/interp"
+	"github.com/siyul-park/minivm/program"
 	"github.com/siyul-park/minivm/types"
 	"github.com/stretchr/testify/require"
 )
+
+// hostCounter carries unexported state next to an exported field, so a copy of
+// it cannot reproduce the whole value and the codec exposes a live view.
+type hostCounter struct {
+	Count  int32
+	offset int32
+}
+
+func (c *hostCounter) Bump(n int32) int32 {
+	c.Count += n + c.offset
+	return c.Count
+}
 
 func TestNewHostFunction(t *testing.T) {
 	t.Run("constructor", func(t *testing.T) {
@@ -55,4 +68,111 @@ func TestHostFunction_String(t *testing.T) {
 	typ := &types.FunctionType{Returns: []types.Type{types.TypeI32}}
 	fn := interp.NewHostFunction(typ, nil)
 	require.Equal(t, "func() i32\n<native>", fn.String())
+}
+
+func TestHostStruct_Kind(t *testing.T) {
+	i := interp.New(program.New(nil))
+	r := interp.NewRegistry()
+	defer i.Close()
+
+	value, err := r.Marshal(i, &hostCounter{})
+	require.NoError(t, err)
+	require.Equal(t, types.KindRef, value.(*interp.HostStruct).Kind())
+}
+
+func TestHostStruct_Type(t *testing.T) {
+	i := interp.New(program.New(nil))
+	r := interp.NewRegistry()
+	defer i.Close()
+
+	value, err := r.Marshal(i, &hostCounter{})
+	require.NoError(t, err)
+
+	// The view reports the type a copy of the same struct would have reported,
+	// so guest code that reads it needs to know nothing about the Go side.
+	typ, ok := value.(*interp.HostStruct).Type().(*types.StructType)
+	require.True(t, ok)
+	require.Len(t, typ.Fields, 1)
+	require.Equal(t, "Count", typ.Fields[0].Name)
+	require.Equal(t, types.TypeI32, typ.Fields[0].Type)
+}
+
+func TestHostStruct_String(t *testing.T) {
+	i := interp.New(program.New(nil))
+	r := interp.NewRegistry()
+	defer i.Close()
+
+	value, err := r.Marshal(i, &hostCounter{})
+	require.NoError(t, err)
+	require.Equal(t, "struct {i32}\n<native>", value.(*interp.HostStruct).String())
+}
+
+func TestHostStruct_Field(t *testing.T) {
+	t.Run("reads through to the Go value", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+		src := &hostCounter{Count: 7}
+
+		value, err := r.Marshal(i, src)
+		require.NoError(t, err)
+		host := value.(*interp.HostStruct)
+
+		got, err := host.Field(i, 0)
+		require.NoError(t, err)
+		require.Equal(t, types.BoxI32(7), got)
+
+		// A copy would have frozen the 7. A view reports what the Go value
+		// holds now, which is the whole point of holding one.
+		src.Count = 9
+		got, err = host.Field(i, 0)
+		require.NoError(t, err)
+		require.Equal(t, types.BoxI32(9), got)
+	})
+
+	t.Run("an index outside the layout faults", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		value, err := r.Marshal(i, &hostCounter{})
+		require.NoError(t, err)
+		host := value.(*interp.HostStruct)
+
+		_, err = host.Field(i, 1)
+		require.ErrorIs(t, err, interp.ErrSegmentationFault)
+		_, err = host.Field(i, -1)
+		require.ErrorIs(t, err, interp.ErrSegmentationFault)
+	})
+}
+
+func TestHostStruct_SetField(t *testing.T) {
+	t.Run("writes through to the Go value", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+		src := &hostCounter{}
+
+		value, err := r.Marshal(i, src)
+		require.NoError(t, err)
+		host := value.(*interp.HostStruct)
+
+		require.NoError(t, host.SetField(i, 0, types.BoxI32(5)))
+		require.Equal(t, int32(5), src.Count)
+
+		// The write reached the Go value, so a method reading private state
+		// alongside it agrees with what the guest just wrote.
+		require.Equal(t, int32(5), src.Bump(0))
+	})
+
+	t.Run("an index outside the layout faults", func(t *testing.T) {
+		i := interp.New(program.New(nil))
+		r := interp.NewRegistry()
+		defer i.Close()
+
+		value, err := r.Marshal(i, &hostCounter{})
+		require.NoError(t, err)
+
+		require.ErrorIs(t, value.(*interp.HostStruct).SetField(i, 1, types.BoxI32(5)), interp.ErrSegmentationFault)
+	})
 }

--- a/interp/interp.go
+++ b/interp/interp.go
@@ -66,6 +66,13 @@ type Interpreter struct {
 	arrays  pool[*types.Array]
 	structs pool[*types.Struct]
 
+	// enc and dec are the scratch a host value converts through. A conversion
+	// takes a pointer, so building one per field access would allocate on every
+	// read; the interpreter executing the access owns it instead, which also
+	// keeps a host value shared by pooled interpreters off a single encoder.
+	enc Encoder
+	dec Decoder
+
 	// tail is the append-only byte buffer the most recent string.concat
 	// published from. A join whose left operand ends exactly where tail ends
 	// extends it and publishes a new ref over the longer prefix; bytes below any
@@ -930,7 +937,7 @@ func (i *Interpreter) callable(val types.Value) (types.Value, bool) {
 		val = loaded
 	}
 	switch val.(type) {
-	case *types.Function, *types.Closure:
+	case *types.Function, *types.Closure, *HostFunction:
 		return val, true
 	default:
 		return nil, false
@@ -2256,37 +2263,48 @@ func (i *Interpreter) arraySet(addr, at int, val types.Boxed) {
 }
 
 // structField reads the field at index at off the struct bound to heap address
-// addr. It is the generic counterpart to the specialized reads struct.get
+// addr, covering a native *types.Struct and a *HostStruct alike. It is the
+// generic counterpart to the specialized reads struct.get
 // fusion emits for a declared *types.StructType slot: the unfused STRUCT_GET
 // handler calls it unconditionally, and a fused handler falls back to it when
 // the runtime value does not match the slot it specialized for. A KindRef
 // field is retained. structField does not release addr itself, for the same
 // reason arrayGet does not.
 func (i *Interpreter) structField(addr, at int) types.Boxed {
-	value, ok := i.heap[addr].(*types.Struct)
-	if !ok {
-		panic(ErrTypeMismatch)
-	}
-	if at < 0 || at >= len(value.Typ.Fields) {
-		panic(ErrSegmentationFault)
-	}
-	data := value.Data[at]
-	switch value.Typ.Fields[at].Kind {
-	case types.KindI1:
-		return types.BoxI1(data != 0)
-	case types.KindI8:
-		return types.BoxI8(int8(uint32(data)))
-	case types.KindI32:
-		return types.BoxI32(int32(uint32(data)))
-	case types.KindI64:
-		return i.boxI64(int64(data))
-	case types.KindF32:
-		return types.BoxF32(math.Float32frombits(uint32(data)))
-	case types.KindF64:
-		return types.BoxF64(math.Float64frombits(data))
-	case types.KindRef:
-		result := types.Boxed(data)
-		i.retainBox(result)
+	switch value := i.heap[addr].(type) {
+	case *types.Struct:
+		if at < 0 || at >= len(value.Typ.Fields) {
+			panic(ErrSegmentationFault)
+		}
+		data := value.Data[at]
+		switch value.Typ.Fields[at].Kind {
+		case types.KindI1:
+			return types.BoxI1(data != 0)
+		case types.KindI8:
+			return types.BoxI8(int8(uint32(data)))
+		case types.KindI32:
+			return types.BoxI32(int32(uint32(data)))
+		case types.KindI64:
+			return i.boxI64(int64(data))
+		case types.KindF32:
+			return types.BoxF32(math.Float32frombits(uint32(data)))
+		case types.KindF64:
+			return types.BoxF64(math.Float64frombits(data))
+		case types.KindRef:
+			result := types.Boxed(data)
+			i.retainBox(result)
+			return result
+		default:
+			panic(ErrTypeMismatch)
+		}
+	case *HostStruct:
+		// A host struct converts on the way out instead of holding VM words,
+		// so a conversion that fails traps the way the threaded contract
+		// expects rather than reporting inward.
+		result, err := value.Field(i, at)
+		if err != nil {
+			panic(err)
+		}
 		return result
 	default:
 		panic(ErrTypeMismatch)

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2629,6 +2629,49 @@ func TestInterpreter_Run(t *testing.T) {
 		}
 	})
 
+	t.Run("parity/host struct field write reaches the Go value", func(t *testing.T) {
+		type counter struct {
+			Count  int32
+			hidden int32
+		}
+		bump := func(c *counter) int32 { c.hidden++; return c.Count }
+
+		runHost := func(opts ...func(*option)) (types.Value, int32) {
+			setup := New(program.New(nil))
+			defer setup.Close()
+			src := &counter{Count: 7}
+			host, err := NewRegistry().Marshal(setup, src)
+			require.NoError(t, err)
+
+			prog := program.New([]instr.Instruction{
+				instr.New(instr.CONST_GET, 0),
+				instr.New(instr.DUP),
+				instr.New(instr.I32_CONST, 0), instr.New(instr.I32_CONST, 99), instr.New(instr.STRUCT_SET),
+				instr.New(instr.I32_CONST, 0), instr.New(instr.STRUCT_GET),
+			}, program.WithConstants(host))
+			i := New(prog, opts...)
+			defer i.Close()
+			require.NoError(t, i.Run(context.Background()))
+			value, err := i.Pop()
+			require.NoError(t, err)
+			// The Go value carries the write, so a method reading it agrees
+			// with what the guest just stored.
+			return value, bump(src)
+		}
+
+		want, seen := runHost(WithTick(1), WithThreshold(-1))
+		require.Equal(t, types.I32(99), want)
+		require.Equal(t, int32(99), seen)
+		got, seen := runHost(WithThreshold(-1))
+		require.Equal(t, want, got)
+		require.Equal(t, int32(99), seen)
+		if runtime.GOARCH == "arm64" {
+			got, seen = runHost(WithThreshold(0))
+			require.Equal(t, want, got)
+			require.Equal(t, int32(99), seen)
+		}
+	})
+
 	t.Run("entry frame yield resumes on the next Run call", func(t *testing.T) {
 		prog := program.New([]instr.Instruction{
 			instr.New(instr.I32_CONST, 1),

--- a/interp/threaded.go
+++ b/interp/threaded.go
@@ -4440,6 +4440,10 @@ var (
 					default:
 						panic(ErrTypeMismatch)
 					}
+				case *HostStruct:
+					if err := s.SetField(i, idx, val); err != nil {
+						panic(err)
+					}
 				default:
 					panic(ErrTypeMismatch)
 				}


### PR DESCRIPTION
## Problem

A Go struct with methods marshaled to a native `*types.Struct` holding field **copies**, followed by one bound `*HostFunction` per method. The two halves were disconnected:

- a VM write to a data slot never reached the Go value, and the bound method never saw it;
- a method's mutation never showed up in the already-copied slots;
- `Unmarshal` recovered exported fields only.

## Change

A struct carrying unexported fields, or any method on `*T`, now marshals to a **`*HostStruct`** — a live view of the Go struct that reports the same VM struct type a copy would have reported. `STRUCT_GET` and `STRUCT_SET` read and write it in place, so the guest and the Go side address the same memory, and `Unmarshal` recovers the whole Go value, unexported state included.

**Methods are no longer fields.** A method is an ordinary Go function, so a method expression marshals through the existing `reflect.Func` path with the receiver as its first parameter:

```go
c := &Counter{}
obj, _ := vm.Marshal(c)                 // *interp.HostStruct
bump, _ := vm.Marshal((*Counter).Bump)  // *interp.HostFunction
```

Handed the host value, it mutates the caller's value. Handed any other VM value — a `*types.Struct` guest code built — the receiver decodes into a fresh Go value and the call still runs, with the mutation staying on that copy. A bound method value (`c.Bump`) works unchanged.

`callable` now accepts a `*HostFunction`, closing the missing half of function ↔ host-function interconversion: a host function unmarshals into a Go func just as a VM function does.

## Why this is not a revert of #208

`HostObject` was deleted in `d63ef27` for four costs. This design pays none of the first three:

| #208 cost | Why it does not return |
|---|---|
| seven-check `valid()` per read | `Typ`/`Receiver` were public and mutable. A host value is fixed at construction and validates nothing. |
| ~20-arm `reflect.Kind` switch per access | Conversions the codec selects once — the `leaves` pattern. |
| one heap alloc per bound method | Methods are no longer bound. |
| refused JIT trace on every field access | `HostObject` captured the interpreter that built it. The interpreter executing the access is passed in instead, so a view reached from a program constant is safe across pooled interpreters. |

## Evidence

Apple M4 Pro, darwin/arm64, go1.26.2, `-benchmem -count=6`:

| Benchmark | Before | After |
|---|---|---|
| `StructGetHost` (10 000 field reads) | 142.6 µs, 11 allocs/op | 154.2 µs, 8 allocs/op |
| — per field read | 14.26 ns | 15.42 ns (**+8.1%**) |
| `Marshal/methods` | 293 ns, 8 allocs/op | 175 ns, 5 allocs/op |

The field read is slower because it converts from Go memory instead of reading a VM word. It stays well under the 27.4 ns `HostObject` charged. Routing each access through a per-interpreter scratch encoder instead of building one per read took that path from **26.4 ns / 10 008 allocs/op → 15.42 ns / zero allocs per read**.

`Marshal` is faster because binding is gone. Scalar, slice, and map rows are unmoved, and `make benchmark-pr` kernels are unmoved (IterativeFib 553 ns, TypedArraySum 2711 ns, BranchTree 502 ns, RecursiveFib/20 338 µs, /35 417 ms).

## Scope

Arrays and maps still marshal as copies. Hosting them needs the `ARRAY_*` and `MAP_*` arms and follows separately. Scalars and strings stay plain primitives by design: a copy of one loses nothing a VM value could hold, so `type Counter int64` keeps `i64` and its whole operator set.

The approved plan staged the opcode arms into a second PR. That would have shipped marshaled structs no opcode could read — `STRUCT_GET` traps on a `HostStruct` — so the struct arms are folded in here.

## Test plan

- [x] `go test -race ./...`
- [x] `make lint`
- [x] `make check-generated` — the generated `STRUCT_SET` arm comes from `internal/cmd/geninterp/lower.go`, regenerated with `make generate`
- [x] `make benchmark-pr` — kernels unmoved
- [x] New `TestHostStruct_{Kind,Type,String,Field,SetField}`; a read reflects a later Go-side write, and a write is visible to a method reading private state alongside it
- [x] `TestInterpreter_Run/parity/host struct field write reaches the Go value` — threaded, fused, and JIT (arm64)
- [x] `TestRegistry_Marshal`: a `types.Value` field is left out of a host layout; a registered marshaler still wins over the host rule; a method runs against a struct guest code built
- [x] `TestRegistry_Unmarshal`: a host value round-trips unexported state
- [ ] `make coverage-check` — fails locally from a goenv go1.25/1.26 split (`compile: version "go1.26.2" does not match go tool version "go1.25.0"`), unrelated to this diff

## Breaking changes

- A struct with methods no longer marshals to a `*types.Struct` with bound method slots. Marshal a method expression or a bound method value instead.
- An exact `context.Context` parameter is host-only in **every** position, not only the first. A method expression carries its receiver first, and the context that follows it is no less host-only for that. A VM signature that carried one as an ordinary argument loses it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live views of Go structs, allowing VM code to read and update exported fields while preserving changes in the original Go value.
  * Improved host-function integration so `context.Context` parameters work in any position.
  * Enhanced handling of pointer methods, private fields, marshaling, and unmarshaling.

* **Bug Fixes**
  * Prevented hosted map entries from sharing temporary storage.
  * Improved error handling for invalid host-struct field access.

* **Documentation**
  * Expanded guidance on host-struct behavior, ownership, values, testing, and integration.

* **REPL**
  * `.save` now rejects programs containing host functions or host structs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->