### PR TITLE
refactor(interp)!: choose a struct's form by what a copy would lose

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,7 +145,8 @@ Each `Interpreter` is single-goroutine-owned during use. `Pool` lets multiple go
 - Values that contain refs must implement `types.Traceable`.
 - Large `i64` values may spill to the heap while preserving bytecode semantics.
 - Strings carry no identity invariant: every comparison and every map keyed by a string compares content, so equal contents may occupy different refs. Only the constant pool deduplicates, at load time.
-- A host value never owns a VM reference. A Go field holding a `types.Value` stays out of a `HostStruct` layout, and a field write copies what the VM value holds rather than storing the slot, so a host value implements no `types.Traceable` and reclaims nothing.
+- A host value never owns a VM reference. Reading a field publishes one the caller owns, and writing one copies what the VM value holds into the Go field rather than storing the slot, so a host value implements no `types.Traceable` and reclaims nothing.
+- A struct compiles to one VM struct type whatever form it takes, because a value and a pointer to it must report the same type. The pointer is what selects the live view; the value copies unless unexported fields make a copy unfaithful.
 
 See `memory-model.md` and `value-representation.md` for the detailed rules.
 

--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -215,10 +215,10 @@ The built-in codec compiles and caches one conversion per Go type. Compilation i
 | other `[]T` | `*Array` ref | generic fallback |
 | `map[K]V` with a primitive or `string` key | `*TypedMap[K]` ref | key type drives the concrete map; content-keyed |
 | other `map[K]V` | `*Map` ref | heap ref identity keys |
-| struct | `*Struct` ref | exported fields, in declaration order |
-| struct with methods or unexported fields | `*HostStruct` ref | live view of the Go struct |
+| struct, by value, all fields exported | `*Struct` ref | exported fields, in declaration order |
+| struct with an unexported field | `*HostStruct` ref | live view of the Go struct |
 | defined scalar or string with methods | underlying scalar or `string` | keeps primitive fast path |
-| `*T` | `T` or `Null` | nil pointer becomes `Null` |
+| `*T` | `T` or `Null` | nil pointer becomes `Null`; a struct behind it is a `*HostStruct` view |
 | `func(...)` | `*HostFunction` ref | final `error` return is host-only |
 | `interface{}` / `any` | `ref` | dynamic value |
 | `types.Value` | passthrough | returned as-is |
@@ -228,9 +228,9 @@ The built-in codec compiles and caches one conversion per Go type. Compilation i
 | `complex64` | `*Struct{Real, Imag F32}` | heap-allocated |
 | `complex128` | `*Struct{Real, Imag F64}` | heap-allocated |
 | `VMMarshaler` | custom | `MarshalVM` decides representation |
-| recursive `*T` field | `any` ref | a true cycle returns `ErrMarshalCycle` |
+| recursive `*T` field | `*HostStruct` ref | a view is shallow, so the walk terminates |
 
-Nil pointers marshal to `types.Null`. Pointer cycles return `ErrMarshalCycle`. Shared non-cycle pointers are allowed.
+Nil pointers marshal to `types.Null`. A map or slice that reaches itself returns `ErrMarshalCycle`; a struct behind a pointer does not, because the view it produces is shallow. Shared pointers are allowed.
 
 ### Go Functions
 
@@ -293,17 +293,24 @@ A struct or array key, or a pointer to one, is therefore reachable only through 
 
 ## Structs and Methods
 
-A Go struct whose state a copy can reproduce marshals to a native
-`*types.Struct`: exported data fields become real slots in declaration order,
-and a field with no VM representation is skipped.
+The form a Go struct takes follows one rule: **use the VM type system whenever a
+copy reproduces the whole value, and a live view only when it cannot.**
 
