### PR TITLE
perf(interp): lower a host struct field access natively

### DIFF
--- a/docs/host-integration.md
+++ b/docs/host-integration.md
@@ -323,6 +323,13 @@ An opcode splits by what it produces:
 A view addresses the Go *variable* rather than the data behind it, so a slice or
 map the Go side replaced is the one the next access reaches.
 
+A host struct field also lowers natively on ARM64: `STRUCT_GET` and `STRUCT_SET`
+read and write the Go field from the compiled layout rather than leaving the
+native trace, so a loop over one runs at the speed of a loop over a VM struct. A
+field the backend has no load for — a string, a pointer, a nested container — and
+a write narrower than its VM slot, whose range check can fail, stay with the
+interpreter. `docs/jit-internals.md` holds the guards.
+
 ### Dynamic Map Keys
 
 A `map[any]V` is a view like any other map. A VM key carries no Go type of its

--- a/docs/instruction-set.md
+++ b/docs/instruction-set.md
@@ -268,8 +268,8 @@ Do not group multiple opcodes in one row. Keep this table in opcode-value order 
 | Arrays | `ARRAY_SLICE` | `array.slice` | ⬜ | 🔲 | allocation and ownership stay threaded |
 | Structs | `STRUCT_NEW` | `struct.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Structs | `STRUCT_NEW_DEFAULT` | `struct.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
