### PR TITLE
test(benchmarks): declare concrete array types on kernel container slots

### DIFF
--- a/benchmarks/call_test.go
+++ b/benchmarks/call_test.go
@@ -328,19 +328,19 @@ func closureCounter(count int) *program.Program {
 
 // nqueens builds the eight-queens backtracking-count kernel. solve is
 // genuinely recursive, called through CONST_GET+CALL once per board column,
-// with cols/diag1/diag2 passed as ref parameters on every recursive call.
-// solve params: 0=row, 1=n, 2=cols, 3=diag1, 4=diag2;
+// with []i1 cols/diag1/diag2 passed as ref parameters on every recursive call.
+// solve params: 0=row, 1=n, 2=cols, 3=diag1, 4=diag2 (each []i1);
 // solve locals:  5=count, 6=col, 7=d1, 8=d2.
-// Type 0 is the []i1 element type shared by cols/diag1/diag2.
+// Main locals: 0=cols, 1=diag1, 2=diag2 (each []i1). Type 0 is their type.
 const nqueensListing = `
 .locals
-any
-any
-any
+[]i1
+[]i1
+[]i1
 .types
 []i1
 .constants
-func(i32, i32, any, any, any) i32
+func(i32, i32, []i1, []i1, []i1) i32
 	i32
 	i32
 	i32
@@ -461,26 +461,27 @@ func nqueens(n int32) *program.Program {
 // tuple: program/verify.go's call already pushes every declared return, and
 // RETURN copies the top len(Returns) stack values to the caller in order.
 //
-// Constant 0 is count_flips (params: 0=perm; locals: 1=a, 2=flips, 3=k, 4=i,
-// 5=j, 6=t). perm is not read again after the copy, so the copy consuming its
-// one retained local.get instance via array.slice needs no dup.
+// Constant 0 is count_flips (params: 0=perm ([]i32); locals: 1=a ([]i32),
+// 2=flips, 3=k, 4=i, 5=j, 6=t). perm is not read again after the copy, so
+// the copy consuming its one retained local.get instance via array.slice
+// needs no dup.
 //
-// Constant 1 is permute (params: 0=a, 1=k, 2=permcount, 3=checksum,
+// Constant 1 is permute (params: 0=a ([]i32), 1=k, 2=permcount, 3=checksum,
 // 4=maxflips; locals: 5=flips, 6=i, 7=tmp), self-recursive through
 // const.get 1 and returning (permcount, checksum, maxflips).
 //
-// Type 0 is the []i32 element type shared by perm/a.
+// Main local 0=perm is []i32. Type 0 is the []i32 type shared by perm/a.
 const fannkuchListing = `
 .locals
-any
+[]i32
 i32
 i32
 i32
 .types
 []i32
 .constants
-func(any) i32
-	any
+func([]i32) i32
+	[]i32
 	i32
 	i32
 	i32
@@ -547,7 +548,7 @@ func(any) i32
 	outerDone:
 	local.get 2
 	return
-func(any, i32, i32, i32, i32) (i32, i32, i32)
+func([]i32, i32, i32, i32, i32) (i32, i32, i32)
 	i32
 	i32
 	i32

--- a/benchmarks/memory_test.go
+++ b/benchmarks/memory_test.go
@@ -886,21 +886,22 @@ func binaryTrees(minDepth, maxDepth int32) *program.Program {
 // least code among the alternatives, keeping the kernel a measure of VM
 // dispatch rather than of an algorithm choice. The LCG state overflows i32
 // (s*1103515245 can reach ~2.4e18), so make_list (constant 0; params: 0=n,
-// 1=seed; locals: 2=xs,3=s(i64),4=i) keeps s in i64; the sorted values
-// (s % 1000000) fit i32, so the array itself stays i32. insertion_sort
-// (constant 1; params: 0=arr,1=n; locals: 2=i,3=key,4=j) sorts in place.
-// Main locals: 0=xs,1=checksum,2=r,3=i. %[1]d substitutes n, %[2]d rounds.
+// 1=seed; result and local 2=xs are []i32; locals 3=s(i64),4=i) keeps s in
+// i64; the sorted values (s % 1000000) fit i32, so the array itself stays
+// i32. insertion_sort (constant 1; params: 0=arr ([]i32),1=n; locals:
+// 2=i,3=key,4=j) sorts in place. Main locals: 0=xs ([]i32),1=checksum,2=r,
+// 3=i. %[1]d substitutes n, %[2]d rounds.
 const sortStressListing = `
 .locals
-any
+[]i32
 i32
 i32
 i32
 .types
 []i32
 .constants
-func(i32, i32) any
-	any
+func(i32, i32) []i32
+	[]i32
 	i64
 	i32
 	local.get 0
@@ -939,7 +940,7 @@ func(i32, i32) any
 	mlDone:
 	local.get 2
 	return
-func(any, i32)
+func([]i32, i32)
 	i32
 	i32
 	i32
@@ -1058,20 +1059,20 @@ func sortStress(n, rounds int32) *program.Program {
 }
 
 // stringBuildListing builds the strbuild kernel: digits(n) token generation
-// (constant 0; params: 0=n; locals: 1=count,2=v,3=arr,4=idx,5=d), a
+// (constant 0; params: 0=n; locals: 1=count,2=v,3=arr ([]i32),4=idx,5=d), a
 // per-character checksum read back through string.encode_utf32, and
 // "big = big + tok + ' '" through string.concat (the allocating operation
 // this kernel exists to measure). Type 0 is the []i32 code-point array used
 // to build each token. Constant 1 is the " " separator, constant 2 the ""
 // used to seed big. Main locals: 0=big,1=tokenChecksum,2=i,3=tok,
-// 4=codePoints,5=tokLen,6=j. %d substitutes n.
+// 4=codePoints ([]i32),5=tokLen,6=j. %d substitutes n.
 const stringBuildListing = `
 .locals
 any
 i32
 i32
 any
-any
+[]i32
 i32
 i32
 .types
@@ -1080,7 +1081,7 @@ i32
 func(i32) any
 	i32
 	i32
-	any
+	[]i32
 	i32
 	i32
 	local.get 0

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -39,7 +39,14 @@ independent statement with its own tier controls and memory behavior.
 Compare within a tier. An interpreter losing to a compiler is not a finding, and
 `threaded` beating `default` on a kernel is a statement about promotion policy, not
 about interpreters. `ClosureCounter`, `AllocationGraph`, `PermutationFlips`,
-`StructTreeWalk`, and `BinaryTrees` currently run fastest under `threaded`.
+`StructTreeWalk`, `BinaryTrees`, and `Fannkuch` currently run fastest under
+`threaded`.
+
+`NQueens`, `Fannkuch`, `SortStress`, and `StringBuild` moved because their
+fixtures were corrected to declare concrete slot types instead of `any`, which
+is what lets a container reach the fused `array.get` / `array.set` paths. The
+interpreter did not change; the kernels simply started exercising a path a
+well-typed program always reaches.
 
 Allocation behavior is a first-class result. `IterativeFib`, `TypedArraySum`,
 `BranchTree`, `Mandelbrot`, `RecursiveFib`, and `IndirectRecursiveFib` hold 0 B/op and
@@ -130,21 +137,21 @@ before making a performance claim.
 
 | Tier | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| Interpreter | minivm `threaded` | 312.42 µs | 120 | 6 |
-|  | CPython | **226.15 µs** | 11 | 0 |
+| Interpreter | minivm `threaded` | 196.49 µs | 120 | 6 |
+|  | CPython | 226.15 µs | 11 | 0 |
 |  | gpython | 782.30 µs | 363,441 | 4,156 |
-| Native | minivm `default` | 133.59 µs | 120 | 6 |
-|  | minivm `jit` | 134.39 µs | 120 | 6 |
+| Native | minivm `default` | 104.60 µs | 120 | 6 |
+|  | minivm `jit` | 104.69 µs | 120 | 6 |
 | Reference | Native Go | 4.21 µs | 0 | 0 |
 #### `Fannkuch(6)`
 
 | Tier | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| Interpreter | minivm `threaded` | 532.22 µs | 34,608 | 1,442 |
-|  | CPython | **430.81 µs** | 20 | 0 |
+| Interpreter | minivm `threaded` | 399.53 µs | 34,608 | 1,442 |
+|  | CPython | 430.81 µs | 20 | 0 |
 |  | gpython | 1.57 ms | 1,367,678 | 16,944 |
-| Native | minivm `default` | 413.81 µs | 34,608 | 1,442 |
-|  | minivm `jit` | 414.71 µs | 34,608 | 1,442 |
+| Native | minivm `default` | 402.25 µs | 34,608 | 1,442 |
+|  | minivm `jit` | 404.40 µs | 34,608 | 1,442 |
 | Reference | Native Go | 17.54 µs | 17,280 | 720 |
 
 ### Memory and data structures
@@ -215,21 +222,21 @@ before making a performance claim.
 
 | Tier | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| Interpreter | minivm `threaded` | 313.3 µs | 5,136 | 512 |
+| Interpreter | minivm `threaded` | 186.7 µs | 5,136 | 512 |
 |  | CPython | 339.27 µs | 16 | 0 |
 |  | gpython | 870.26 µs | 23,448 | 2,034 |
-| Native | minivm `default` | 54.13 µs | 5,136 | 512 |
-|  | minivm `jit` | 69.94 µs | 5,136 | 512 |
+| Native | minivm `default` | 51.07 µs | 5,136 | 512 |
+|  | minivm `jit` | 66.49 µs | 5,136 | 512 |
 | Reference | Native Go | 4.38 µs | 1,024 | 2 |
 #### `StringBuild(512)`
 
 | Tier | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| Interpreter | minivm `threaded` | 379.3 µs | 85,408 | 4,107 |
-|  | CPython | **368.74 µs** | 17 | 0 |
+| Interpreter | minivm `threaded` | 335.8 µs | 85,408 | 4,107 |
+|  | CPython | 368.74 µs | 17 | 0 |
 |  | gpython | 1.25 ms | 2,104,720 | 21,456 |
-| Native | minivm `default` | 266.5 µs | 85,408 | 4,107 |
-|  | minivm `jit` | 267.2 µs | 85,408 | 4,107 |
+| Native | minivm `default` | 261.7 µs | 85,408 | 4,107 |
+|  | minivm `jit` | 260.6 µs | 85,408 | 4,107 |
 | Reference | Native Go | 138.19 µs | 855,892 | 5,001 |
 
 ### Numeric


### PR DESCRIPTION
Closes the array half of #176.

Four kernels declared their typed-array locals and function params as `any` (`types.TypeRef`).
Container fusion proves an element kind from the **declared** slot type at threading time, so an
`any` slot never reaches the fused `array.get` / `array.set` paths however consistently it holds a
typed array. Those kernels were under-reporting what the interpreter does with a well-typed program.

**No interpreter code changes.** This is a corrected fixture, not an optimizer gain — the kernels
simply start exercising a path a well-typed program always reaches.

The concrete type is also the more faithful translation: `conformance/testdata/benchmark/{nqueens,fannkuch}.py`
annotate `cols: list[bool]` and `perm: list[int]`, and NBody, SpectralNorm, MatMul, and Sieve already
declare `[]f64` / `[]i32` in exactly these positions.

## Changes

| kernel | slots |
|---|---|
| nqueens | 3 module locals + `solve`'s three params -> `[]i1` |
| fannkuch | module local + `count_flips`/`permute` params + the `array.slice` copy -> `[]i32` |
| sortStress | module local + `make_list` return/local + `insertion_sort` param -> `[]i32` |
| stringBuild | `codePoints` and `digits`' `arr` -> `[]i32` |

## Measured

Interleaved A/B — six alternating rounds with a settle between, `-benchtime=300ms -count=6`,
Apple M4 Pro. Plain back-to-back runs are not trustworthy on this machine (#227 saw +-169% variance
and a fabricated +50% regression that way).

| benchmark | main | branch | delta |
|---|---:|---:|---|
| `Memory_SortStress/threaded` | 310.0 µs | 188.3 µs | **-39.26%** (p=0.002) |
| `Call_NQueens/threaded` | 304.3 µs | 195.7 µs | **-35.66%** (p=0.002) |
| `Call_Fannkuch/threaded` | 513.2 µs | 400.5 µs | **-21.97%** (p=0.002) |
| `Call_NQueens/default` | 136.4 µs | 107.3 µs | -21.36% (p=0.002) |
| `Call_NQueens/jit` | 131.9 µs | 104.3 µs | -20.95% (p=0.002) |
| `Memory_StringBuild/threaded` | 359.4 µs | 336.6 µs | -6.34% (p=0.002) |
| `Memory_SortStress/default` | 52.71 µs | 50.81 µs | -3.60% (p=0.002) |
| `Call_Fannkuch/default` | 407.6 µs | 401.7 µs | -1.44% (p=0.002) |
| `Memory_SortStress/jit`, `Memory_StringBuild/{default,jit}`, `Call_Fannkuch/jit` | | | ~ |

Geomean -9.51%. `B/op` and `allocs/op` are byte-identical on every row.

Controls: `Control_Sieve` and `Numeric_NBody` already declare concrete types and are flat in all
three modes (p >= 0.09), which is the evidence that the movement comes from the retyped slots and
not from drift.

In `threaded` mode minivm now beats CPython on `NQueens` (196.49 vs 226.15 µs), `Fannkuch`
(399.53 vs 430.81 µs), and `StringBuild` (335.8 vs 368.74 µs), so those three bold marks move.

## Left out, with reasons

- **The struct half of #176** — `StructTreeWalk` and `BinaryTrees` keep `any`. `binarytrees.py`
  annotates `t: "Node | None"`; minivm has no union type, so `any` is the faithful translation. And
  declaring the parameter as a concrete struct type anyway makes the JIT fault where threaded
  execution is correct: filed as #228 with a one-line repro. #176 anticipated this case ("or the
  kernel keeps `TypeRef` for a stated reason").
- **`allocationGraph` / `permutationFlips` `any` -> `[]any`** — `arrayKind` recognizes only the six
  `TypedArray[T]` kinds, so an `any` element type cannot fuse. Pure churn on the measurement.
- **`stringBuild`'s `big` / `tok` `any` -> `string`** — no string container fusion exists.
- **Removing the now-redundant `ref.cast 0`** in the two tree kernels — moot while those kernels keep
  `any`, and it changes the instruction stream rather than a declaration.

## Test plan

- [x] `cd benchmarks && go test -run='^$' -bench='^(BenchmarkCall|BenchmarkMemory|BenchmarkControl|BenchmarkNumeric)' -benchtime=1x .` — every kernel self-verifies its result; all pass
- [x] `go test -race ./...` — 19 packages green
- [x] `make lint` — clean
- [x] `docs/benchmarks.md` re-measured under its own protocol (`-benchtime=300ms -count=3`, median, on the machine its header records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)