-A struct carrying **unexported fields**, or one with any method on `*T`,
-marshals to a `*interp.HostStruct` instead — a live view of the Go struct rather
-than a snapshot of it. A copy would lose that state: unexported fields have no
-slot, and a mutation a pointer receiver makes lands on the copy. The view
-reports the same VM struct type a copy would have reported, so guest code reads
-and writes it with `STRUCT_GET` and `STRUCT_SET` exactly as it reads a native
-struct, and those reads and writes address the Go memory in place.
+| Marshaled | Result | Why |
+|---|---|---|
+| a value, all fields exported | `*types.Struct` | the VM struct holds every field; nothing is left behind |
+| a value with methods, all fields exported | `*types.Struct` | a method that mutates a copy is Go value semantics, not a loss |
+| a pointer | `*interp.HostStruct` | the caller asked for a reference; a copy would drop the aliasing |
+| a value with an unexported field | `*interp.HostStruct` | unexported state has no slot, so no copy is faithful |
+
+A native `*types.Struct` keeps the fast path: fused `STRUCT_GET` and native JIT
+lowering apply, and `Unmarshal` rebuilds an equal Go value from it.
+
+A `*interp.HostStruct` is a live view of the Go struct that reports the same VM
+struct type a copy would have reported, so guest code reads and writes it with
+`STRUCT_GET` and `STRUCT_SET` exactly as it reads a native struct — and those
+reads and writes address the Go memory in place. `Unmarshal` recovers the whole
+Go value from a view, unexported state included.
 
 ```go
 type Counter struct {
@@ -314,28 +321,23 @@ type Counter struct {
 func (c *Counter) Bump(n int32) int32 { c.count += int(n); return int32(c.count) }
 
 c := &Counter{Name: "a"}
-obj, _ := vm.Marshal(c)                 // *interp.HostStruct{Name}
+obj, _ := vm.Marshal(c)                 // *interp.HostStruct{Name}: pointer, and unexported state
 bump, _ := vm.Marshal((*Counter).Bump)  // *interp.HostFunction
 ```
 
 Methods are not fields. A method is an ordinary Go function, so a **method
 expression** marshals through the same path any `func` does, with the receiver
-as its first parameter. Called with the host value, it mutates the value the
-caller marshaled; called with any other VM value, the receiver decodes into a
-fresh Go value and the call still runs, with the mutation staying on that copy.
-A **method value** — `c.Bump`, already bound — marshals just as well and takes
-no receiver parameter.
+as its first parameter. Called with a host view, it mutates the value the caller
+marshaled; called with any other VM value — a native `*types.Struct` among them
+— the receiver decodes into a fresh Go value and the call still runs, with the
+mutation staying on that copy. A **method value** — `c.Bump`, already bound —
+marshals just as well and takes no receiver parameter.
 
-A host view never owns a VM reference, so a Go field whose type is a
-`types.Value` stays out of the layout. Writing a field copies what the VM value
-holds into the Go field rather than storing the slot, so a reference the write
-carried is released rather than retained.
-
-When the marshaled value is a pointer, the view addresses the caller's value and
-Go-side state stays observable in Go; when it is a value, it addresses the copy
-the conversion allocates. `Unmarshal` recovers the whole Go value from a host
-view, unexported state included, and falls back to the structural decode for any
-other VM value.
+One layout serves both forms, because a value and a pointer to it must report
+the same VM type. A view owns none of the references it hands out: reading a
+field publishes a reference the caller owns, and writing one copies what the VM
+value holds into the Go field rather than storing the slot, leaving the Go side
+holding a borrowed reference exactly as `Unmarshal` does.
 
 An `interp.Interpreter` is passed into each field access rather than captured, so
 a host view reached from a program constant is safe to share across pooled
@@ -479,7 +481,7 @@ A type providing only one direction leaves the other returning
 | `RuntimeError` | guest execution failed; unwraps to the cause and carries frames |
 | `types.Error` | guest exception value with code, message, payload, and optional wrapped Go cause |
 | `ErrHeapExhausted` | heap allocation exceeded `WithHeapLimit` |
-| `ErrMarshalCycle` | pointer graph contains a cycle |
+| `ErrMarshalCycle` | a map, slice, or non-struct pointer chain reaches itself |
 | `ErrUnsupportedMarshalType` | Go type or conversion direction is unsupported |
 | `ErrInvalidUnmarshalTarget` | destination is not a non-nil pointer |
 | `ErrValueOverflow` | numeric value does not fit destination type |