-| Structs | `STRUCT_GET` | `struct.get` | ✅ | 🔲 | native field get fast path; static plans resolve constant field indexes |
-| Structs | `STRUCT_SET` | `struct.set` | ◐ | 🔲 | guarded native store when the no-spill budget permits; ref-field writes remain terminal |
+| Structs | `STRUCT_GET` | `struct.get` | ✅ | 🔲 | native field get fast path; static plans resolve constant field indexes; a `*HostStruct` field loads Go memory in place |
+| Structs | `STRUCT_SET` | `struct.set` | ◐ | 🔲 | guarded native store when the no-spill budget permits; ref-field writes remain terminal; a `*HostStruct` field stores Go memory in place when it is as wide as its slot |
 | Maps | `MAP_NEW` | `map.new` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Maps | `MAP_NEW_DEFAULT` | `map.new_default` | ⬜ | 🔲 | allocation stays interpreter-owned |
 | Maps | `MAP_LEN` | `map.len` | ◐ | 🔲 | terminal fallback |

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -460,6 +460,10 @@ Native full-trace reads include observed shapes for scalar `REF_GET`, selected `
 
 Heap reads guard ref address, heap itab, array element kind, struct type pointer, struct field kind, index bounds, and release safety when needed.
 
+`STRUCT_GET` and `STRUCT_SET` also lower against a `*HostStruct`, whose fields hold Go memory rather than VM words (see `docs/host-integration.md`). `hostGet` and `hostSet` (`interp/jit_arm64.go`) guard the heap itab against `heapHostStruct`, bounds-guard the field index against the compiled layout the view carries, and guard that field's Go kind against the one the trace recorded in `shape.field`, then load or store the Go field through the address the layout's offset names. Nothing about a host view is assumed from the itab alone: the same compiled access serves every `*HostStruct`, so a container whose field at that index has another Go kind exits at the kind guard rather than loading the wrong width.
+
+`hostShapes` (`interp/jit.go`) is the one place a hosted Go field's layout is written down, indexed by the `reflect.Kind` the codec compiled the field through, and mirrors the codec's own `leaves` table. A kind with no row - `string`, a pointer, a nested container - publishes a heap reference rather than loading a word, so its access stays with the interpreter. A read reinterprets a field as wide as its VM slot and widens a narrower one by the field's own signedness, which is why an `int16`, an `int32`, and a `uint32` field all reach the guest as i32 but do not share a load. A write lowers only for a field as wide as its slot: a narrower one decodes through the range check `setSigned` and `setUnsigned` perform, and a check that can fail belongs with the interpreter that reports it.
+
 Ref reads retain the loaded element or payload. A container consumer releases its container handle only when that operand owns its retain, eliding the release for a deferred operand (see Reference Ownership): `CORO_VALUE` still retains the value and releases the handle when the handle is `backingStack`. `CORO_DONE` keeps the handle.
 
 Heap-promoted `i64` values fall back before boxing.

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -8803,30 +8803,42 @@ func (h *structGetHostFields) Bump(n int32) int32 {
 // dispatch cost from any boxing or heap traffic. The marshal and reset work
 // outside the inner loop is amortized over repeats field reads per run, the
 // same way BenchmarkInterpreter_StructGetLocalFusion amortizes its tree build.
+// The two rows separate the threaded read from the lowered one, which is the
+// pair a change to hostGet has to report.
 func BenchmarkInterpreter_StructGetHost(b *testing.B) {
 	const repeats = 10000
 
-	prog := structGetHostLoop(repeats)
-	vm := New(prog, WithThreshold(-1)) // threaded + fused, no JIT
-	b.Cleanup(func() { require.NoError(b, vm.Close()) })
-	ctx := context.Background()
+	for _, tt := range []struct {
+		name      string
+		threshold int
+	}{
+		{name: "Threaded", threshold: -1},
+		{name: "JIT", threshold: 0},
+	} {
+		b.Run(tt.name, func(b *testing.B) {
+			prog := structGetHostLoop(repeats)
+			vm := New(prog, WithThreshold(tt.threshold))
+			b.Cleanup(func() { require.NoError(b, vm.Close()) })
+			ctx := context.Background()
 
-	run := func() types.Boxed {
-		host, err := vm.Marshal(&structGetHostFields{Count: 1})
-		require.NoError(b, err)
-		require.NoError(b, vm.Push(host))
-		require.NoError(b, vm.Run(ctx))
-		got, err := vm.PopBoxed()
-		require.NoError(b, err)
-		vm.Reset()
-		return got
-	}
+			run := func() types.Boxed {
+				host, err := vm.Marshal(&structGetHostFields{Count: 1})
+				require.NoError(b, err)
+				require.NoError(b, vm.Push(host))
+				require.NoError(b, vm.Run(ctx))
+				got, err := vm.PopBoxed()
+				require.NoError(b, err)
+				vm.Reset()
+				return got
+			}
 
-	want := run()
+			want := run()
 
-	b.ReportAllocs()
-	for b.Loop() {
-		require.Equal(b, want, run())
+			b.ReportAllocs()
+			for b.Loop() {
+				require.Equal(b, want, run())
+			}
+		})
 	}
 }
 

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -2,6 +2,7 @@ package interp
 
 import (
 	"errors"
+	"reflect"
 	"unsafe"
 
 	"github.com/siyul-park/minivm/asm"
@@ -298,20 +299,21 @@ const arrayElems = int(unsafe.Offsetof(types.Array{}.Elems))
 // the portable JIT core: jit_plan.go resolves element layout on every
 // architecture, including ones with no native backend at all.
 var (
-	heapI32       = itab(types.I32(0))
-	heapF32       = itab(types.F32(0))
-	heapF64       = itab(types.F64(0))
-	heapArrayI1   = itab(types.TypedArray[bool](nil))
-	heapArrayI8   = itab(types.TypedArray[int8](nil))
-	heapArrayI32  = itab(types.TypedArray[int32](nil))
-	heapArrayI64  = itab(types.TypedArray[int64](nil))
-	heapArrayF32  = itab(types.TypedArray[float32](nil))
-	heapArrayF64  = itab(types.TypedArray[float64](nil))
-	heapArrayRef  = itab((*types.Array)(nil))
-	heapString    = itab(types.String(""))
-	heapStruct    = itab((*types.Struct)(nil))
-	heapError     = itab((*types.Error)(nil))
-	heapCoroutine = itab((*coroutine)(nil))
+	heapI32        = itab(types.I32(0))
+	heapF32        = itab(types.F32(0))
+	heapF64        = itab(types.F64(0))
+	heapArrayI1    = itab(types.TypedArray[bool](nil))
+	heapArrayI8    = itab(types.TypedArray[int8](nil))
+	heapArrayI32   = itab(types.TypedArray[int32](nil))
+	heapArrayI64   = itab(types.TypedArray[int64](nil))
+	heapArrayF32   = itab(types.TypedArray[float32](nil))
+	heapArrayF64   = itab(types.TypedArray[float64](nil))
+	heapArrayRef   = itab((*types.Array)(nil))
+	heapString     = itab(types.String(""))
+	heapStruct     = itab((*types.Struct)(nil))
+	heapHostStruct = itab((*HostStruct)(nil))
+	heapError      = itab((*types.Error)(nil))
+	heapCoroutine  = itab((*coroutine)(nil))
 )
 
 // elemShapes is the one place the element storage layout is written down.
@@ -348,6 +350,86 @@ func elemShapeByItab(want uintptr) (elemShape, bool) {
 		}
 	}
 	return elemShape{}, false
+}
+
+// hostShape is how one Go field kind sits in memory. kind is the VM kind its
+// conversion produces, size is the width of the Go field, and signed is the
+// extension a field narrower than its slot widens with; a float row is signed
+// because the VM holds a float's bit pattern sign-extended, as it holds an i32.
+type hostShape struct {
+	kind   types.Kind
+	size   uintptr
+	signed bool
+}
+
+// hostShapes is the one place the memory layout of a hosted Go field is written
+// down, indexed by the reflect.Kind the codec compiled the field through. It
+// mirrors the leaves table the codec picks a conversion from, and holds a row
+// exactly where that conversion is a plain load or store: a string, pointer, or
+// container field publishes a heap reference instead, so it has no row and its
+// access stays with the interpreter.
+var hostShapes = [...]hostShape{
+	reflect.Bool:    {kind: types.KindI1, size: unsafe.Sizeof(false)},
+	reflect.Int8:    {kind: types.KindI8, size: unsafe.Sizeof(int8(0)), signed: true},
+	reflect.Int16:   {kind: types.KindI32, size: unsafe.Sizeof(int16(0)), signed: true},
+	reflect.Int32:   {kind: types.KindI32, size: unsafe.Sizeof(int32(0)), signed: true},
+	reflect.Int:     {kind: types.KindI64, size: unsafe.Sizeof(int(0)), signed: true},
+	reflect.Int64:   {kind: types.KindI64, size: unsafe.Sizeof(int64(0)), signed: true},
+	reflect.Uint8:   {kind: types.KindI32, size: unsafe.Sizeof(uint8(0))},
+	reflect.Uint16:  {kind: types.KindI32, size: unsafe.Sizeof(uint16(0))},
+	reflect.Uint32:  {kind: types.KindI32, size: unsafe.Sizeof(uint32(0))},
+	reflect.Uint:    {kind: types.KindI64, size: unsafe.Sizeof(uint(0))},
+	reflect.Uint64:  {kind: types.KindI64, size: unsafe.Sizeof(uint64(0))},
+	reflect.Uintptr: {kind: types.KindI64, size: unsafe.Sizeof(uintptr(0))},
+	reflect.Float32: {kind: types.KindF32, size: unsafe.Sizeof(float32(0)), signed: true},
+	reflect.Float64: {kind: types.KindF64, size: unsafe.Sizeof(float64(0)), signed: true},
+}
+
+// hostShapeOf resolves the layout of a Go field kind, and reports false where
+// the kind has no row.
+func hostShapeOf(kind reflect.Kind) (hostShape, bool) {
+	if int(kind) >= len(hostShapes) {
+		return hostShape{}, false
+	}
+	shape := hostShapes[kind]
+	return shape, shape.size != 0
+}
+
+// slotShapes is the width a VM slot holds a raw scalar in, and whether it holds
+// it sign-extended. A host field as wide as its slot is the slot's exact image,
+// so a read reinterprets it and a write stores it whole.
+var slotShapes = [...]struct {
+	size   uintptr
+	signed bool
+}{
+	types.KindI1:  {size: 1},
+	types.KindI8:  {size: 1, signed: true},
+	types.KindI32: {size: 4, signed: true},
+	types.KindI64: {size: 8, signed: true},
+	types.KindF32: {size: 4, signed: true},
+	types.KindF64: {size: 8, signed: true},
+}
+
+// exact reports whether the Go field of shape s is as wide as a VM slot of
+// s.kind, which makes the two the same bytes in either direction. A narrower
+// field is not: it decodes through the range check setSigned and setUnsigned
+// perform, and a check that can fail belongs with the interpreter that reports
+// it, so only an exact field lowers a write. Signedness does not enter, because
+// at equal width a conversion only reinterprets the bytes a store already
+// writes.
+func (s hostShape) exact() bool {
+	return s.size == slotShapes[s.kind].size
+}
+
+// read is the width and extension a read of the field loads with. An exact
+// field is reinterpreted with its slot's own extension, which is how an
+// unsigned Go field reaches the guest as the signed VM value its conversion
+// casts to; a narrower one widens with its own.
+func (s hostShape) read() (uintptr, bool) {
+	if s.exact() {
+		return s.size, slotShapes[s.kind].signed
+	}
+	return s.size, s.signed
 }
 
 func newActivation(addr int, fn *types.Function, base, opBase int) activation {

--- a/interp/jit_arm64.go
+++ b/interp/jit_arm64.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"reflect"
 	"slices"
 	"unsafe"
 
@@ -30,17 +31,23 @@ const (
 )
 
 const (
-	sliceData   = 0
-	sliceLen    = 8
-	structTyp   = int(unsafe.Offsetof(types.Struct{}.Typ))
-	structData  = int(unsafe.Offsetof(types.Struct{}.Data))
-	closureUpvs = int(unsafe.Offsetof(types.Closure{}.Upvals))
-	fieldsSlice = int(unsafe.Offsetof(types.StructType{}.Fields))
-	fieldKind   = int(unsafe.Offsetof(types.StructField{}.Kind))
-	fieldSize   = int(unsafe.Sizeof(types.StructField{}))
-	errorValue  = types.ErrorValueOffset
-	coroValue   = int(unsafe.Offsetof(coroutine{}.value))
-	coroDone    = int(unsafe.Offsetof(coroutine{}.done))
+	sliceData       = 0
+	sliceLen        = 8
+	structTyp       = int(unsafe.Offsetof(types.Struct{}.Typ))
+	structData      = int(unsafe.Offsetof(types.Struct{}.Data))
+	closureUpvs     = int(unsafe.Offsetof(types.Closure{}.Upvals))
+	fieldsSlice     = int(unsafe.Offsetof(types.StructType{}.Fields))
+	fieldKind       = int(unsafe.Offsetof(types.StructField{}.Kind))
+	fieldSize       = int(unsafe.Sizeof(types.StructField{}))
+	hostFields      = int(unsafe.Offsetof(HostStruct{}.fields))
+	hostPtr         = int(unsafe.Offsetof(HostStruct{}.ptr))
+	hostFieldOffset = int(unsafe.Offsetof(field{}.offset))
+	hostFieldConv   = int(unsafe.Offsetof(field{}.conversion))
+	hostFieldSize   = int(unsafe.Sizeof(field{}))
+	hostConvKind    = int(unsafe.Offsetof(conversion{}.kind))
+	errorValue      = types.ErrorValueOffset
+	coroValue       = int(unsafe.Offsetof(coroutine{}.value))
+	coroDone        = int(unsafe.Offsetof(coroutine{}.done))
 )
 
 const branchTableLimit = 32
@@ -3494,6 +3501,9 @@ func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
 	if ctx.count() < 2 || ctx.values[len(ctx.values)-1].kind != types.KindI32 || ctx.values[len(ctx.values)-2].kind != types.KindRef {
 		return false
 	}
+	if op.shape.itab == heapHostStruct {
+		return l.hostGet(ctx, op)
+	}
 	out := op.seen.Kind()
 	switch out {
 	case types.KindI1, types.KindI8, types.KindI32, types.KindI64, types.KindF32, types.KindF64, types.KindRef:
@@ -3572,6 +3582,172 @@ func (l arm64Lowerer) structGet(ctx *lowering, op step) bool {
 	return true
 }
 
+// hostEntry walks the compiled layout of the *HostStruct at data to the field
+// the index in idx names, and returns the address of that field inside the Go
+// struct. The index is bounds-guarded against the layout the view carries and
+// the field's Go kind is guarded against the one the trace recorded, so the
+// caller's load or store is the one that kind compiled to.
+func (l arm64Lowerer) hostEntry(ctx *lowering, data, idx asm.VReg, kind reflect.Kind, bounds, kindFail asm.Label) asm.VReg {
+	a := ctx.assembler
+	fields, n := l.sliceHeader(ctx, data, int16(hostFields))
+	l.guardIndex(ctx, idx, n, bounds)
+
+	stride := a.Reg(asm.RegTypeInt, asm.Width64)
+	entry := a.Reg(asm.RegTypeInt, asm.Width64)
+	a.Emit(arm64.LDI(stride, uint64(hostFieldSize))...)
+	a.Emit(arm64.MUL(stride, idx, stride), arm64.ADD(entry, fields, stride))
+
+	conv := a.Reg(asm.RegTypeInt, asm.Width64)
+	got := a.Reg(asm.RegTypeInt, asm.Width64)
+	a.Emit(arm64.LDR(conv, entry, int16(hostFieldConv)), arm64.LDRB(got, conv, int16(hostConvKind)))
+	a.Emit(arm64.CMPI(got, uint16(kind)), arm64.BCondLabel(arm64.OpBNE, kindFail))
+
+	offset := a.Reg(asm.RegTypeInt, asm.Width64)
+	base := a.Reg(asm.RegTypeInt, asm.Width64)
+	target := a.Reg(asm.RegTypeInt, asm.Width64)
+	a.Emit(arm64.LDR(offset, entry, int16(hostFieldOffset)), arm64.LDR(base, data, int16(hostPtr)), arm64.ADD(target, base, offset))
+	return target
+}
+
+// hostLoad reads size bytes at target into an integer register, extending them
+// as signed says, which leaves the register holding what a VM slot of that
+// field's kind holds raw. hostGet settles which widths reach here.
+func (l arm64Lowerer) hostLoad(ctx *lowering, size uintptr, signed bool, target asm.VReg) asm.VReg {
+	a := ctx.assembler
+	out := a.Reg(asm.RegTypeInt, asm.Width64)
+	switch {
+	case size == 1 && signed:
+		raw := a.Reg(asm.RegTypeInt, asm.Width64)
+		a.Emit(arm64.LDRB(raw, target, 0), arm64.SXTB(out, raw))
+	case size == 1:
+		a.Emit(arm64.LDRB(out, target, 0))
+	case size == 2 && signed:
+		a.Emit(arm64.LDRSH(out, target, 0))
+	case size == 2:
+		a.Emit(arm64.LDRH(out, target, 0))
+	case size == 4:
+		a.Emit(arm64.LDRSW(out, target, 0))
+	default:
+		a.Emit(arm64.LDR(out, target, 0))
+	}
+	return out
+}
+
+// hostGet lowers STRUCT_GET against a *HostStruct. A host field holds Go memory
+// rather than a VM word, so the read loads that memory in the form the field's
+// conversion produces instead of reading a struct data slot.
+func (l arm64Lowerer) hostGet(ctx *lowering, op step) bool {
+	s, ok := hostShapeOf(op.shape.field)
+	if !ok || s.kind != op.seen.Kind() {
+		return false
+	}
+	size, signed := s.read()
+	if size == 4 && !signed {
+		// Four unsigned bytes widening into an eight-byte slot would need a
+		// zero-extending word load that no target this backend lowers for
+		// asks for, since int and uint are eight bytes on all of them.
+		return false
+	}
+	container := ctx.values[len(ctx.values)-2]
+	owned := container.backing == backingStack
+	pre := ctx.pre()
+	idx := l.sign32(ctx, ctx.values[len(ctx.values)-1].reg)
+	ref, ok := l.box(ctx, container)
+	if !ok {
+		return false
+	}
+	a := ctx.assembler
+	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
+	if !ok {
+		return false
+	}
+	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
+	if !ok {
+		return false
+	}
+	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
+	if !ok {
+		return false
+	}
+	kindFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardKind, int(op.op))
+	if !ok {
+		return false
+	}
+	addr, itab, data := l.guardHeap(ctx, ref, fail)
+	l.guardItab(ctx, itab, heapHostStruct, fail)
+	target := l.hostEntry(ctx, data, idx, op.shape.field, bounds, kindFail)
+	result := l.hostLoad(ctx, size, signed, target)
+	if s.kind == types.KindI64 {
+		l.guardBoxable(ctx, result, valueFail)
+	}
+	if owned {
+		rcBase := l.rcBase(ctx)
+		rc := l.guardRC(ctx, addr, rcBase, valueFail)
+		a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
+	}
+	ctx.values = append(pre[:len(pre)-2:len(pre)-2], value{reg: result, kind: s.kind, raw: true})
+	return true
+}
+
+// hostSet lowers STRUCT_SET against a *HostStruct. It lowers only a field that
+// is the exact image of its VM slot, because every other field decodes through
+// the range check setSigned and setUnsigned perform, and a check that can fail
+// belongs with the interpreter that reports it.
+func (l arm64Lowerer) hostSet(ctx *lowering, op step) (bool, bool) {
+	s, ok := hostShapeOf(op.shape.field)
+	if !ok || !s.exact() || s.kind != ctx.values[len(ctx.values)-1].kind {
+		return false, false
+	}
+	container := ctx.values[len(ctx.values)-3]
+	owned := container.backing == backingStack
+	pre := ctx.pre()
+	val := ctx.values[len(ctx.values)-1]
+	idx := l.sign32(ctx, ctx.values[len(ctx.values)-2].reg)
+	ref, ok := l.box(ctx, container)
+	if !ok {
+		return false, false
+	}
+	a := ctx.assembler
+	fail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardShape, int(op.op))
+	if !ok {
+		return false, false
+	}
+	bounds, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardBounds, int(op.op))
+	if !ok {
+		return false, false
+	}
+	valueFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardValue, int(op.op))
+	if !ok {
+		return false, false
+	}
+	kindFail, ok := l.sideExit(ctx, pre, op.ip, prof.ExitGuardKind, int(op.op))
+	if !ok {
+		return false, false
+	}
+	addr, itab, data := l.guardHeap(ctx, ref, fail)
+	l.guardItab(ctx, itab, heapHostStruct, fail)
+	target := l.hostEntry(ctx, data, idx, op.shape.field, bounds, kindFail)
+	if owned {
+		rcBase := l.rcBase(ctx)
+		rc := l.guardRC(ctx, addr, rcBase, valueFail)
+		a.Emit(arm64.SUBI(rc, rc, 1), arm64.STRR(rc, rcBase, addr))
+	}
+	// exact leaves three widths, so the store is total over them.
+	switch s.size {
+	case 1:
+		a.Emit(arm64.STRB(val.reg, target, 0))
+	case 4:
+		a.Emit(arm64.STRW(val.reg, target, 0))
+	default:
+		a.Emit(arm64.STR(val.reg, target, 0))
+	}
+	ctx.values = ctx.values[:len(ctx.values)-3]
+	if op.terminal {
+		return l.exit(ctx, op.ip+1, prof.ExitTerminalOp, int(op.op)), true
+	}
+	return true, false
+}
+
 func (l arm64Lowerer) guardBoxable(ctx *lowering, v asm.VReg, fail asm.Label) {
 	ext := ctx.assembler.Reg(asm.RegTypeInt, asm.Width64)
 	ctx.assembler.Emit(arm64.SBFX(ext, v, 0, boxableWidth))
@@ -3582,6 +3758,9 @@ func (l arm64Lowerer) guardBoxable(ctx *lowering, v asm.VReg, fail asm.Label) {
 func (l arm64Lowerer) structSet(ctx *lowering, op step) (bool, bool) {
 	if ctx.count() < 3 || ctx.values[len(ctx.values)-2].kind != types.KindI32 || ctx.values[len(ctx.values)-3].kind != types.KindRef {
 		return false, false
+	}
+	if op.shape.itab == heapHostStruct {
+		return l.hostSet(ctx, op)
 	}
 	kind := ctx.values[len(ctx.values)-1].kind
 	switch kind {

--- a/interp/jit_arm64_test.go
+++ b/interp/jit_arm64_test.go
@@ -3962,3 +3962,463 @@ func TestARM64_BridgedOpcodes(t *testing.T) {
 		runParityErr(t, prog)
 	})
 }
+
+// hostLoopFields is the Go struct TestARM64_HostStructLoop reads and writes
+// through. It carries an unexported field so the codec picks a live view, one
+// exported field per Go kind the lowerer has a row for, a string field it has
+// none for, and an int64 field holding more than a box payload fits.
+type hostLoopFields struct {
+	Flag   bool
+	I8     int8
+	I16    int16
+	I32    int32
+	Int    int
+	I64    int64
+	U8     uint8
+	U16    uint16
+	U32    uint32
+	U64    uint64
+	F32    float32
+	F64    float64
+	Text   string
+	Big    int64
+	hidden int32
+}
+
+func (h *hostLoopFields) Hidden() int32 { return h.hidden }
+
+// hostNarrowField and hostWideField hold one field of the same VM kind in two
+// Go widths, which is what makes a lowered read of one wrong for the other.
+type hostNarrowField struct {
+	V      int16
+	hidden int32
+}
+
+func (h *hostNarrowField) Hidden() int32 { return h.hidden }
+
+type hostWideField struct {
+	V      int32
+	hidden int32
+}
+
+func (h *hostWideField) Hidden() int32 { return h.hidden }
+
+// TestARM64_HostStructLoop covers STRUCT_GET and STRUCT_SET against a
+// *HostStruct, whose fields hold Go memory rather than VM words. Every case
+// reads or writes inside a counted loop and hands the loop's own value back, so
+// a row that loads the wrong width or extension reports a wrong value rather
+// than merely a different speed, and the native entry count separates an access
+// that stayed in the loop from one that exited on every iteration.
+func TestARM64_HostStructLoop(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("native JIT is only available on arm64")
+	}
+
+	const size = int32(24)
+	negI32, negI64 := int32(-99), int64(-1)<<41
+	seed := hostLoopFields{
+		Flag: true, I8: -8, I16: -300, I32: -70000, Int: -1 << 40, I64: -1 << 40,
+		U8: 200, U16: 60000, U32: 0xFFFF_FFFF, U64: 1 << 40, F32: 1.5, F64: -2.5,
+		Text: "text", Big: 1 << 60,
+	}
+
+	// run marshals its own copy of seed, so a JIT run and a threaded run each
+	// own the Go memory they write and the comparison between them stays
+	// honest. body runs once per iteration and tail leaves the result.
+	run := func(t *testing.T, locals []types.Type, body, tail []instr.Instruction, opts ...func(*option)) (types.Value, hostLoopFields, float64) {
+		t.Helper()
+		setup := New(program.New(nil))
+		defer func() { require.NoError(t, setup.Close()) }()
+		src := seed
+		host, err := NewRegistry().Marshal(setup, &src)
+		require.NoError(t, err)
+
+		b := program.NewBuilder()
+		require.Equal(t, 0, b.Const(host))
+		b.Locals(append([]types.Type{types.TypeI32}, locals...)...)
+		loop, done := b.Label(), b.Label()
+		b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 0)
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+		for _, step := range body {
+			b.Emit(step.Opcode(), step.Operands()...)
+		}
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 0)
+		b.Br(loop)
+		b.Bind(done)
+		for _, step := range tail {
+			b.Emit(step.Opcode(), step.Operands()...)
+		}
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		profile := prof.New()
+		i := New(prog, append(opts, WithProfiler(profile))...)
+		require.NoError(t, i.Run(context.Background()))
+		got, err := i.Pop()
+		require.NoError(t, err)
+		// Metrics land when the interpreter closes, so the count is read
+		// after the run has finished rather than during it.
+		require.NoError(t, i.Close())
+
+		var entries float64
+		for _, metric := range profile.Metrics() {
+			if metric.Name == "vm_jit_native_entries_total" {
+				entries += metric.Value
+			}
+		}
+		return got, src, entries
+	}
+
+	t.Run("a read of every lowered field kind stays native and agrees with threaded", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			at   uint64
+			typ  types.Type
+			want types.Value
+		}{
+			{name: "bool", at: 0, typ: types.TypeI1, want: types.I1(true)},
+			{name: "int8", at: 1, typ: types.TypeI8, want: types.I8(-8)},
+			{name: "int16", at: 2, typ: types.TypeI32, want: types.I32(-300)},
+			{name: "int32", at: 3, typ: types.TypeI32, want: types.I32(-70000)},
+			{name: "int", at: 4, typ: types.TypeI64, want: types.I64(-1 << 40)},
+			{name: "int64", at: 5, typ: types.TypeI64, want: types.I64(-1 << 40)},
+			{name: "uint8", at: 6, typ: types.TypeI32, want: types.I32(200)},
+			{name: "uint16", at: 7, typ: types.TypeI32, want: types.I32(60000)},
+			// A uint32 field reaches the guest as the signed i32 its
+			// conversion casts to, so the load sign-extends the same four
+			// bytes rather than widening them.
+			{name: "uint32", at: 8, typ: types.TypeI32, want: types.I32(-1)},
+			{name: "uint64", at: 9, typ: types.TypeI64, want: types.I64(1 << 40)},
+			{name: "float32", at: 10, typ: types.TypeF32, want: types.F32(1.5)},
+			{name: "float64", at: 11, typ: types.TypeF64, want: types.F64(-2.5)},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				locals := []types.Type{tt.typ}
+				body := []instr.Instruction{
+					instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, tt.at),
+					instr.New(instr.STRUCT_GET), instr.New(instr.LOCAL_SET, 1),
+				}
+				tail := []instr.Instruction{instr.New(instr.LOCAL_GET, 1)}
+
+				want, _, _ := run(t, locals, body, tail, WithTick(1), WithThreshold(-1))
+				require.Equal(t, tt.want, want)
+
+				got, _, entries := run(t, locals, body, tail, WithTick(1), WithThreshold(0))
+				require.Equal(t, want, got)
+				require.Greater(t, entries, float64(0), "expected a native entry")
+				require.Less(t, entries, float64(size), "the read exits the native loop")
+			})
+		}
+	})
+
+	t.Run("a read the interpreter still owns agrees with threaded", func(t *testing.T) {
+		for _, tt := range []struct {
+			name string
+			at   uint64
+			typ  types.Type
+			want types.Value
+		}{
+			// A string field publishes a heap reference rather than loading
+			// a word, so it has no row at all.
+			{name: "no row for the field kind", at: 12, typ: types.TypeString, want: types.String("text")},
+			// An i64 past the box payload cannot stay raw, so the read
+			// leaves the loop where the interpreter spills it to the heap.
+			{name: "a value past the box payload", at: 13, typ: types.TypeI64, want: types.I64(1 << 60)},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				locals := []types.Type{tt.typ}
+				body := []instr.Instruction{
+					instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, tt.at),
+					instr.New(instr.STRUCT_GET), instr.New(instr.LOCAL_SET, 1),
+				}
+				tail := []instr.Instruction{instr.New(instr.LOCAL_GET, 1)}
+
+				want, _, _ := run(t, locals, body, tail, WithTick(1), WithThreshold(-1))
+				require.Equal(t, tt.want, want)
+				got, _, _ := run(t, locals, body, tail, WithTick(1), WithThreshold(0))
+				require.Equal(t, want, got)
+			})
+		}
+	})
+
+	t.Run("a write of every exactly imaged field kind reaches the Go value", func(t *testing.T) {
+		for _, tt := range []struct {
+			name  string
+			at    uint64
+			store []instr.Instruction
+			want  types.Value
+			check func(*testing.T, hostLoopFields)
+		}{
+			{
+				name: "bool", at: 0,
+				store: []instr.Instruction{instr.New(instr.I32_CONST, 1), instr.New(instr.I32_EQZ)},
+				want:  types.I1(false),
+				check: func(t *testing.T, got hostLoopFields) { require.False(t, got.Flag) },
+			},
+			{
+				// No opcode makes an i8 constant, so the value written is the
+				// one a read of the same field produced.
+				name: "int8", at: 1,
+				store: []instr.Instruction{instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, 1), instr.New(instr.STRUCT_GET)},
+				want:  types.I8(-8),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, int8(-8), got.I8) },
+			},
+			{
+				name: "int32", at: 3,
+				store: []instr.Instruction{instr.New(instr.I32_CONST, uint64(uint32(negI32)))},
+				want:  types.I32(negI32),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, negI32, got.I32) },
+			},
+			{
+				name: "int64", at: 5,
+				store: []instr.Instruction{instr.New(instr.I64_CONST, uint64(negI64))},
+				want:  types.I64(negI64),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, negI64, got.I64) },
+			},
+			{
+				// A uint32 field is as wide as its slot, so the store writes
+				// the same four bytes the conversion would reinterpret.
+				name: "uint32", at: 8,
+				store: []instr.Instruction{instr.New(instr.I32_CONST, uint64(uint32(negI32)))},
+				want:  types.I32(negI32),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, uint32(0xFFFF_FF9D), got.U32) },
+			},
+			{
+				name: "uint64", at: 9,
+				store: []instr.Instruction{instr.New(instr.I64_CONST, uint64(negI64))},
+				want:  types.I64(negI64),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, uint64(0xFFFF_FE00_0000_0000), got.U64) },
+			},
+			{
+				name: "float32", at: 10,
+				store: []instr.Instruction{instr.New(instr.F32_CONST, uint64(math.Float32bits(-3.5)))},
+				want:  types.F32(-3.5),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, float32(-3.5), got.F32) },
+			},
+			{
+				name: "float64", at: 11,
+				store: []instr.Instruction{instr.New(instr.F64_CONST, math.Float64bits(4.25))},
+				want:  types.F64(4.25),
+				check: func(t *testing.T, got hostLoopFields) { require.Equal(t, float64(4.25), got.F64) },
+			},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				body := append([]instr.Instruction{instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, tt.at)}, tt.store...)
+				body = append(body, instr.New(instr.STRUCT_SET))
+				tail := []instr.Instruction{
+					instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, tt.at), instr.New(instr.STRUCT_GET),
+				}
+
+				want, threaded, _ := run(t, nil, body, tail, WithTick(1), WithThreshold(-1))
+				require.Equal(t, tt.want, want)
+				tt.check(t, threaded)
+
+				got, jit, entries := run(t, nil, body, tail, WithTick(1), WithThreshold(0))
+				require.Equal(t, want, got)
+				require.Equal(t, threaded, jit, "the Go value diverged from the threaded run")
+				require.Greater(t, entries, float64(0), "expected a native entry")
+				require.Less(t, entries, float64(size), "the write exits the native loop")
+			})
+		}
+	})
+
+	t.Run("a write a range check governs agrees with threaded", func(t *testing.T) {
+		// An int16 field is narrower than the i32 slot the guest writes, so
+		// the store can overflow and the interpreter is the one that says so.
+		for _, threshold := range []int{-1, 0} {
+			setup := New(program.New(nil))
+			src := seed
+			host, err := NewRegistry().Marshal(setup, &src)
+			require.NoError(t, err)
+			i := New(program.New([]instr.Instruction{
+				instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, 2),
+				instr.New(instr.I32_CONST, 70000), instr.New(instr.STRUCT_SET),
+			}, program.WithConstants(host)), WithTick(1), WithThreshold(threshold))
+			require.ErrorIs(t, i.Run(context.Background()), ErrValueOverflow)
+			require.Equal(t, int16(-300), src.I16, "the rejected write left the Go field alone")
+			require.NoError(t, i.Close())
+			require.NoError(t, setup.Close())
+		}
+	})
+
+	t.Run("a field of another Go width at the same read exits", func(t *testing.T) {
+		// A Go int16 and a Go int32 field both reach the guest as i32, so the
+		// same compiled read serves both once the container arrives from the
+		// stack. Only the kind guard keeps the second run from loading two
+		// bytes of a four-byte field.
+		b := program.NewBuilder()
+		b.Locals(types.TypeAny, types.TypeI32, types.TypeI32)
+		loop, done := b.Label(), b.Label()
+		b.Emit(instr.LOCAL_SET, 0).Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 0).Emit(instr.STRUCT_GET).Emit(instr.LOCAL_SET, 2)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 2)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		read := func(threshold int) (types.Value, types.Value, float64) {
+			profile := prof.New()
+			i := New(prog, WithTick(1), WithThreshold(threshold), WithProfiler(profile))
+			pass := func(value any) types.Value {
+				host, err := i.Marshal(value)
+				require.NoError(t, err)
+				require.NoError(t, i.Push(host))
+				require.NoError(t, i.Run(context.Background()))
+				got, err := i.Pop()
+				require.NoError(t, err)
+				i.Reset()
+				return got
+			}
+			narrow, wide := pass(&hostNarrowField{V: -300}), pass(&hostWideField{V: -70000})
+			require.NoError(t, i.Close())
+			var entries float64
+			for _, metric := range profile.Metrics() {
+				if metric.Name == "vm_jit_native_entries_total" {
+					entries += metric.Value
+				}
+			}
+			return narrow, wide, entries
+		}
+
+		narrow, wide, _ := read(-1)
+		require.Equal(t, types.I32(-300), narrow)
+		require.Equal(t, types.I32(-70000), wide)
+
+		gotNarrow, gotWide, entries := read(0)
+		require.Equal(t, narrow, gotNarrow)
+		require.Equal(t, wide, gotWide)
+		require.Greater(t, entries, float64(0), "expected a native entry")
+	})
+
+	t.Run("a write to a field a range check narrows agrees with threaded", func(t *testing.T) {
+		// A uint8 field is narrower than the i32 slot the guest writes, so a
+		// store past 255 has to report an overflow rather than truncate. The
+		// loop writes in range long enough to compile before it does not.
+		const wide = int32(64)
+		b := program.NewBuilder()
+		b.Locals(types.TypeAny, types.TypeI32)
+		loop, done := b.Label(), b.Label()
+		b.Emit(instr.LOCAL_SET, 0).Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
+		b.Bind(loop)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, uint64(uint32(wide))).Emit(instr.I32_GE_S).BrIf(done)
+		b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 6)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 200).Emit(instr.I32_ADD)
+		b.Emit(instr.STRUCT_SET)
+		b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 1)
+		b.Br(loop)
+		b.Bind(done)
+		b.Emit(instr.LOCAL_GET, 1)
+		prog, err := b.Build()
+		require.NoError(t, err)
+
+		for _, threshold := range []int{-1, 0} {
+			i := New(prog, WithTick(1), WithThreshold(threshold))
+			src := seed
+			host, err := i.Marshal(&src)
+			require.NoError(t, err)
+			require.NoError(t, i.Push(host))
+			require.ErrorIs(t, i.Run(context.Background()), ErrValueOverflow)
+			// 200+55 is the last value a uint8 holds, so the field stops
+			// there instead of wrapping to what a raw byte store would leave.
+			require.Equal(t, uint8(255), src.U8)
+			require.NoError(t, i.Close())
+		}
+	})
+
+	t.Run("a write a range check governs agrees with threaded", func(t *testing.T) {
+		// An int16 field is narrower than the i32 slot the guest writes, so
+		// the store can overflow and the interpreter is the one that says so.
+		for _, threshold := range []int{-1, 0} {
+			setup := New(program.New(nil))
+			src := seed
+			host, err := NewRegistry().Marshal(setup, &src)
+			require.NoError(t, err)
+			i := New(program.New([]instr.Instruction{
+				instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, 2),
+				instr.New(instr.I32_CONST, 70000), instr.New(instr.STRUCT_SET),
+			}, program.WithConstants(host)), WithTick(1), WithThreshold(threshold))
+			require.ErrorIs(t, i.Run(context.Background()), ErrValueOverflow)
+			require.Equal(t, int16(-300), src.I16, "the rejected write left the Go field alone")
+			require.NoError(t, i.Close())
+			require.NoError(t, setup.Close())
+		}
+	})
+
+	t.Run("a field of another Go width at the same read exits", func(t *testing.T) {
+		// A Go int16 and a Go int32 field both reach the guest as i32, so one
+		// STRUCT_GET alternating between them keeps the same VM kind while
+		// changing the load width. Only the kind guard separates them.
+		build := func() *program.Program {
+			setup := New(program.New(nil))
+			defer func() { require.NoError(t, setup.Close()) }()
+			registry := NewRegistry()
+			narrow, err := registry.Marshal(setup, &hostNarrowField{V: -300})
+			require.NoError(t, err)
+			wide, err := registry.Marshal(setup, &hostWideField{V: -70000})
+			require.NoError(t, err)
+
+			b := program.NewBuilder()
+			require.Equal(t, 0, b.Const(narrow))
+			require.Equal(t, 1, b.Const(wide))
+			b.Locals(types.TypeI32, types.TypeAny, types.TypeI32)
+			loop, odd, read, done := b.Label(), b.Label(), b.Label(), b.Label()
+			b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 0)
+			b.Bind(loop)
+			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, uint64(uint32(size))).Emit(instr.I32_GE_S).BrIf(done)
+			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_AND).BrIf(odd)
+			b.Emit(instr.CONST_GET, 0).Emit(instr.LOCAL_SET, 1).Br(read)
+			b.Bind(odd)
+			b.Emit(instr.CONST_GET, 1).Emit(instr.LOCAL_SET, 1)
+			b.Bind(read)
+			b.Emit(instr.LOCAL_GET, 1).Emit(instr.I32_CONST, 0).Emit(instr.STRUCT_GET).Emit(instr.LOCAL_SET, 2)
+			b.Emit(instr.LOCAL_GET, 0).Emit(instr.I32_CONST, 1).Emit(instr.I32_ADD).Emit(instr.LOCAL_SET, 0)
+			b.Br(loop)
+			b.Bind(done)
+			b.Emit(instr.LOCAL_GET, 2)
+			prog, err := b.Build()
+			require.NoError(t, err)
+			return prog
+		}
+
+		read := func(threshold int) (types.Value, float64) {
+			profile := prof.New()
+			i := New(build(), WithTick(1), WithThreshold(threshold), WithProfiler(profile))
+			require.NoError(t, i.Run(context.Background()))
+			got, err := i.Pop()
+			require.NoError(t, err)
+			require.NoError(t, i.Close())
+			var entries float64
+			for _, metric := range profile.Metrics() {
+				if metric.Name == "vm_jit_native_entries_total" {
+					entries += metric.Value
+				}
+			}
+			return got, entries
+		}
+		want, _ := read(-1)
+		require.Equal(t, types.I32(-70000), want)
+		got, entries := read(0)
+		require.Equal(t, want, got)
+		require.Greater(t, entries, float64(0), "expected a native entry")
+	})
+
+	t.Run("an index past the layout faults the same way", func(t *testing.T) {
+		for _, threshold := range []int{-1, 0} {
+			setup := New(program.New(nil))
+			src := seed
+			host, err := NewRegistry().Marshal(setup, &src)
+			require.NoError(t, err)
+			i := New(program.New([]instr.Instruction{
+				instr.New(instr.CONST_GET, 0), instr.New(instr.I32_CONST, 99), instr.New(instr.STRUCT_GET),
+			}, program.WithConstants(host)), WithTick(1), WithThreshold(threshold))
+			require.ErrorIs(t, i.Run(context.Background()), ErrSegmentationFault)
+			require.NoError(t, i.Close())
+			require.NoError(t, setup.Close())
+		}
+	})
+}

--- a/interp/jit_plan.go
+++ b/interp/jit_plan.go
@@ -1,6 +1,7 @@
 package interp
 
 import (
+	"reflect"
 	"sort"
 
 	"github.com/siyul-park/minivm/analysis"
@@ -17,6 +18,13 @@ type anchor struct {
 type shape struct {
 	itab uintptr
 	typ  uintptr
+	// field is the Go kind a *HostStruct access read its field through. A
+	// host field converts on the way out, so its width and signedness are
+	// what the read loads with, and the VM kind alone does not name them:
+	// int16, int32, and uint32 all reach the guest as i32. It is
+	// reflect.Invalid for every other container, and for a host field the
+	// lowerer has no row for.
+	field reflect.Kind
 }
 
 type step struct {

--- a/interp/trace.go
+++ b/interp/trace.go
@@ -2,6 +2,7 @@ package interp
 
 import (
 	"maps"
+	"reflect"
 	"slices"
 	"sort"
 	"sync"
@@ -546,11 +547,17 @@ func (t *tracer) op(i *Interpreter, op instr.Opcode, startFP int) record {
 		}
 		if i.sp > 1 {
 			st.shape = t.shape(i, i.stack[i.sp-2])
+			if op == instr.STRUCT_GET {
+				st.shape.field = t.field(i, i.stack[i.sp-2], st.arg)
+			}
 		}
 	case instr.ARRAY_SET, instr.STRUCT_SET:
 		if i.sp > 2 {
 			st.arg = i.stack[i.sp-2]
 			st.shape = t.shape(i, i.stack[i.sp-3])
+			if op == instr.STRUCT_SET {
+				st.shape.field = t.field(i, i.stack[i.sp-3], st.arg)
+			}
 		}
 	case instr.BR, instr.BR_IF:
 		st.target = f.ip + instr.ParseI16(i.instrs[f.addr], f.ip+1) + 3
@@ -582,6 +589,29 @@ func (t *tracer) shape(i *Interpreter, v types.Boxed) shape {
 		out.typ = uintptr(unsafe.Pointer(s.Typ))
 	}
 	return out
+}
+
+// field reports the Go kind the *HostStruct at container holds its at'th field
+// in. A host field is read and written through that kind rather than through a
+// VM word, so it is what the lowerer needs to pick a load and a store; see
+// shape.field. Anything else records reflect.Invalid, which has no row.
+func (t *tracer) field(i *Interpreter, container, at types.Boxed) reflect.Kind {
+	if container.Kind() != types.KindRef {
+		return reflect.Invalid
+	}
+	addr := container.Ref()
+	if addr < 0 || addr >= len(i.heap) {
+		return reflect.Invalid
+	}
+	host, ok := i.heap[addr].(*HostStruct)
+	if !ok {
+		return reflect.Invalid
+	}
+	idx := int(at.I32())
+	if idx < 0 || idx >= len(host.fields) {
+		return reflect.Invalid
+	}
+	return host.fields[idx].conversion.kind
 }
 
 func (t *tracer) finish(i *Interpreter, st *record, op instr.Opcode) {


### PR DESCRIPTION
Final stage of the host-value plan (after #214, #215, #216).

## Problem

A `*HostStruct` field holds Go memory rather than a VM word, so `structGet` and `structSet` returned false for any trace whose `STRUCT_GET`/`STRUCT_SET` recorded one — and a false there refuses the **whole trace**, not just that access. Measured on `structGetHostLoop` (10000 field reads per run):

| container | threaded | JIT | ratio |
|---|---|---|---|
| `*types.Struct` | 141 µs | 21.6 µs | 6.5× |
| `*HostStruct` | 154 µs | 154 µs | 1.0× |

So every host struct was a JIT cliff.

## Change

`hostGet` and `hostSet` (`interp/jit_arm64.go`) lower the access. Both:

1. guard the heap itab against `heapHostStruct`,
2. bounds-guard the field index against the compiled layout the view carries,
3. guard that field's Go kind against the one the trace recorded,
4. load or store the Go field at the offset the layout names.

Nothing is assumed from the itab alone, so one compiled access serves every `*HostStruct`; a container whose field at that index has another Go kind exits at the kind guard rather than loading the wrong width.

`hostShapes` (`interp/jit.go`) is the one place a hosted field's layout is written down, indexed by the `reflect.Kind` the codec compiled it through and mirroring the codec's own `leaves` table:

- **No row** — string, pointer, nested container. These publish a heap reference rather than loading a word, so the access stays with the interpreter.
- **Read** — a field as wide as its slot is reinterpreted with the slot's extension; a narrower one widens with its own. That is why `int16`, `int32`, and `uint32` all reach the guest as i32 without sharing a load.
- **Write** — lowers only for a field as wide as its slot. A narrower one decodes through the range check `setSigned`/`setUnsigned` perform, and a check that can fail belongs with the interpreter that reports it.

The Go kind is not derivable from the VM kind, so `shape` carries it (`shape.field`) and the tracer records it in `tracer.field`, where it already holds both the container and the index.

## Evidence

`BenchmarkInterpreter_StructGetHost`, split into `Threaded`/`JIT` rows, `-count=6`:

| row | before | after |
|---|---|---|
| Threaded | 156.0 µs | 155.3 µs |
| JIT | 156.5 µs | **20.7 µs** |

The threaded row is unchanged code and does not move. The JIT row was previously the threaded number because the trace was refused. The same loop over a native `*types.Struct` runs 21.8 µs, so a host field now costs no more than a VM field.

`make benchmark-pr` kernels unmoved.

## Tests

`TestARM64_HostStructLoop` (`interp/jit_arm64_test.go`), each case reading or writing inside a counted loop and handing the loop's own value back, so a wrong width or extension reports a wrong value rather than only a different speed:

- a read of all 12 lowered Go kinds — value parity with threaded, plus `vm_jit_native_entries_total` bounded below the iteration count to prove the access stayed in the loop
- a read the interpreter still owns — a string field (no row) and an i64 past the box payload
- a write of all 8 exactly-imaged kinds — VM result, Go value, and parity with the threaded run
- a `uint8` write past 255 — `ErrValueOverflow` in both modes, so a raw byte store cannot silently truncate
- a field of another Go width at the same read — an `int16` and an `int32` field through one compiled access across two runs, which the kind guard has to separate
- an index past the layout — `ErrSegmentationFault` in both modes

Each rule was mutation-checked: disabling the lowering, flipping `int16` to unsigned, shrinking `uint32` to two bytes, removing the kind guard, and making `exact()` always true each fail a specific case.

## Test plan

- [x] `go test -race ./...`
- [x] `make lint`
- [x] `make check-generated`
- [x] `make benchmark-pr`
- [x] `make coverage-check` → `coverage 71.0% meets baseline 63.5%` (needs #217's `.go-version` pin, or `GOENV_VERSION=1.26.2`, on this branch)

## Docs

`docs/jit-internals.md` (guards and the layout table), `docs/instruction-set.md` (JIT status for both opcodes), `docs/host-integration.md` (what lowers and what stays with the interpreter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)