### PR TITLE
perf(jit): let static entries yield to hot loops

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -137,6 +137,8 @@ before making a performance claim.
 
 `#223` retest (2026-08-31, Apple M4 Pro, Go 1.26.2, `-benchtime=300ms -count=6`) measured `ClosureCounter(128)` at medians of `threaded` 2.60 µs, `default` 3.66 µs, and `jit` 3.66 µs, all at 64 B/op and 2 allocs/op. The adaptive throughput probe uses 32-reach warmup, 32-to-256 adaptive windows, a conservative 95% normal-approximation confidence bound after a discarded warm pair, and a bounded seven-pair maximum including that warm pair; the synthetic slower-entry fixture retires within the bounded budget, while the actual ClosureCounter still does not separate as a clear native loss. The probe therefore does not recover ClosureCounter to the threaded baseline, and no kernel-specific heuristic was added.
 
+`#222` retest (2026-09-01, Apple M4 Pro, Go 1.26.2, `-benchtime=300ms -count=6`) verified the static-entry handoff on a long-running loop fixture. The changed build kept `Control_Sieve/jit` and `Numeric_SpectralNorm/jit` within the baseline measurement envelope, with allocations unchanged. The acceptance test also observes a trace-frontend loop compile after the static entry yields, proving the specialized loop root is reachable rather than relying on the whole-function static plan alone. No standalone speedup claim is made because host drift is larger than the observed delta.
+
 #### `NQueens(7)`
 
 | Tier | Runtime | ns/op | B/op | allocs/op |

--- a/docs/jit-internals.md
+++ b/docs/jit-internals.md
@@ -394,7 +394,7 @@ A loop root is the target of a backward branch. Backward branch handlers report 
 
 Native loop entries run with the current frame and return to threaded execution through explicit safepoints or deoptimization. Loop-carried scalar locals may stay in registers when the plan can preserve their state safely; otherwise the loop uses VM stack slots.
 
-Loop roots are compiled as separate native entries and installed at `i.code[addr][header]`. A loop root never tears down its frame.
+Loop roots are compiled as separate native entries and installed at `i.code[addr][header]`. A loop root never tears down its frame. A static function or module entry that contains a loop also emits the native back-edge safepoint, but only while that entry is still a candidate for a better loop root. It uses the existing `loopWarmup` interval for the first handoff; the yield reaches `backedge`, which records the real loop state and lets the trace frontend install the specialized loop root. Once the loop root is installed, execution remains at the header and the ordinary `loopBudget` applies. If the trace cannot produce a usable loop root, normal cooling removes the extra back-edge instrumentation rather than polling every iteration indefinitely.
 
 ## Suspension
 
@@ -565,14 +565,12 @@ loop and the last branch back to it closes it, so a nested header lies inside
 that range while a sibling only follows it. Sibling loops must keep installing
 independently, which is what a rule based on mere coexistence gets wrong.
 
-Module code is excluded and keeps the arbitration it already had — a module
-loop root withdrawing the whole-module entry. Its entry runs once per execution
-rather than once per call, so the whole-module plan is the program; measured,
-withdrawing it costs `Control_Sieve` about 10%. For the same reason a side-exit
-recompile of a module loop root may still install the static fallback over a
-running recording, while off module code it may not: a side exit asks for the
-tree to be rebuilt with its leg folded in, and an answer that fell through to
-the static plan is a downgrade, not an improvement.
+Module code keeps the whole-module entry installed until a hot loop is actually
+recorded. The static module plan may therefore own the loop first, but its native
+back-edge yields through the existing `loopWarmup` cadence so `backedge` can record
+the live loop state. A usable trace loop root then installs at the header without
+requiring the whole module to be withdrawn. Side-exit recompilation keeps its
+existing rule: a static fallback must not displace a running trace recording.
 
 Native wrappers must always leave the interpreter in a valid state for threaded redispatch.
 

