### PR TITLE
test(benchmarks): declare the concrete node type on tree-kernel struct slots

### DIFF
--- a/benchmarks/memory_test.go
+++ b/benchmarks/memory_test.go
@@ -605,14 +605,14 @@ func permutationFlips(size, depth int32) *program.Program {
 
 // structTreeWalkListing builds a self-recursive binary-tree build/count
 // kernel over a named struct type (constant 0=build, 1=check; type 0=Node
-// {value, left, right}). build's params: 0=d; locals: 1=n. check's params:
-// 0=node.
+// {value, left, right}). build's params: 0=d; its result and local 1=n are
+// Node. check's param 0=node is Node, and may be the null ref at a leaf.
 const structTreeWalkListing = `
 .types
 struct {value: i64; left: any; right: any}
 .constants
-func(i32) any
-	any
+func(i32) struct {value: i64; left: any; right: any}
+	struct {value: i64; left: any; right: any}
 	struct.new_default 0
 	local.set 1
 	local.get 1
@@ -643,7 +643,7 @@ func(i32) any
 	buildDone:
 	local.get 1
 	return
-func(any) i32
+func(struct {value: i64; left: any; right: any}) i32
 	local.get 0
 	ref.is_null
 	br_if nullCase
@@ -680,30 +680,31 @@ func structTreeWalk(depth int32) *program.Program {
 // binaryTreesListing builds the benchmarks-game binary-trees kernel over a
 // named struct type (type 0=Node{item, left, right}; constant 0=
 // bottom_up_tree, 1=item_check; each is self-recursive, calling back through
-// its own const.get index). bottom_up_tree params: 0=item,1=depth; locals:
-// 2=n. item_check params: 0=t. STRUCT_NEW_DEFAULT zero-initializes ref
-// fields to the null heap ref, so the depth<=0 base case can leave
-// left/right unset instead of writing a null ref. Main locals:
-// 0=stretchTree,1=checksum,2=longLivedTree,3=depth,4=iterations,5=shift,
-// 6=acc,7=i,8=t1,9=t2. %[1]d substitutes min_depth, %[2]d max_depth, %[3]d
+// its own const.get index). bottom_up_tree params: 0=item,1=depth; its
+// result and local 2=n are Node. item_check param 0=t is Node, and may be
+// the null ref at a leaf. STRUCT_NEW_DEFAULT zero-initializes ref fields to
+// the null heap ref, so the depth<=0 base case can leave left/right unset
+// instead of writing a null ref. Main locals: 0=stretchTree (Node),
+// 1=checksum,2=longLivedTree (Node),3=depth,4=iterations,5=shift,
+// 6=acc,7=i,8=t1 (Node),9=t2 (Node). %[1]d substitutes min_depth, %[2]d max_depth, %[3]d
 // max_depth+1.
 const binaryTreesListing = `
 .locals
-any
+struct {item: i32; left: any; right: any}
 i32
-any
-i32
-i32
+struct {item: i32; left: any; right: any}
 i32
 i32
 i32
-any
-any
+i32
+i32
+struct {item: i32; left: any; right: any}
+struct {item: i32; left: any; right: any}
 .types
 struct {item: i32; left: any; right: any}
 .constants
-func(i32, i32) any
-	any
+func(i32, i32) struct {item: i32; left: any; right: any}
+	struct {item: i32; left: any; right: any}
 	struct.new_default 0
 	local.set 2
 	local.get 2
@@ -741,7 +742,7 @@ func(i32, i32) any
 	buDone:
 	local.get 2
 	return
-func(any) i32
+func(struct {item: i32; left: any; right: any}) i32
 	local.get 0
 	ref.is_null
 	br_if nullCase

--- a/benchmarks/memory_test.go
+++ b/benchmarks/memory_test.go
@@ -648,7 +648,6 @@ func(struct {value: i64; left: any; right: any}) i32
 	ref.is_null
 	br_if nullCase
 	local.get 0
-	ref.cast 0
 	i32.const 1
 	struct.get
 	const.get 1
@@ -747,7 +746,6 @@ func(struct {item: i32; left: any; right: any}) i32
 	ref.is_null
 	br_if nullCase
 	local.get 0
-	ref.cast 0
 	i32.const 1
 	struct.get
 	ref.is_null

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -38,14 +38,15 @@ independent statement with its own tier controls and memory behavior.
 
 Compare within a tier. An interpreter losing to a compiler is not a finding, and
 `threaded` beating `default` on a kernel is a statement about promotion policy, not
-about interpreters. `ClosureCounter`, `AllocationGraph`, `PermutationFlips`,
-`StructTreeWalk`, `BinaryTrees`, and `Fannkuch` currently run fastest under
-`threaded`.
+about interpreters. `ClosureCounter`, `AllocationGraph`, `PermutationFlips`, and
+`Fannkuch` currently run fastest under `threaded`.
 
-`NQueens`, `Fannkuch`, `SortStress`, and `StringBuild` moved because their
-fixtures were corrected to declare concrete slot types instead of `any`, which
-is what lets a container reach the fused `array.get` / `array.set` paths. The
-interpreter did not change; the kernels simply started exercising a path a
+`NQueens`, `Fannkuch`, `SortStress`, `StringBuild`, `StructTreeWalk`, and
+`BinaryTrees` moved because their fixtures were corrected to declare concrete
+slot types instead of `any`, which is what lets a container reach the fused
+`array.get` / `array.set` / `struct.get` paths. The two tree kernels also
+dropped a `ref.cast` that existed only to work around the `any` declaration.
+The interpreter did not change; the kernels simply started exercising a path a
 well-typed program always reaches.
 
 Allocation behavior is a first-class result. `IterativeFib`, `TypedArraySum`,
@@ -199,24 +200,24 @@ before making a performance claim.
 
 | Tier | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| Interpreter | minivm `threaded` | 160.6 µs | 768 | 8 |
+| Interpreter | minivm `threaded` | 137.5 µs | 768 | 8 |
 |  | Tengo | 280.54 µs | 458,379 | 5,114 |
 |  | GopherLua | 545.66 µs | 818,512 | 11,253 |
 |  | Goja | 448.41 µs | 558,961 | 6,149 |
 |  | gpython | 1.26 ms | 2,570,669 | 34,797 |
 |  | Yaegi | 846.99 µs | 1,422,624 | 35,306 |
-| Native | minivm `default` | 169.1 µs | 768 | 8 |
-|  | minivm `jit` | 168.3 µs | 768 | 8 |
+| Native | minivm `default` | 133.5 µs | 768 | 8 |
+|  | minivm `jit` | 135.6 µs | 768 | 8 |
 | Reference | Native Go | 12.97 µs | 16,368 | 1,023 |
 #### `BinaryTrees(4..6)`
 
 | Tier | Runtime | ns/op | B/op | allocs/op |
 |---|---|---:|---:|---:|
-| Interpreter | minivm `threaded` | 1.233 ms | 768 | 8 |
-|  | CPython | **991.16 µs** | 45 | 0 |
+| Interpreter | minivm `threaded` | 951.4 µs | 768 | 8 |
+|  | CPython | 991.16 µs | 45 | 0 |
 |  | gpython | 9.87 ms | 19,457,623 | 280,714 |
-| Native | minivm `default` | 1.246 ms | 768 | 8 |
-|  | minivm `jit` | 1.249 ms | 768 | 8 |
+| Native | minivm `default` | 749.5 µs | 768 | 8 |
+|  | minivm `jit` | 752.7 µs | 768 | 8 |
 | Reference | Native Go | 118.71 µs | 201,936 | 8,414 |
 #### `SortStress(128,2)`
 


### PR DESCRIPTION
Finishes #176. #229 landed the array half and had to drop the struct half, because declaring a node
param concretely made the ARM64 JIT fault where threaded execution was correct. #230 fixed that, so
these declarations can now say what the Python sources say.

**No interpreter code changes.** Corrected fixtures, not an optimizer gain.

## Two commits, measured separately

### 1. Declare the node type

Every Node-holding local, return, and param in `structTreeWalk` and `binaryTrees` was `any`, so
`struct.get` never reached its fused container path.

`left`/`right` stay `any` — the grammar cannot name a recursive type. The `check`/`item_check` params
may hold the null ref at a leaf, which is fine now: heap slots do not exclude null, and after #230
both tiers agree on `ref.is_null` for a default-initialized ref field.

| benchmark | before | after | delta |
|---|---:|---:|---|
| `Memory_BinaryTrees/threaded` | 1.145 ms | 1.059 ms | -7.55% |
| `Memory_BinaryTrees/default` | 1.187 ms | 1.104 ms | -7.01% |
| `Memory_BinaryTrees/jit` | 1.187 ms | 1.106 ms | -6.85% |
| `Memory_StructTreeWalk/default` | 160.5 µs | 154.6 µs | -3.69% |
| `Memory_StructTreeWalk/threaded` | 153.0 µs | 147.5 µs | -3.58% |
| `Memory_StructTreeWalk/jit` | 160.2 µs | 155.7 µs | -2.81% |

### 2. Drop the redundant `ref.cast`

Both walkers downcast their node param with `ref.cast 0` immediately after a `ref.is_null; br_if`
guard. That cast only existed because the param was declared `any`; against a concretely declared
param it proves nothing the declaration does not already state, and neither Python source has a cast.

It was not free, and this is the larger half of the win:

- `REF_CAST` is **bridged**, so every node walk left native code for the interpreter and came back.
- It split `local.get 0` from the `i32.const N; struct.get` behind it, blocking that field read from
  fusing.

That is why the native tiers gain roughly three times what `threaded` does.

| benchmark | before | after | delta |
|---|---:|---:|---|
| `Memory_BinaryTrees/jit` | 1108.1 µs | 752.7 µs | **-32.08%** |
| `Memory_BinaryTrees/default` | 1102.7 µs | 751.8 µs | **-31.82%** |
| `Memory_StructTreeWalk/jit` | 156.0 µs | 135.0 µs | -13.43% |
| `Memory_StructTreeWalk/default` | 154.8 µs | 134.4 µs | -13.20% |
| `Memory_BinaryTrees/threaded` | 1055.9 µs | 950.9 µs | -9.94% |
| `Memory_StructTreeWalk/threaded` | 147.7 µs | 138.1 µs | -6.52% |

### Cumulative vs `main`

| benchmark | main | branch | delta |
|---|---:|---:|---|
| `Memory_BinaryTrees/default` | 1173.6 µs | 750.2 µs | **-36.08%** |
| `Memory_BinaryTrees/jit` | 1175.5 µs | 752.0 µs | **-36.03%** |
| `Memory_StructTreeWalk/default` | 162.8 µs | 133.5 µs | -18.03% |
| `Memory_BinaryTrees/threaded` | 1137.5 µs | 948.2 µs | -16.64% |
| `Memory_StructTreeWalk/jit` | 158.5 µs | 134.7 µs | -15.01% |
| `Memory_StructTreeWalk/threaded` | 151.3 µs | 137.4 µs | -9.22% |

Geomean -22.57%, all p=0.002 (n=6). `B/op` and `allocs/op` identical on every row.

All measurements are interleaved A/B — six alternating rounds with a settle between,
`-benchtime=300ms -count=6`, Apple M4 Pro. `Control_Sieve` and `Numeric_NBody` are carried as
controls and are flat in all three modes on both steps.

## Docs

- `docs/benchmarks.md`: `StructTreeWalk(9)` and `BinaryTrees(4..6)` minivm rows re-measured under the
  document's own protocol (`-benchtime=300ms -count=3`, median, same machine its header records).
- Both kernels now run fastest under `default`, not `threaded`, so they leave that list in §2.
- minivm `threaded` overtakes CPython on `BinaryTrees` (951.4 vs 991.16 µs), so that bold mark moves.
- The §2 fixture-correction note extended to cover these two kernels and the `ref.cast` removal.

## Test plan

- [x] `cd benchmarks && go test -run='^$' -bench='^(BenchmarkCall|BenchmarkMemory|BenchmarkControl|BenchmarkNumeric)' -benchtime=1x .` — every kernel self-verifies its result; all pass in all three modes
- [x] `go test -race ./...` — green
- [x] `make lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved execution speed for the StructTreeWalk and BinaryTrees benchmarks.
  * Updated benchmark results to reflect the latest performance improvements.

* **Documentation**
  * Revised benchmark guidance to identify the currently fastest threaded workloads.
  * Updated StructTreeWalk and BinaryTrees performance tables with new measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->