--- a/interp/codec.go
+++ b/interp/codec.go
@@ -46,8 +46,9 @@ type registry struct {
 // of vm, allocating a heap ref when the slot needs one. set is the reverse of
 // both, because a slot resolves to a value before it is written back.
 //
-// host marks a conversion whose value is a live view of the Go value rather than
-// a copy of it, which is what lets a pointer to it stay the caller's pointer.
+// view produces a live view of the Go value instead of a copy, and only a struct
+// has one. host reports that value is that view, so the conversion never copies
+// however it is reached.
 type conversion struct {
 	typ  reflect.Type
 	kind reflect.Kind
@@ -55,6 +56,7 @@ type conversion struct {
 	host bool
 
 	value func(*Encoder, unsafe.Pointer) (types.Value, error)
+	view  func(*Encoder, unsafe.Pointer) (types.Value, error)
 	box   func(*Encoder, unsafe.Pointer) (types.Boxed, error)
 	set   func(*Decoder, types.Value, unsafe.Pointer) error
 }
@@ -332,35 +334,36 @@ func (r *Registry) structure(p *conversion, seen map[reflect.Type]*conversion) e
 		return nil
 
 	case reflect.Struct:
-		// A copy of this struct would lose state no VM value carries -
-		// unexported fields have no slot, and a pointer receiver's mutation
-		// lands on the copy - so it is exposed as a live view instead.
-		p.host = reflect.PointerTo(t).NumMethod() > 0
-		for idx := 0; idx < t.NumField() && !p.host; idx++ {
-			p.host = t.Field(idx).PkgPath != ""
-		}
-		vm, fields, err := r.layout(t, seen, p.host)
+		vm, fields, err := r.layout(t, seen)
 		if err != nil {
 			return err
 		}
-		p.vm = vm
-		if p.host {
-			p.value = marshalHostStruct(t, vm, fields)
-			p.set = unmarshalHost(t, unmarshalStruct(fields))
-			return nil
+		// Unexported fields have no slot, so no VM struct reproduces the value
+		// and the view is its only faithful form. Everything else copies: a
+		// struct handed over by value carries all of its state into the VM
+		// struct, and a method that mutates that copy is Go value semantics
+		// rather than a loss. Asking for a view is what a pointer means, and
+		// marshalPointer is where that is answered.
+		for idx := 0; idx < t.NumField() && !p.host; idx++ {
+			p.host = t.Field(idx).PkgPath != ""
 		}
+		p.vm = vm
+		p.view = marshalHostStruct(t, vm, fields)
 		p.value = marshalStruct(vm, fields)
-		p.set = unmarshalStruct(fields)
+		if p.host {
+			p.value = p.view
+		}
+		p.set = unmarshalHost(t, unmarshalStruct(fields))
 		return nil
 	}
 	return fmt.Errorf("%w: type=%s", ErrUnsupportedMarshalType, t)
 }
 
 // layout compiles a Go struct into a VM struct type: exported data fields in
-// declaration order. A field whose type has no VM representation is skipped,
-// and a host layout also skips a field holding a VM value, because a host value
-// never owns a VM reference.
-func (r *Registry) layout(t reflect.Type, seen map[reflect.Type]*conversion, host bool) (*types.StructType, []field, error) {
+// declaration order. A field whose type has no VM representation is skipped.
+// One layout serves both forms of the struct, because a value and a pointer to
+// it must report the same VM type.
+func (r *Registry) layout(t reflect.Type, seen map[reflect.Type]*conversion) (*types.StructType, []field, error) {
 	var slots []types.StructField
 	var fields []field
 
@@ -368,13 +371,6 @@ func (r *Registry) layout(t reflect.Type, seen map[reflect.Type]*conversion, hos
 		f := t.Field(idx)
 		if f.PkgPath != "" {
 			continue
-		}
-		if host {
-			// A host value never owns a VM reference, so a Go field that holds
-			// one stays out of the layout.
-			if _, ok := natives[f.Type]; ok || f.Type.Implements(typeValue) {
-				continue
-			}
 		}
 		child, err := r.compile(f.Type, seen)
 		if err != nil {

--- a/interp/codec_test.go
+++ b/interp/codec_test.go
@@ -84,6 +84,12 @@ type codecHeld struct {
 
 func (h *codecHeld) Tag() int32 { return h.tag }
 
+// codecCounted is fully exported and still carries a pointer method, the case
+// that separates "has methods" from "a copy would lose something".
+type codecCounted struct{ Count int32 }
+
+func (c *codecCounted) Bump() int32 { c.Count++; return c.Count }
+
 type codecFirst struct{ Shared codecShared }
 
 type codecSecond struct{ Shared codecShared }
@@ -393,7 +399,31 @@ func TestRegistry_Marshal(t *testing.T) {
 		require.Equal(t, types.I64(src.UnixNano()), value)
 	})
 
-	t.Run("a struct with methods becomes a live view", func(t *testing.T) {
+	// The form a struct takes follows one rule: use the VM type system whenever
+	// a copy reproduces the whole value, and a live view only when it cannot.
+	for _, tt := range []struct {
+		name  string
+		value any
+		want  types.Value
+	}{
+		{name: "a value copies", value: codecShared{}, want: &types.Struct{}},
+		{name: "a value with methods still copies", value: codecCounted{}, want: &types.Struct{}},
+		{name: "a pointer is a view", value: &codecShared{}, want: &interp.HostStruct{}},
+		{name: "a pointer with methods is a view", value: &codecCounted{}, want: &interp.HostStruct{}},
+		{name: "an unexported field forces a view", value: marshalHostFields{}, want: &interp.HostStruct{}},
+	} {
+		t.Run("struct form: "+tt.name, func(t *testing.T) {
+			i := interp.New(program.New(nil))
+			r := interp.NewRegistry()
+			defer i.Close()
+
+			value, err := r.Marshal(i, tt.value)
+			require.NoError(t, err)
+			require.IsType(t, tt.want, value)
+		})
+	}
+
+	t.Run("a struct with unexported state becomes a live view", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
@@ -592,20 +622,28 @@ func TestRegistry_Marshal(t *testing.T) {
 		require.ErrorIs(t, err, interp.ErrTypeMismatch)
 	})
 
-	t.Run("a host layout leaves out a field holding a VM value", func(t *testing.T) {
+	t.Run("a host view reads a field holding a VM value", func(t *testing.T) {
 		i := interp.New(program.New(nil))
 		r := interp.NewRegistry()
 		defer i.Close()
 
 		value, err := r.Marshal(i, &codecHeld{Count: 7, Held: types.I32(1)})
 		require.NoError(t, err)
-		typ, ok := value.(*interp.HostStruct).Type().(*types.StructType)
-		require.True(t, ok)
+		host := value.(*interp.HostStruct)
 
-		// A host value never owns a VM reference, so Held has no slot even
-		// though it is exported and would otherwise convert.
-		require.Len(t, typ.Fields, 1)
-		require.Equal(t, "Count", typ.Fields[0].Name)
+		// One layout serves the value and the pointer, so a VM-valued field
+		// keeps its slot. The view hands the reference out to the caller and
+		// keeps none of its own.
+		typ, ok := host.Type().(*types.StructType)
+		require.True(t, ok)
+		require.Len(t, typ.Fields, 2)
+		require.Equal(t, "Held", typ.Fields[1].Name)
+
+		got, err := host.Field(i, 1)
+		require.NoError(t, err)
+		held, err := i.Load(got.Ref())
+		require.NoError(t, err)
+		require.Equal(t, types.I32(1), held)
 	})
 
 	t.Run("a registered marshaler wins over the host rule", func(t *testing.T) {
@@ -698,10 +736,14 @@ func TestRegistry_Marshal(t *testing.T) {
 		r := interp.NewRegistry()
 		defer i.Close()
 
+		// A struct behind a pointer is a view, and a view is shallow, so a
+		// self-referential one converts instead of recursing: the guest walks
+		// it a field at a time, and each step produces the next view.
 		node := &struct{ Next any }{}
 		node.Next = node
-		_, err := r.Marshal(i, node)
-		require.ErrorIs(t, err, interp.ErrMarshalCycle)
+		value, err := r.Marshal(i, node)
+		require.NoError(t, err)
+		require.IsType(t, &interp.HostStruct{}, value)
 
 		// A map or slice reaches itself without an intervening pointer, so the
 		// walk has to refuse those containers too rather than recurse forever.

--- a/interp/decode.go
+++ b/interp/decode.go
@@ -132,7 +132,7 @@ func unmarshalPointer(elem *conversion) func(*Decoder, types.Value, unsafe.Point
 			*(*unsafe.Pointer)(p) = nil
 			return nil
 		}
-		if elem.host {
+		if elem.view != nil {
 			value, err := d.registry.resolve(d.interp, val)
 			if err != nil {
 				return err

--- a/interp/encode.go
+++ b/interp/encode.go
@@ -340,10 +340,31 @@ func marshalDynamic(t reflect.Type) (
 }
 
 // marshalPointer follows a pointer, refusing one that reaches itself.
+//
+// A pointer to a struct is the caller asking for a reference, so it produces a
+// live view rather than a copy: copying would drop exactly the aliasing that
+// made the caller pass a pointer. A view is shallow, so it cannot reach itself
+// and needs no cycle check.
 func marshalPointer(elem *conversion) (
 	func(*Encoder, unsafe.Pointer) (types.Value, error),
 	func(*Encoder, unsafe.Pointer) (types.Boxed, error),
 ) {
+	if elem.view != nil {
+		value := func(e *Encoder, p unsafe.Pointer) (types.Value, error) {
+			target := *(*unsafe.Pointer)(p)
+			if target == nil {
+				return types.Null, nil
+			}
+			return elem.view(e, target)
+		}
+		return value, func(e *Encoder, p unsafe.Pointer) (types.Boxed, error) {
+			val, err := value(e, p)
+			if err != nil {
+				return 0, err
+			}
+			return e.ref(val)
+		}
+	}
 	value := func(e *Encoder, p unsafe.Pointer) (types.Value, error) {
 		target := *(*unsafe.Pointer)(p)
 		if target == nil {


### PR DESCRIPTION
Follow-up to #214.

## Problem

#214 triggered hosting on "has methods **or** has unexported fields", which ignores how the value was handed over. That is wrong in both directions:

- **Over-hosts.** A fully exported struct passed *by value* left the native fast path the moment it gained a `String()` method — even though the VM struct reproduces every field of it, so nothing was at stake.
- **Under-hosts.** A pointer to a fully exported struct copied, dropping exactly the aliasing that made the caller pass a pointer.

## The rule

Use the VM type system whenever a copy reproduces the whole value; use a live view only when it cannot.

| Marshaled | Result | Why |
|---|---|---|
| a value, all fields exported | `*types.Struct` | the VM struct holds every field |
| a value with methods, all exported | `*types.Struct` | a method mutating a copy is Go value semantics, not a loss |
| a pointer | `*interp.HostStruct` | the caller asked for a reference |
| a value with an unexported field | `*interp.HostStruct` | unexported state has no slot |

Methods no longer decide anything. `marshalPointer` is where a view is produced, which is what "pass a pointer" already means in Go.

## Consequences

**One layout per struct.** A value and a pointer to it must report the same VM type, so the two forms share a layout. That retires #214's rule that kept a Go field holding a `types.Value` out of a host layout — the field keeps its slot, and a host write leaves the Go side holding a *borrowed* reference exactly as `unmarshalValue` already does. The view still owns nothing and still needs no `types.Traceable`.

**Struct pointers cannot cycle.** A view is shallow, so `marshalPointer` skips the cycle check on that path. A self-referential struct now converts instead of failing, and the guest walks it a field at a time — each step produces the next view. Maps, slices, and non-struct pointer chains still return `ErrMarshalCycle`.

## Evidence

Apple M4 Pro, darwin/arm64, go1.26.2, `-benchmem -count=6`:

| Benchmark | Before | After |
|---|---|---|
| `Marshal/methods` | 175 ns, 5 allocs/op | **104 ns, 3 allocs/op** |
| `StructGetHost` | 154.2 µs, 8 allocs/op | **149.5 µs, 6 allocs/op** |
| — per field read | 15.42 ns | **14.95 ns** |

Marshaling a pointer no longer builds the cycle-tracking `seen` set — that is the two allocations and most of the time the methods row loses. Against the pre-view baseline of 14.26 ns, a host field read is now **+4.8%** rather than +8.1%.

Scalar, struct, slice, map, and every `Unmarshal` row are unmoved, as are the `benchmark-pr` kernels.

## Test plan

- [x] `go test -race ./...`
- [x] `make lint`, `make check-generated`
- [x] `make benchmark-pr` — kernels unmoved
- [x] New table in `TestRegistry_Marshal` pinning all five rows of the rule above
- [x] `TestRegistry_Marshal/cycle` updated: a self-referential struct converts to a view; map and slice cycles still error
- [x] `TestRegistry_Marshal` VM-valued field case rewritten: the field keeps its slot and a host read hands out the reference
- [ ] `make coverage-check` — fails locally from a goenv go1.25/1.26 split, unrelated to this diff

## Breaking changes

- A fully exported struct with methods marshals to `*types.Struct`, not a host view.
- A pointer to a fully exported struct marshals to `*interp.HostStruct`, not a copy.
- A struct behind a pointer no longer returns `ErrMarshalCycle` when its graph reaches itself.