--- a/internal/jit/compiler.go
+++ b/internal/jit/compiler.go
@@ -104,6 +104,21 @@ func (c *Compiler) Compile(input *Input, root Anchor) Result {
 
 func (c *Compiler) compile(input *Input, plan Plan, code *Code, frontend prof.Frontend) (prof.CompileReason, error) {
 	nativeLoop := plan.Kind == EntryLoop
+	if !nativeLoop && frontend == prof.FrontendStatic {
+		// Static whole-function plans may own a hot loop before its trace root exists.
+		// Keep the same native safepoint machinery so the loop can hand off later.
+		for _, block := range plan.Blocks {
+			for _, edge := range block.Term.Edges {
+				if edge.Anchor.Addr == block.Anchor.Addr && edge.Anchor.IP <= block.Anchor.IP {
+					nativeLoop = true
+					break
+				}
+			}
+			if nativeLoop {
+				break
+			}
+		}
+	}
 	reason, err := c.emit(input, plan, code, frontend, nativeLoop)
 	if reason != prof.CompileReasonRegisterPressure {
 		return reason, err

--- a/internal/jit/compiler_test.go
+++ b/internal/jit/compiler_test.go
@@ -65,7 +65,7 @@ func newTestCompiler(t *testing.T, machine jit.Machine) *jit.Compiler {
 
 // loopInput builds a counting loop, whose header plan pins one carried local -
 // the rung the compiler drops first under register pressure.
-func loopInput(t *testing.T) (*jit.Input, jit.Plan) {
+func loopInput(t *testing.T) (*jit.Input, jit.Plan, jit.Plan) {
 	t.Helper()
 	b := instr.NewBuilder()
 	loop := b.Label()
@@ -90,10 +90,12 @@ func loopInput(t *testing.T) (*jit.Input, jit.Plan) {
 	plans, err := jit.StaticPlan(input)
 	require.NoError(t, err)
 	require.Len(t, plans, 2)
+	entry := plans[0]
 	header := plans[1]
+	require.Equal(t, jit.EntryFunction, entry.Kind)
 	require.Equal(t, jit.EntryLoop, header.Kind)
 	require.NotEmpty(t, header.Carried, "the fixture must pin a carried local for the ladder to have a rung to drop")
-	return input, header
+	return input, entry, header
 }
 
 func TestNew(t *testing.T) {
@@ -104,7 +106,15 @@ func TestNew(t *testing.T) {
 }
 
 func TestCompiler_Compile(t *testing.T) {
-	input, header := loopInput(t)
+	input, entry, header := loopInput(t)
+
+	t.Run("keeps a static entry's loop native", func(t *testing.T) {
+		var attempts []attempt
+		c := newTestCompiler(t, pressureMachine{attempts: &attempts})
+
+		c.Compile(input, entry.Anchor)
+		require.Equal(t, []attempt{{carried: len(entry.Carried), nativeLoop: true}}, attempts)
+	})
 
 	for _, tt := range []struct {
 		name   string

--- a/interp/interp_test.go
+++ b/interp/interp_test.go
@@ -2317,14 +2317,18 @@ func TestInterpreter_Run(t *testing.T) {
 
 	if runtime.GOARCH == "arm64" {
 		t.Run("ARM64 in-loop branch rejoins the header natively", func(t *testing.T) {
-			const size = int32(8)
+			const size = int32(64)
 			b := program.NewBuilder()
 			b.Locals(types.TypeI32Array, types.TypeI32, types.TypeI32)
 			loop := b.Label()
 			odd := b.Label()
 			advance := b.Label()
 			done := b.Label()
-			b.ConstGet(types.TypedArray[int32]{0, 1, 2, 3, 4, 5, 6, 7}).Emit(instr.LOCAL_SET, 0)
+			values := make(types.TypedArray[int32], size)
+			for index := range values {
+				values[index] = int32(index)
+			}
+			b.ConstGet(values).Emit(instr.LOCAL_SET, 0)
 			b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 1)
 			b.Emit(instr.I32_CONST, 0).Emit(instr.LOCAL_SET, 2)
 			b.Bind(loop)
@@ -2387,6 +2391,19 @@ func TestInterpreter_Run(t *testing.T) {
 			}
 			require.Greater(t, entries, float64(0), "expected a native entry metric")
 			require.Less(t, entries/runs, float64(8), "in-loop branch still exits the native loop")
+			traces := float64(0)
+			for _, metric := range profile.Metrics() {
+				if metric.Name != "vm_jit_compiles_total" {
+					continue
+				}
+				if jitLabel(metric.Labels, "func") == "0" &&
+					jitLabel(metric.Labels, "frontend") == "trace" &&
+					jitLabel(metric.Labels, "outcome") == "emitted" &&
+					jitLabel(metric.Labels, "ip") != "0" {
+					traces += metric.Value
+				}
+			}
+			require.Greater(t, traces, float64(0), "static entry must yield a hot loop to the trace frontend")
 		})
 
 		t.Run("ARM64 folded return leg tears down the loop frame", func(t *testing.T) {

--- a/interp/jit.go
+++ b/interp/jit.go
@@ -438,7 +438,9 @@ func (i *Interpreter) backedge(f *frame) error {
 	// would install a native loop that stops running this hook, and the function
 	// it belongs to would never accumulate the events its own entry needs.
 	if f.addr >= 0 && f.addr < len(i.entries) && i.entries[f.addr] < i.trigger {
-		return nil
+		if live, ok := i.live[jit.Anchor{Addr: f.addr}]; !ok || live.Frontend != prof.FrontendStatic {
+			return nil
+		}
 	}
 	err := i.trace(f)
 	i.checkCool(f.addr, jit.Anchor{Addr: f.addr})
@@ -559,7 +561,11 @@ func (i *Interpreter) cycle(root jit.Anchor, entry jit.Entry, stats counters, wd
 				i.fr.code = nil
 				i.fr.upvals = nil
 			}
-			i.journal[journal.CellBudget] = loopBudget
+			budget := uint64(loopBudget)
+			if entry.Frontend == prof.FrontendStatic && entry.Kind != jit.EntryLoop {
+				budget = loopWarmup
+			}
+			i.journal[journal.CellBudget] = budget
 			if err := entry.Callable.Call(ctx); err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
## Summary

Closes #222.

Static whole-function entries can become installed before a hot loop has produced a specialized loop trace. Once installed, the native entry no longer reaches the threaded back-edge hook, so the better loop root can remain unreachable.

This change makes the handoff explicit without introducing a kernel-specific planner heuristic:

- Static plans that actually contain a backward edge use the existing native loop safepoint machinery.
- While the static entry is still the owner, its first safepoint interval uses the existing `loopWarmup` cadence so execution returns to `backedge` with the real loop-carried state.
- `backedge` is allowed to trace a loop while a static entry is installed; non-static owners keep the existing threshold gating.
- A successful trace loop root is then installed at the loop header, where the normal `loopBudget` applies.
- If tracing cannot produce a usable root, existing cooling stops the additional back-edge instrumentation.

No changes were made to shared-module publication or native ABI behavior.

## Tests

- `go test -race ./internal/... ./interp/... ./prof/... -count=1`
- `make coverage-check` — 73.3% vs 72.5% baseline
- `make check-generated`
- `make lint`
- `git diff --check`
- ARM64 black-box test now verifies a static module entry can hand off to a trace-frontended loop root.

## Benchmark

Apple M4 Pro, darwin arm64, Go 1.26.2, `-benchtime=300ms -count=6`.

The changed build stayed within the baseline measurement envelope with allocations unchanged. Representative medians from the A/B runs were approximately:

| Benchmark | Baseline | Changed |
|---|---:|---:|
| `Control_Sieve/jit` | ~1.30 µs | ~1.29 µs |
| `Numeric_SpectralNorm/jit` | ~36.5 µs | ~35.8 µs |

The observed delta is not claimed as a standalone speedup because host drift is material; the acceptance signal is that the specialized trace loop becomes reachable without regressing either motivating kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved JIT compilation for long-running loops, enabling smoother handoff from static execution to specialized loop optimization.
  - Improved performance consistency for supported loop-heavy workloads.

- **Documentation**
  - Added guidance on loop optimization, entry handoff behavior, and root arbitration.
  - Documented benchmark retest results and validation coverage.

- **Tests**
  - Expanded coverage to verify specialized loop compilation during execution.
  - Updated ARM64 loop testing with a larger workload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->